### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout the source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Check AUTHORS file
       run:
         ./ci/pull_request_checks.sh
@@ -29,21 +29,19 @@ jobs:
     name: Test, Format and Clippy
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-          toolchain: stable
-          override: true
 
       - name: Build artefact caching
-        uses: Swatinem/rust-cache@v2.0.0
+        uses: Swatinem/rust-cache@v2.7.3
 
-      - name: Format 
+      - name: Format
         run: cargo fmt --all -- --check
 
       - name: Clippy


### PR DESCRIPTION
- Update `actions/checkout` to v4.
- Update `Swatinem/rust-cache` to v2.7.3.
- Use `dtolnay/rust-toolchain` because `actions-rs/toolchain` is no longer maintained.