### PR TITLE
Implement ToLinearStage

### DIFF
--- a/jxl/src/color/tf.rs
+++ b/jxl/src/color/tf.rs
@@ -384,6 +384,32 @@ pub fn scene_to_hlg(samples: &mut [f32]) {
     }
 }
 
+/// Converts HLG signal to scene-referred linear sample.
+///
+/// This version uses `fast_pow2f` to apply logarithmic function.
+// Max error: ~5e-6
+pub fn hlg_to_scene(samples: &mut [f32]) {
+    for s in samples {
+        let a = s.abs();
+        let y = if a <= 0.5 {
+            a * a / 3.0
+        } else {
+            const POW: f32 = (std::f64::consts::LOG2_E / HLG_A) as f32;
+            const ADD: f32 = (HLG_B / 12.0) as f32;
+            // TODO(OneDeuxTriSeiGo): replace raw constant with the below equation
+            // when std::f64::exp() can is available as a const fn.
+            //
+            // Equation: ((-HLG_B / HLG_A).exp() / 12.0)
+            // Constant: 0.003_639_807_079_052_639
+            const MUL: f32 = 0.003_639_807;
+
+            // TODO(OneDeuxTriSeiGo): maybe use mul_add?
+            crate::util::fast_pow2f(a * POW) * MUL + ADD
+        };
+        *s = y.copysign(*s);
+    }
+}
+
 #[cfg(test)]
 mod test {
     use test_log::test;
@@ -556,6 +582,19 @@ mod test {
             scene_to_hlg(&mut samples);
             scene_to_hlg_precise(&mut precise);
             assert_all_almost_eq!(&samples, &precise, 5e-7);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn hlg_to_scene_arb() {
+        arbtest::arbtest(|u| {
+            let mut samples = arb_samples(u)?;
+            let mut precise = samples.clone();
+
+            hlg_to_scene(&mut samples);
+            hlg_to_scene_precise(&mut precise);
+            assert_all_almost_eq!(&samples, &precise, 5e-6);
             Ok(())
         });
     }

--- a/jxl/src/render/stages/mod.rs
+++ b/jxl/src/render/stages/mod.rs
@@ -12,6 +12,7 @@ mod noise;
 mod save;
 mod splines;
 mod spot;
+mod to_linear;
 mod upsample;
 mod xyb;
 mod ycbcr;

--- a/jxl/src/render/stages/to_linear.rs
+++ b/jxl/src/render/stages/to_linear.rs
@@ -1,0 +1,263 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use crate::color::tf;
+use crate::headers::color_encoding::CustomTransferFunction;
+use crate::render::{RenderPipelineInPlaceStage, RenderPipelineStage};
+
+/// Apply transfer function to display-referred linear color samples.
+#[derive(Debug)]
+pub struct ToLinearStage {
+    first_channel: usize,
+    tf: TransferFunction,
+}
+
+impl ToLinearStage {
+    fn new(first_channel: usize, tf: TransferFunction) -> Self {
+        Self { first_channel, tf }
+    }
+
+    #[allow(unused, reason = "tirr-c: remove once we use this!")]
+    pub fn sdr(first_channel: usize, tf: CustomTransferFunction) -> Self {
+        let tf = TransferFunction::try_from(tf).expect("transfer function is not an SDR one");
+        Self::new(first_channel, tf)
+    }
+
+    #[allow(unused, reason = "tirr-c: remove once we use this!")]
+    pub fn pq(first_channel: usize, intensity_target: f32) -> Self {
+        let tf = TransferFunction::Pq { intensity_target };
+        Self::new(first_channel, tf)
+    }
+
+    #[allow(unused, reason = "tirr-c: remove once we use this!")]
+    pub fn hlg(first_channel: usize, intensity_target: f32, luminance_rgb: [f32; 3]) -> Self {
+        let tf = TransferFunction::Hlg {
+            intensity_target,
+            luminance_rgb,
+        };
+        Self::new(first_channel, tf)
+    }
+}
+
+impl std::fmt::Display for ToLinearStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let channel = self.first_channel;
+        write!(
+            f,
+            "Apply transfer function {:?} to channel [{},{},{}]",
+            self.tf,
+            channel,
+            channel + 1,
+            channel + 2
+        )
+    }
+}
+
+impl RenderPipelineStage for ToLinearStage {
+    type Type = RenderPipelineInPlaceStage<f32>;
+
+    fn uses_channel(&self, c: usize) -> bool {
+        (self.first_channel..self.first_channel + 3).contains(&c)
+    }
+
+    fn process_row_chunk(
+        &mut self,
+        _position: (usize, usize),
+        xsize: usize,
+        row: &mut [&mut [f32]],
+    ) {
+        let [row_r, row_g, row_b] = row else {
+            panic!(
+                "incorrect number of channels; expected 3, found {}",
+                row.len()
+            );
+        };
+
+        match self.tf {
+            TransferFunction::Bt709 => {
+                for row in row {
+                    tf::bt709_to_linear(&mut row[..xsize]);
+                }
+            }
+            TransferFunction::Srgb => {
+                for row in row {
+                    tf::srgb_to_linear(&mut row[..xsize]);
+                }
+            }
+            TransferFunction::Pq { intensity_target } => {
+                for row in row {
+                    tf::pq_to_linear(intensity_target, &mut row[..xsize]);
+                }
+            }
+            TransferFunction::Hlg {
+                intensity_target,
+                luminance_rgb,
+            } => {
+                tf::hlg_to_scene(&mut row_r[..xsize]);
+                tf::hlg_to_scene(&mut row_g[..xsize]);
+                tf::hlg_to_scene(&mut row_b[..xsize]);
+
+                let rows = [
+                    &mut row_r[..xsize],
+                    &mut row_g[..xsize],
+                    &mut row_b[..xsize],
+                ];
+                tf::hlg_scene_to_display(intensity_target, luminance_rgb, rows);
+            }
+            TransferFunction::Gamma(g) => {
+                for row in row {
+                    for v in &mut row[..xsize] {
+                        *v = crate::util::fast_powf(*v, g);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum TransferFunction {
+    Bt709,
+    Srgb,
+    Pq {
+        intensity_target: f32,
+    },
+    Hlg {
+        intensity_target: f32,
+        luminance_rgb: [f32; 3],
+    },
+    /// Inverse gamma in range `(0, 1]`
+    Gamma(f32),
+}
+
+impl TryFrom<CustomTransferFunction> for TransferFunction {
+    type Error = ();
+
+    fn try_from(ctf: CustomTransferFunction) -> Result<Self, ()> {
+        use crate::headers::color_encoding::TransferFunction;
+
+        if ctf.have_gamma {
+            Ok(Self::Gamma(ctf.gamma()))
+        } else {
+            match ctf.transfer_function {
+                TransferFunction::BT709 => Ok(Self::Bt709),
+                TransferFunction::Unknown => Err(()),
+                TransferFunction::Linear => Err(()),
+                TransferFunction::SRGB => Ok(Self::Srgb),
+                TransferFunction::PQ => Err(()),
+                TransferFunction::DCI => Ok(Self::Gamma(2.6f32.recip())),
+                TransferFunction::HLG => Err(()),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_log::test;
+
+    use super::*;
+    use crate::error::Result;
+    use crate::image::Image;
+    use crate::render::test::make_and_run_simple_pipeline;
+    use crate::util::test::assert_all_almost_eq;
+
+    const LUMINANCE_BT2020: [f32; 3] = [0.2627, 0.678, 0.0593];
+
+    #[test]
+    fn consistency_hlg() -> Result<()> {
+        crate::render::test::test_stage_consistency::<_, f32, f32>(
+            ToLinearStage::hlg(0, 1000f32, LUMINANCE_BT2020),
+            (500, 500),
+            3,
+        )
+    }
+
+    #[test]
+    fn consistency_pq() -> Result<()> {
+        crate::render::test::test_stage_consistency::<_, f32, f32>(
+            ToLinearStage::pq(0, 10000f32),
+            (500, 500),
+            3,
+        )
+    }
+
+    #[test]
+    fn consistency_srgb() -> Result<()> {
+        crate::render::test::test_stage_consistency::<_, f32, f32>(
+            ToLinearStage::new(0, TransferFunction::Srgb),
+            (500, 500),
+            3,
+        )
+    }
+
+    #[test]
+    fn consistency_bt709() -> Result<()> {
+        crate::render::test::test_stage_consistency::<_, f32, f32>(
+            ToLinearStage::new(0, TransferFunction::Bt709),
+            (500, 500),
+            3,
+        )
+    }
+
+    #[test]
+    fn consistency_gamma22() -> Result<()> {
+        crate::render::test::test_stage_consistency::<_, f32, f32>(
+            ToLinearStage::new(0, TransferFunction::Gamma(0.4545455)),
+            (500, 500),
+            3,
+        )
+    }
+
+    #[test]
+    fn sdr_white_hlg() -> Result<()> {
+        let intensity_target = 1000f32;
+        // Reversed version of FromLinear test
+        let input_r = Image::new_constant((1, 1), 0.75)?;
+        let input_g = Image::new_constant((1, 1), 0.75)?;
+        let input_b = Image::new_constant((1, 1), 0.75)?;
+
+        // 75% HLG
+        let stage = ToLinearStage::hlg(0, intensity_target, LUMINANCE_BT2020);
+        let output = make_and_run_simple_pipeline::<_, f32, f32>(
+            stage,
+            &[input_r, input_g, input_b],
+            (1, 1),
+            256,
+        )?
+        .1;
+
+        assert_all_almost_eq!(output[0].as_rect().row(0), &[0.203], 1e-3);
+        assert_all_almost_eq!(output[1].as_rect().row(0), &[0.203], 1e-3);
+        assert_all_almost_eq!(output[2].as_rect().row(0), &[0.203], 1e-3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn sdr_white_pq() -> Result<()> {
+        let intensity_target = 1000f32;
+        // Reversed version of FromLinear test
+        let input_r = Image::new_constant((1, 1), 0.5807)?;
+        let input_g = Image::new_constant((1, 1), 0.5807)?;
+        let input_b = Image::new_constant((1, 1), 0.5807)?;
+
+        // 58% PQ
+        let stage = ToLinearStage::pq(0, intensity_target);
+        let output = make_and_run_simple_pipeline::<_, f32, f32>(
+            stage,
+            &[input_r, input_g, input_b],
+            (1, 1),
+            256,
+        )?
+        .1;
+
+        assert_all_almost_eq!(output[0].as_rect().row(0), &[0.203], 1e-3);
+        assert_all_almost_eq!(output[1].as_rect().row(0), &[0.203], 1e-3);
+        assert_all_almost_eq!(output[2].as_rect().row(0), &[0.203], 1e-3);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Other than adding a fastmath `hlg_to_scene` impl, changing the functions for the tf conversions, and reversing the test values for the test cases, this mostly just copies `FromLinearStage`.

I had to add some precision to the values for the `sdr_white_pq` test to get the tests to pass as the rounded values pick up just barely too much error when going in the reverse direction.

Given how much is similar between this and FromLinear, later on down the road we could fairly trivially collapse them into a single implementation and define the stages as type aliases off that base implementation.