### PR TITLE
Create a `Frame` type to handle frame parsing.

### DIFF
--- a/jxl/src/frame.rs
+++ b/jxl/src/frame.rs
@@ -1,0 +1,72 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    bit_reader::BitReader,
+    error::Result,
+    headers::{
+        encodings::UnconditionalCoder,
+        frame_header::{FrameHeader, Toc, TocNonserialized},
+        FileHeader,
+    },
+};
+
+pub struct Frame {
+    header: FrameHeader,
+    toc: Toc,
+}
+
+impl Frame {
+    pub fn new(br: &mut BitReader, file_header: &FileHeader) -> Result<Self> {
+        let frame_header =
+            FrameHeader::read_unconditional(&(), br, &file_header.frame_header_nonserialized())
+                .unwrap();
+        let num_toc_entries = frame_header.num_toc_entries();
+        let toc = Toc::read_unconditional(
+            &(),
+            br,
+            &TocNonserialized {
+                num_entries: num_toc_entries,
+            },
+        )
+        .unwrap();
+        br.jump_to_byte_boundary()?;
+        Ok(Self {
+            header: frame_header,
+            toc,
+        })
+    }
+
+    pub fn header(&self) -> &FrameHeader {
+        &self.header
+    }
+
+    pub fn total_bytes_in_toc(&self) -> usize {
+        self.toc.entries.iter().map(|x| *x as usize).sum()
+    }
+
+    pub fn is_last(&self) -> bool {
+        self.header.is_last
+    }
+
+    /// Given a bit reader pointing at the end of the TOC, returns a vector of `BitReader`s, each
+    /// of which reads a specific section.
+    pub fn sections<'a>(&self, br: &'a mut BitReader) -> Result<Vec<BitReader<'a>>> {
+        if self.toc.permuted {
+            self.toc
+                .permutation
+                .iter()
+                .map(|x| self.toc.entries[*x as usize] as usize)
+                .scan(br, |br, count| Some(br.split_at(count)))
+                .collect()
+        } else {
+            self.toc
+                .entries
+                .iter()
+                .scan(br, |br, count| Some(br.split_at(*count as usize)))
+                .collect()
+        }
+    }
+}

--- a/jxl/src/headers/frame_header.rs
+++ b/jxl/src/headers/frame_header.rs
@@ -234,12 +234,12 @@ pub struct PermutationNonserialized {
 #[nonserialized(TocNonserialized)]
 pub struct Toc {
     #[default(false)]
-    permuted: bool,
+    pub permuted: bool,
 
     // Here we don't use `condition(permuted)`, because `jump_to_byte_boundary` needs to be executed in both cases
     #[default(Permutation::default())]
     #[nonserialized(num_entries: nonserialized.num_entries, permuted: permuted)]
-    permutation: Permutation,
+    pub permutation: Permutation,
 
     #[coder(u2S(Bits(10), Bits(14) + 1024, Bits(22) + 17408, Bits(30) + 4211712))]
     #[size_coder(explicit(nonserialized.num_entries))]

--- a/jxl/src/lib.rs
+++ b/jxl/src/lib.rs
@@ -8,6 +8,7 @@ pub mod bit_reader;
 pub mod container;
 pub mod entropy_coding;
 pub mod error;
+pub mod frame;
 pub mod headers;
 pub mod icc;
 pub mod image;


### PR DESCRIPTION
This includes adding a function to split up a BitReader for a frame into a vector of `BitReader`s for each section.