### PR TITLE
Use `Display` to set render stage names

### DIFF
--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -70,7 +70,7 @@ pub struct RenderPipelineExtendStage<T: ImageDataType> {
 }
 
 // TODO(veluca): figure out how to modify the interface for concurrent usage.
-pub trait RenderPipelineStage: Any {
+pub trait RenderPipelineStage: Any + std::fmt::Display {
     type Type: RenderPipelineStageInfo;
 
     /// Which channels are actually used by this stage.
@@ -97,9 +97,6 @@ pub trait RenderPipelineStage: Any {
     fn original_data_origin(&self) -> (usize, usize) {
         (0, 0)
     }
-
-    /// Returns a name for this stage.
-    fn name(&self) -> String;
 }
 
 pub trait RenderPipelineBuilder: Sized {

--- a/jxl/src/render/stages/convert.rs
+++ b/jxl/src/render/stages/convert.rs
@@ -15,12 +15,14 @@ impl ConvertU8F32Stage {
     }
 }
 
+impl std::fmt::Display for ConvertU8F32Stage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "convert U8 data to F32 in channel {}", self.channel)
+    }
+}
+
 impl RenderPipelineStage for ConvertU8F32Stage {
     type Type = RenderPipelineInOutStage<u8, f32, 0, 0, 0, 0>;
-
-    fn name(&self) -> String {
-        format!("convert U8 data to F32 in channel {}", self.channel)
-    }
 
     fn uses_channel(&self, c: usize) -> bool {
         c == self.channel

--- a/jxl/src/render/stages/save.rs
+++ b/jxl/src/render/stages/save.rs
@@ -36,12 +36,19 @@ impl<T: ImageDataType> SaveStage<T> {
     }
 }
 
+impl<T: ImageDataType> std::fmt::Display for SaveStage<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "save channel {} (type {:?})",
+            self.channel,
+            T::DATA_TYPE_ID
+        )
+    }
+}
+
 impl<T: ImageDataType> RenderPipelineStage for SaveStage<T> {
     type Type = RenderPipelineInputStage<T>;
-
-    fn name(&self) -> String {
-        format!("save channel {} (type {:?})", self.channel, T::DATA_TYPE_ID)
-    }
 
     fn uses_channel(&self, c: usize) -> bool {
         c == self.channel

--- a/jxl/src/render/stages/upsample.rs
+++ b/jxl/src/render/stages/upsample.rs
@@ -15,12 +15,18 @@ impl NearestNeighbourUpsample {
     }
 }
 
+impl std::fmt::Display for NearestNeighbourUpsample {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "2x2 nearest neighbour upsample of channel {}",
+            self.channel
+        )
+    }
+}
+
 impl RenderPipelineStage for NearestNeighbourUpsample {
     type Type = RenderPipelineInOutStage<u8, u8, 0, 0, 1, 1>;
-
-    fn name(&self) -> String {
-        format!("2x2 nearest neighbour upsample of channel {}", self.channel)
-    }
 
     fn uses_channel(&self, c: usize) -> bool {
         c == self.channel


### PR DESCRIPTION
Use `Display::fmt` instead of separate `name` method, like [`std::error::Error`][error] does. (`.to_string()` can be used if `String` is needed.)

[error]: https://doc.rust-lang.org/stable/std/error/trait.Error.html