### PR TITLE
implemented FrameHeader parsing

### DIFF
--- a/jxl_headers_derive/src/lib.rs
+++ b/jxl_headers_derive/src/lib.rs
@@ -45,7 +45,7 @@ fn parse_single_coder(input: &syn::Expr, extra_lit: Option<&syn::ExprLit>) -> To
             Some(elit) => quote! {U32::Val(#lit + #elit)},
         },
         syn::Expr::Call(expr_call) => {
-            let bits = get_bits(&expr_call);
+            let bits = get_bits(expr_call);
             match extra_lit {
                 None => quote! {U32::Bits(#bits)},
                 Some(elit) => quote! {U32::BitsOffset{n: #bits, off: #elit}},
@@ -64,7 +64,7 @@ fn parse_single_coder(input: &syn::Expr, extra_lit: Option<&syn::ExprLit>) -> To
             };
             match (&**left, &**right) {
                 (syn::Expr::Call(expr_call), syn::Expr::Lit(lit)) => {
-                    let bits = get_bits(&expr_call);
+                    let bits = get_bits(expr_call);
                     match extra_lit {
                         None => quote! {U32::BitsOffset{n: #bits, off: #lit}},
                         Some(elit) => quote! {U32::BitsOffset{n: #bits, off: #lit + #elit}},
@@ -109,7 +109,7 @@ fn parse_coder(input: syn::Expr) -> TokenStream2 {
     };
 
     match &input {
-        syn::Expr::Call(expr_call) => parse_u2s(&expr_call, None),
+        syn::Expr::Call(expr_call) => parse_u2s(expr_call, None),
         syn::Expr::Binary(syn::ExprBinary {
             attrs: _,
             left,
@@ -123,7 +123,7 @@ fn parse_coder(input: syn::Expr) -> TokenStream2 {
             };
             match (&**left, &**right) {
                 (syn::Expr::Call(expr_call), syn::Expr::Lit(lit)) => {
-                    parse_u2s(&expr_call, Some(&lit))
+                    parse_u2s(expr_call, Some(lit))
                 }
                 _ => abort!(
                     input,
@@ -579,11 +579,11 @@ impl Field {
                     cond.as_deref(),
                     &("\\hyperref[hdr:".to_owned() + &href_ty + "]{" + &minted(&ty) + "}"),
                     dfl.as_deref(),
-                    &ident,
+                    ident,
                 );
             }
             Coder::U32(U32 { coder: _, pretty }) => {
-                add_row(cond.as_deref(), &minted(pretty), dfl.as_deref(), &ident);
+                add_row(cond.as_deref(), &minted(pretty), dfl.as_deref(), ident);
             }
             Coder::Select(
                 Condition {
@@ -610,17 +610,12 @@ impl Field {
                 } else {
                     "!(".to_owned() + condition + ")"
                 };
-                add_row(
-                    Some(&cond_true),
-                    &minted(&coder_true),
-                    dfl.as_deref(),
-                    &ident,
-                );
+                add_row(Some(&cond_true), &minted(coder_true), dfl.as_deref(), ident);
                 add_row(
                     Some(&cond_false),
-                    &minted(&coder_false),
+                    &minted(coder_false),
                     dfl.as_deref(),
-                    &ident,
+                    ident,
                 );
             }
             Coder::Vector(size_coder, value_coder) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,4 +59,9 @@ pub enum Error {
     InvalidContextMap(u32),
     #[error("Invalid context map: number of histogram {0}, number of distinct histograms {1}")]
     InvalidContextMapHole(u32, u32),
+    // FrameHeader format errors
+    #[error("Invalid extra channel upsampling: upsampling: {0} dim_shift: {1} ec_upsampling: {2}")]
+    InvalidEcUpsampling(u32, u32, u32),
+    #[error("Num_ds: {0} should be smaller than num_passes: {1}")]
+    NumPassesTooLarge(u32, u32),
 }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -11,6 +11,7 @@ pub mod bit_depth;
 pub mod color_encoding;
 pub mod encodings;
 pub mod extra_channels;
+pub mod frame_header;
 pub mod image_metadata;
 pub mod size;
 pub mod transform_data;

--- a/src/headers/bit_depth.rs
+++ b/src/headers/bit_depth.rs
@@ -28,7 +28,7 @@ pub struct BitDepth {
 }
 
 impl BitDepth {
-    fn check(&self) -> Result<(), Error> {
+    fn check(&self, _: &Empty) -> Result<(), Error> {
         if self.floating_point_sample {
             if self.exponent_bits_per_sample < 2 || self.exponent_bits_per_sample > 8 {
                 Err(Error::InvalidExponent(self.exponent_bits_per_sample))

--- a/src/headers/color_encoding.rs
+++ b/src/headers/color_encoding.rs
@@ -95,7 +95,7 @@ impl CustomTransferFunction {
         self.gamma as f32 * 0.0000001
     }
 
-    pub fn check(&self) -> Result<(), Error> {
+    pub fn check(&self, _: &CustomTransferFunctionNonserialized) -> Result<(), Error> {
         if self.have_gamma {
             let gamma = self.gamma();
             if gamma > 1.0 || gamma * 8192.0 < 1.0 {
@@ -142,7 +142,7 @@ pub struct ColorEncoding {
 }
 
 impl ColorEncoding {
-    pub fn check(&self) -> Result<(), Error> {
+    pub fn check(&self, _: &Empty) -> Result<(), Error> {
         if !self.want_icc
             && (self.color_space == ColorSpace::Unknown
                 || self.tf.transfer_function == TransferFunction::Unknown)

--- a/src/headers/extra_channels.rs
+++ b/src/headers/extra_channels.rs
@@ -47,7 +47,7 @@ pub struct ExtraChannelInfo {
     bit_depth: BitDepth,
     #[coder(u2S(0, 3, 4, Bits(3) + 1))]
     #[default(0)]
-    dim_shift: u32,
+    pub dim_shift: u32,
     name: String,
     // TODO(veluca93): if using Option<bool>, this is None when all_default.
     #[condition(ec_type == ExtraChannel::Alpha)]
@@ -61,7 +61,7 @@ pub struct ExtraChannelInfo {
 }
 
 impl ExtraChannelInfo {
-    fn check(&self) -> Result<(), Error> {
+    fn check(&self, _: &Empty) -> Result<(), Error> {
         if self.dim_shift > 3 {
             Err(Error::DimShiftTooLarge(self.dim_shift))
         } else {

--- a/src/headers/frame_header.rs
+++ b/src/headers/frame_header.rs
@@ -1,0 +1,542 @@
+#![allow(clippy::excessive_precision)]
+
+use crate::{
+    bit_reader::BitReader,
+    error::Error,
+    headers::{encodings::*, extra_channels::ExtraChannelInfo},
+};
+
+use jxl_headers_derive::UnconditionalCoder;
+use num_derive::FromPrimitive;
+
+#[derive(UnconditionalCoder, Copy, Clone, PartialEq, Debug, FromPrimitive)]
+enum FrameType {
+    RegularFrame = 0,
+    LFFrame = 1,
+    ReferenceOnly = 2,
+    SkipProgressive = 3,
+}
+
+#[derive(UnconditionalCoder, Copy, Clone, PartialEq, Debug, FromPrimitive)]
+enum Encoding {
+    VarDCT = 0,
+    Modular = 1,
+}
+
+struct Flags;
+
+#[allow(dead_code)]
+impl Flags {
+    pub const ENABLE_NOISE: u64 = 1;
+    pub const ENABLE_PATCHES: u64 = 2;
+    pub const ENABLE_SPLINES: u64 = 0x10;
+    pub const USE_LF_FRAME: u64 = 0x20;
+    pub const SKIP_ADAPTIVE_LF_SMOOTHING: u64 = 0x80;
+}
+
+#[derive(UnconditionalCoder, Debug, PartialEq)]
+struct Passes {
+    #[coder(u2S(1, 2, 3, Bits(3) + 4))]
+    #[default(1)]
+    num_passes: u32,
+
+    #[coder(u2S(0, 1, 2, Bits(1) + 3))]
+    #[default(0)]
+    #[condition(num_passes != 1)]
+    num_ds: u32,
+
+    #[size_coder(explicit(num_passes - 1))]
+    #[coder(Bits(2))]
+    #[default_element(0)]
+    #[condition(num_passes != 1)]
+    shift: Vec<u32>,
+
+    #[size_coder(explicit(num_ds))]
+    #[coder(u2S(1, 2, 4, 8))]
+    #[default_element(1)]
+    #[condition(num_passes != 1)]
+    downsample: Vec<u32>,
+
+    #[size_coder(explicit(num_ds))]
+    #[coder(u2S(0, 1, 2, Bits(3)))]
+    #[default_element(0)]
+    #[condition(num_passes != 1)]
+    last_pass: Vec<u32>,
+}
+
+#[derive(UnconditionalCoder, Copy, Clone, PartialEq, Debug, FromPrimitive)]
+enum BlendingMode {
+    Replace = 0,
+    Add = 1,
+    Blend = 2,
+    AlphaWeightedAdd = 3,
+    Mul = 4,
+}
+
+struct BlendingInfoNonserialized {
+    num_extra_channels: u32,
+    have_crop: bool,
+    x0: i32,
+    y0: i32,
+    width: u32,
+    height: u32,
+    img_width: u32,
+    img_height: u32,
+}
+
+#[derive(UnconditionalCoder, Debug, PartialEq, Clone)]
+#[nonserialized(BlendingInfoNonserialized)]
+struct BlendingInfo {
+    #[coder(u2S(0, 1, 2, Bits(2) + 3))]
+    #[default(BlendingMode::Replace)]
+    mode: BlendingMode,
+
+    /* Spec: "Let multi_extra be true if and only if and the number of extra channels is at least two."
+    libjxl condition is num_extra_channels > 0 */
+    #[coder(u2S(0, 1, 2, Bits(3) + 3))]
+    #[default(0)]
+    #[condition(nonserialized.num_extra_channels > 0 &&
+        (mode == BlendingMode::Blend || mode == BlendingMode::AlphaWeightedAdd))]
+    alpha_channel: u32,
+
+    #[default(false)]
+    #[condition(nonserialized.num_extra_channels > 0 &&
+        (mode == BlendingMode::Blend || mode == BlendingMode::AlphaWeightedAdd || mode == BlendingMode::Mul))]
+    clamp: bool,
+
+    #[coder(u2S(0, 1, 2, 3))]
+    #[default(0)]
+    // TODO(TomasKralCZ): figure out a way of extracting this huge condition into separate variables
+    /* Let full_frame be true if and only if have_crop is false or if the
+    frame area given by width and height and offsets x0 and y0 completely covers the image area. */
+    #[condition(mode != BlendingMode::Replace && !(!nonserialized.have_crop ||
+        (nonserialized.x0 == 0 && nonserialized.y0 == 0 &&
+        nonserialized.width as i64 + nonserialized.x0 as i64 >= nonserialized.img_width as i64 &&
+        nonserialized.height as i64 + nonserialized.y0 as i64 >= nonserialized.img_height as i64)))]
+    source: u32,
+}
+
+struct RestorationFilterNonserialized {
+    encoding: Encoding,
+}
+
+#[derive(UnconditionalCoder, Debug, PartialEq)]
+#[nonserialized(RestorationFilterNonserialized)]
+struct RestorationFilter {
+    // all_default isn't mentioned in the spec, but libjxl has it
+    #[all_default]
+    #[default(true)]
+    all_default: bool,
+
+    #[default(true)]
+    gab: bool,
+
+    #[default(false)]
+    #[condition(gab)]
+    gab_custom: bool,
+
+    #[default(0.115169525)]
+    #[condition(gab_custom)]
+    gab_x_weight1: f32,
+
+    #[default(0.061248592)]
+    #[condition(gab_custom)]
+    gab_x_weight2: f32,
+
+    #[default(0.115169525)]
+    #[condition(gab_custom)]
+    gab_y_weight1: f32,
+
+    #[default(0.061248592)]
+    #[condition(gab_custom)]
+    gab_y_weight2: f32,
+
+    #[default(0.115169525)]
+    #[condition(gab_custom)]
+    gab_b_weight1: f32,
+
+    #[default(0.061248592)]
+    #[condition(gab_custom)]
+    gab_b_weight2: f32,
+
+    #[coder(Bits(2))]
+    #[default(2)]
+    epf_iters: u32,
+
+    #[default(false)]
+    #[condition(epf_iters > 0 && nonserialized.encoding == Encoding::VarDCT)]
+    epf_sharp_custom: bool,
+
+    #[default([0.0, 1.0 / 7.0, 2.0 / 7.0, 3.0 / 7.0, 4.0 / 7.0, 5.0 / 7.0, 6.0 / 7.0, 1.0])]
+    #[condition(epf_sharp_custom)]
+    epf_sharp_lut: [f32; 8],
+
+    #[default(false)]
+    #[condition(epf_iters > 0)]
+    epf_weight_custom: bool,
+
+    #[default([40.0, 5.0, 3.5])]
+    #[condition(epf_weight_custom)]
+    epf_channel_scale: [f32; 3],
+
+    #[default(0.45)]
+    #[condition(epf_weight_custom)]
+    epf_pass1_zeroflush: f32,
+
+    #[default(0.6)]
+    #[condition(epf_weight_custom)]
+    epf_pass2_zeroflush: f32,
+
+    #[default(false)]
+    #[condition(epf_iters > 0)]
+    epf_sigma_custom: bool,
+
+    #[default(0.46)]
+    #[condition(epf_sigma_custom && nonserialized.encoding == Encoding::VarDCT)]
+    epf_quant_mul: f32,
+
+    #[default(0.9)]
+    #[condition(epf_sigma_custom)]
+    epf_pass0_sigma_scale: f32,
+
+    #[default(6.5)]
+    #[condition(epf_sigma_custom)]
+    epf_pass2_sigma_scale: f32,
+
+    #[default(2.0 / 3.0)]
+    #[condition(epf_sigma_custom)]
+    epf_border_sad_mul: f32,
+
+    #[default(1.0)]
+    #[condition(epf_iters > 0 && nonserialized.encoding == Encoding::Modular)]
+    epf_sigma_for_modular: f32,
+
+    #[default(Extensions::default())]
+    extensions: Extensions,
+}
+
+pub struct FrameHeaderNonserialized {
+    pub xyb_encoded: bool,
+    pub num_extra_channels: u32,
+    pub extra_channel_info: Vec<ExtraChannelInfo>,
+    pub have_animation: bool,
+    pub have_timecode: bool,
+    pub img_width: u32,
+    pub img_height: u32,
+}
+
+#[derive(UnconditionalCoder, Debug, PartialEq)]
+#[nonserialized(FrameHeaderNonserialized)]
+#[aligned]
+#[validate]
+pub struct FrameHeader {
+    #[all_default]
+    #[default(true)]
+    all_default: bool,
+
+    #[default(FrameType::RegularFrame)]
+    frame_type: FrameType,
+
+    #[coder(Bits(1))]
+    #[default(Encoding::VarDCT)]
+    encoding: Encoding,
+
+    #[default(0)]
+    flags: u64,
+
+    #[default(false)]
+    #[condition(!nonserialized.xyb_encoded)]
+    do_ycbcr: bool,
+
+    #[coder(Bits(2))]
+    #[default([0, 0, 0])]
+    #[condition(do_ycbcr && flags & Flags::USE_LF_FRAME == 0)]
+    jpeg_upsampling: [u32; 3],
+
+    #[coder(u2S(1, 2, 4, 8))]
+    #[default(1)]
+    #[condition(flags & Flags::USE_LF_FRAME == 0)]
+    upsampling: u32,
+
+    #[size_coder(explicit(nonserialized.num_extra_channels))]
+    #[coder(u2S(1, 2, 4, 8))]
+    #[default_element(1)]
+    #[condition(flags & Flags::USE_LF_FRAME == 0)]
+    ec_upsampling: Vec<u32>,
+
+    #[coder(Bits(2))]
+    #[default(1)]
+    #[condition(encoding == Encoding::Modular)]
+    group_size_shift: u32,
+
+    #[coder(Bits(3))]
+    #[default(3)]
+    #[condition(encoding == Encoding::VarDCT && nonserialized.xyb_encoded)]
+    x_qm_scale: u32,
+
+    #[coder(Bits(3))]
+    #[default(2)]
+    #[condition(encoding == Encoding::VarDCT && nonserialized.xyb_encoded)]
+    b_qm_scale: u32,
+
+    #[condition(frame_type != FrameType::ReferenceOnly)]
+    #[default(Passes::default())]
+    passes: Passes,
+
+    #[coder(u2S(1, 2, 3, 4))]
+    #[default(0)]
+    #[condition(frame_type == FrameType::LFFrame)]
+    lf_level: u32,
+
+    #[default(false)]
+    #[condition(frame_type != FrameType::LFFrame)]
+    have_crop: bool,
+
+    #[coder(u2S(Bits(8), Bits(11) + 256, Bits(14) + 2304, Bits(30) + 18688))]
+    #[default(0)]
+    #[condition(have_crop && frame_type != FrameType::ReferenceOnly)]
+    x0: i32,
+
+    #[coder(u2S(Bits(8), Bits(11) + 256, Bits(14) + 2304, Bits(30) + 18688))]
+    #[default(0)]
+    #[condition(have_crop && frame_type != FrameType::ReferenceOnly)]
+    y0: i32,
+
+    #[coder(u2S(Bits(8), Bits(11) + 256, Bits(14) + 2304, Bits(30) + 18688))]
+    #[default(0)]
+    #[condition(have_crop)]
+    width: u32,
+
+    #[coder(u2S(Bits(8), Bits(11) + 256, Bits(14) + 2304, Bits(30) + 18688))]
+    #[default(0)]
+    #[condition(have_crop)]
+    height: u32,
+
+    /* "normal_frame" denotes the condition !all_default
+    && (frame_type == kRegularFrame || frame_type == kSkipProgressive) */
+    #[default(BlendingInfo::default())]
+    #[condition(frame_type == FrameType::RegularFrame || frame_type == FrameType::SkipProgressive)]
+    #[nonserialized(num_extra_channels : nonserialized.num_extra_channels,
+        have_crop : have_crop, x0: x0, y0: y0, width: width, height: height,
+        img_width: nonserialized.img_width, img_height: nonserialized.img_height)]
+    blending_info: BlendingInfo,
+
+    #[size_coder(explicit(nonserialized.num_extra_channels))]
+    #[default_element(BlendingInfo::default())]
+    #[nonserialized(num_extra_channels : nonserialized.num_extra_channels,
+        have_crop : have_crop, x0: x0, y0: y0, width: width, height: height,
+        img_width: nonserialized.img_width, img_height: nonserialized.img_height)]
+    ec_blending_info: Vec<BlendingInfo>,
+
+    #[coder(u2S(0, 1, Bits(8), Bits(32)))]
+    #[default(0)]
+    #[condition((frame_type == FrameType::RegularFrame ||
+        frame_type == FrameType::SkipProgressive) && nonserialized.have_animation)]
+    duration: u32,
+
+    #[coder(Bits(32))]
+    #[default(0)]
+    #[condition((frame_type == FrameType::RegularFrame ||
+        frame_type == FrameType::SkipProgressive) && nonserialized.have_timecode)]
+    timecode: u32,
+
+    #[default(frame_type == FrameType::RegularFrame)]
+    #[condition(frame_type == FrameType::RegularFrame || frame_type == FrameType::SkipProgressive)]
+    pub is_last: bool,
+
+    #[coder(Bits(2))]
+    #[default(0)]
+    #[condition(frame_type != FrameType::LFFrame && !is_last)]
+    save_as_reference: u32,
+
+    // TODO(TomasKralCZ): figure out a way of extracting this huge default into separate variables
+    /* The default value for save_before_ct is d_sbct = !(full_frame && (frame_type ==
+    kRegularFrame || frame_type == kSkipProgressive) && blending_info.mode ==
+    kReplace && (duration == 0 || save_as_reference != 0) && !is_last). */
+    #[default(!(!have_crop || (x0 == 0 && y0 == 0 &&
+        width as i64 + x0 as i64 >= nonserialized.img_width as i64 &&
+        height as i64 + y0 as i64 >= nonserialized.img_height as i64))
+        && (frame_type == FrameType::RegularFrame || frame_type == FrameType::SkipProgressive) &&
+        blending_info.mode == BlendingMode::Replace && (duration == 0 || save_as_reference != 0) && !is_last)]
+    #[condition(frame_type != FrameType::LFFrame)]
+    save_before_ct: bool,
+
+    name: String,
+
+    #[default(RestorationFilter::default())]
+    #[nonserialized(encoding : encoding)]
+    restoration_filter: RestorationFilter,
+
+    #[default(Extensions::default())]
+    extensions: Extensions,
+}
+
+impl FrameHeader {
+    fn check(&self, nonserialized: &FrameHeaderNonserialized) -> Result<(), Error> {
+        if self.upsampling > 1 {
+            if let Some((info, upsampling)) = nonserialized
+                .extra_channel_info
+                .iter()
+                .zip(&self.ec_upsampling)
+                .find(|(info, ec_upsampling)| {
+                    ((*ec_upsampling << info.dim_shift) < self.upsampling) || (**ec_upsampling > 8)
+                })
+            {
+                return Err(Error::InvalidEcUpsampling(
+                    self.upsampling,
+                    info.dim_shift,
+                    *upsampling,
+                ));
+            }
+        }
+
+        if self.passes.num_ds >= self.passes.num_passes {
+            return Err(Error::NumPassesTooLarge(
+                self.passes.num_ds,
+                self.passes.num_passes,
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_frame_header {
+    use super::*;
+    use crate::{
+        bit_reader::BitReader,
+        bmff::JxlCodestream,
+        headers::{FileHeaders, JxlHeader},
+    };
+
+    fn test_frame_header(image: Vec<u8>, correct_frame_header: FrameHeader) {
+        let codestream = JxlCodestream::new(image).unwrap();
+
+        let mut br = BitReader::new(codestream.get());
+        let fh = FileHeaders::read(&mut br).unwrap();
+
+        let have_timecode = match fh.image_metadata.animation {
+            Some(ref a) => a.have_timecodes,
+            None => false,
+        };
+        let frame_header = FrameHeader::read_unconditional(
+            &(),
+            &mut br,
+            &FrameHeaderNonserialized {
+                xyb_encoded: fh.image_metadata.xyb_encoded,
+                num_extra_channels: fh.image_metadata.extra_channel_info.len() as u32,
+                extra_channel_info: fh.image_metadata.extra_channel_info,
+                have_animation: fh.image_metadata.animation.is_some(),
+                have_timecode,
+                img_width: fh.size.xsize(),
+                img_height: fh.size.ysize(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(correct_frame_header, frame_header);
+    }
+
+    #[test]
+    fn test_basic() {
+        test_frame_header(
+            vec![
+                0xFF, 0x0A, 0x00, 0x90, 0x01, 0x00, 0x12, 0x88, 0x02, 0x00, 0xD4, 0x00, 0x55, 0x0F,
+                0x00, 0x00, 0xA8, 0x50, 0x19, 0x65, 0xDC, 0xE0, 0xE5, 0x5C, 0xCF, 0x97, 0x1F, 0x3A,
+                0x2C, 0xA6, 0x6D, 0x5C, 0x67, 0x68, 0xAB, 0x6D, 0x0B, 0x4B, 0x12, 0x45, 0xC6, 0xB1,
+                0x49, 0x3A, 0x81, 0x43, 0x92, 0x58, 0x04, 0x36, 0x2E, 0x98, 0x07, 0x18, 0x00, 0x86,
+                0x99, 0x03, 0x27, 0x33, 0x50, 0xE4, 0x4A, 0x12, 0x00,
+            ],
+            // TODO(TomasKralCZ): It would be nice to use struct update syntax like this:
+            // FrameHeader {
+            //     fields that we actually care about
+            //     ..FrameHeader::default_from_nonserialized(&nonserialized)
+            // }
+            FrameHeader {
+                all_default: false,
+                frame_type: FrameType::RegularFrame,
+                encoding: Encoding::VarDCT,
+                flags: 0,
+                do_ycbcr: false,
+                jpeg_upsampling: [0, 0, 0],
+                upsampling: 1,
+                ec_upsampling: vec![],
+                group_size_shift: 1,
+                x_qm_scale: 2,
+                b_qm_scale: 2,
+                passes: Passes::default(),
+                lf_level: 0,
+                have_crop: false,
+                x0: 0,
+                y0: 0,
+                width: 0,
+                height: 0,
+                blending_info: BlendingInfo::default(),
+                ec_blending_info: vec![],
+                duration: 0,
+                timecode: 0,
+                is_last: true,
+                save_as_reference: 0,
+                save_before_ct: false,
+                name: String::from(""),
+                restoration_filter: RestorationFilter::default(),
+                extensions: Extensions::default(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_extra_channel() {
+        test_frame_header(
+            vec![
+                0xFF, 0x0A, 0x41, 0xC0, 0x4A, 0x08, 0x10, 0x10, 0x00, 0xE4, 0x01, 0x4B, 0x28, 0x36,
+                0x56, 0x1F, 0xDC, 0x4B, 0x28, 0x98, 0x10, 0x01, 0x55, 0x21, 0xC4, 0x30, 0x06, 0x50,
+                0x87, 0x61, 0xAB, 0x2A, 0xB2, 0x17, 0x03, 0x02, 0xA0, 0x97, 0xCC, 0x08, 0x00, 0xC3,
+                0x63, 0x80, 0x49, 0x66, 0x12, 0x04, 0x78, 0x2C, 0xD6, 0x89, 0x53, 0xEF, 0xF9, 0x15,
+                0xFC, 0xD1, 0x6B, 0xC4, 0xF3, 0xC0, 0x0E, 0xA9, 0x8D, 0xB6, 0x16, 0x4E, 0x5C, 0x70,
+                0x06, 0xE2, 0x07, 0x12, 0x62, 0xEC, 0x6C, 0xBE, 0x7C, 0x16, 0xDC, 0x72, 0xCE, 0xF3,
+                0xC1, 0xA2, 0xE2, 0x0A, 0xC8, 0xF9, 0xA1, 0x8C, 0xDA, 0xCF, 0xE3, 0xE8, 0x27, 0xDA,
+                0x66, 0xE2, 0xD6, 0x20, 0x2A, 0x38, 0xC1, 0xF7, 0xD0, 0x66, 0xED, 0xD2, 0xE0, 0x04,
+                0x42, 0x3A, 0x2A, 0x99, 0x2C, 0x12, 0x19, 0x9D, 0x9E, 0x83, 0x28, 0x54, 0x81, 0x55,
+                0x83, 0x3D, 0x69, 0x00, 0x1D, 0x03,
+            ],
+            FrameHeader {
+                all_default: false,
+                frame_type: FrameType::RegularFrame,
+                encoding: Encoding::Modular,
+                flags: 0,
+                do_ycbcr: false,
+                jpeg_upsampling: [0, 0, 0],
+                upsampling: 1,
+                ec_upsampling: vec![1],
+                group_size_shift: 2,
+                // libjxl x_qm_scale = 2, but condition is false (should be 3 according to the draft)
+                x_qm_scale: 3,
+                b_qm_scale: 2,
+                passes: Passes::default(),
+                lf_level: 0,
+                have_crop: false,
+                x0: 0,
+                y0: 0,
+                width: 0,
+                height: 0,
+                blending_info: BlendingInfo::default(),
+                ec_blending_info: vec![BlendingInfo::default()],
+                duration: 0,
+                timecode: 0,
+                is_last: true,
+                save_as_reference: 0,
+                save_before_ct: false,
+                name: String::from(""),
+                restoration_filter: RestorationFilter {
+                    all_default: false,
+                    gab: false,
+                    epf_iters: 0,
+                    ..RestorationFilter::default()
+                },
+                extensions: Extensions::default(),
+            },
+        );
+    }
+}

--- a/src/headers/image_metadata.rs
+++ b/src/headers/image_metadata.rs
@@ -78,7 +78,7 @@ pub struct ToneMapping {
 }
 
 impl ToneMapping {
-    pub fn check(&self) -> Result<(), Error> {
+    pub fn check(&self, _: &Empty) -> Result<(), Error> {
         if self.intensity_target <= 0.0 {
             Err(Error::InvalidIntensityTarget(self.intensity_target))
         } else if self.min_nits < 0.0 || self.min_nits > self.intensity_target {
@@ -125,7 +125,7 @@ pub struct ImageMetadata {
     pub bit_depth: BitDepth,
     #[default(true)]
     pub modular_16bit_sufficient: bool,
-    #[size_coder(u2S(0, 1, Bits(4) + 2, Bits(12) + 1))]
+    #[size_coder(implicit(u2S(0, 1, Bits(4) + 2, Bits(12) + 1)))]
     pub extra_channel_info: Vec<ExtraChannelInfo>,
     #[default(true)]
     pub xyb_encoded: bool,


### PR DESCRIPTION
Hi ! This PR implements parsing of the frame headers.

To do that, I needed to change some of the `derive` code:

- `#[size_coder]` now accepts either `implicit(...)` or `explicit(...)`. Implicit will read the size from the `BitReader`, explicit uses some already decoded variable to get the size.
- I added a new attribute `#[aligned]` that calls `jump_to_byte_boundary()` before and after decoding the bundle.
- I removed the `abort` caused by using `#[default]` with `#[size_coder]`. It should work as-is as far as I can see, but let me know if I missed something.