### PR TITLE
Cleanup: fix pull_request_checks.sh, add missing headers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,10 @@ debug = true
 [workspace]
 members = [ "jxl", "jxl_cli", "jxl_headers_derive"]
 resolver = "2"
+
+[workspace.lints.clippy]
+missing_safety_doc = "deny"
+undocumented_unsafe_blocks = "deny"
+
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "deny"

--- a/ci/pull_request_checks.sh
+++ b/ci/pull_request_checks.sh
@@ -9,15 +9,15 @@
 
 MYDIR=$(dirname $(realpath "$0"))
 
+TEXT_FILES='(Dockerfile.*|\.c|\.cc|\.cpp|\.gni|\.h|\.java|\.sh|\.m|\.py|\.ui|\.yml|\.rs)$'
+
 set -u
 
 # Check for copyright / license markers.
 test_copyright() {
   local ret=0
   local f
-  for f in $(
-      git ls-files | grep -E \
-      '(Dockerfile.*|\.c|\.cc|\.cpp|\.gni|\.h|\.java|\.sh|\.m|\.py|\.ui|\.yml|\.rs)$'); do
+  for f in $(git ls-files .. | grep -E ${TEXT_FILES}); do
     if [[ "${f#third_party/}" == "$f" ]]; then
       # $f is not in third_party/
       if ! head -n 10 "$f" |
@@ -49,8 +49,7 @@ test_author() {
 # Check for git merge conflict markers.
 test_merge_conflict() {
   local ret=0
-  TEXT_FILES='(\.cc|\.cpp|\.h|\.sh|\.m|\.py|\.md|\.txt|\.cmake|\.rs)$'
-  for f in $(git ls-files | grep -E "${TEXT_FILES}"); do
+  for f in $(git ls-files .. | grep -E "${TEXT_FILES}"); do
     if grep -E '^<<<<<<< ' "$f"; then
       echo "$f: Found git merge conflict marker. Please resolve." >&2
       ret=1

--- a/jxl/Cargo.toml
+++ b/jxl/Cargo.toml
@@ -18,3 +18,6 @@ jxl_headers_derive = { path = "../jxl_headers_derive" }
 
 [features]
 debug_tools = []
+
+[lints]
+workspace = true

--- a/jxl/src/headers/frame_header.rs
+++ b/jxl/src/headers/frame_header.rs
@@ -1,3 +1,8 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 #![allow(clippy::excessive_precision)]
 
 use crate::{

--- a/jxl/src/image.rs
+++ b/jxl/src/image.rs
@@ -1,3 +1,8 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 use crate::error::{Error, Result};
 
 mod private {

--- a/jxl/src/lib.rs
+++ b/jxl/src/lib.rs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#![deny(unsafe_code)]
 pub mod bit_reader;
 pub mod container;
 pub mod entropy_coding;

--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -1,3 +1,8 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 use crate::{
     error::Result,
     image::{ImageDataType, ImageRectMut},

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 jxl = { path = "../jxl" }
+
+[lints]
+workspace = true

--- a/jxl_headers_derive/Cargo.toml
+++ b/jxl_headers_derive/Cargo.toml
@@ -14,3 +14,6 @@ proc-macro2 = "1.0"
 proc-macro-error = "1.0"
 quote = "1.0"
 syn = { version = "1.0.45", features = ["extra-traits", "full"] }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Also add `#[deny(unsafe_code)]` to ensure that unsafe code is easier to audit, and missing_safety_doc, undocumented_unsafe_blocks, unsafe_op_in_unsafe_fn.