### PR TITLE
color/tf: Fix constant in hlg_to_scene_precise

### DIFF
--- a/jxl/src/color/tf.rs
+++ b/jxl/src/color/tf.rs
@@ -357,7 +357,7 @@ pub fn hlg_to_scene_precise(samples: &mut [f32]) {
     for s in samples {
         let a = s.abs() as f64;
         let y = if a <= 0.5 {
-            a * a * 3.0
+            a * a / 3.0
         } else {
             (((a - HLG_C) / HLG_A).exp() + HLG_B) / 12.0
         };


### PR DESCRIPTION
Updated the constant in `hlg_to_scene_precise` to match the equivalent upstream libjxl transfer function definitions.

Upstream Definitions: 
- https://github.com/libjxl/libjxl/blob/main/lib/jxl/cms/transfer_functions.h#L54-L64
- https://github.com/libjxl/libjxl/blob/main/lib/jxl/cms/transfer_functions-inl.h#L71-L83