### PR TITLE
Fix reading simple Huffman table

### DIFF
--- a/jxl/src/entropy_coding/huffman.rs
+++ b/jxl/src/entropy_coding/huffman.rs
@@ -90,9 +90,6 @@ impl Table {
         } else {
             false
         };
-        if !special_4_symbols {
-            symbols.sort_unstable();
-        };
         debug!(symbols = ?symbols[..num_symbols]);
         match (num_symbols, special_4_symbols) {
             (1, _) => Ok(vec![


### PR DESCRIPTION
Symbols of simple Huffman table are used in the order they were read.

(Found while testing with my own testset)