### PR TITLE
Pass the render pipeline callback to the vardct group decoder.

### DIFF
--- a/jxl/src/enc/mod.rs
+++ b/jxl/src/enc/mod.rs
@@ -65,7 +65,7 @@ impl<T: ImageDataType + ToU8ForWriting> ImageRect<'_, T> {
     }
 }
 
-impl ImageRect<'_, i32> {
+impl ImageRect<'_, f32> {
     pub fn to_pgm_as_8bit(&self) -> Vec<u8> {
         use std::io::Write;
         let mut ret = vec![];
@@ -73,13 +73,13 @@ impl ImageRect<'_, i32> {
         ret.extend(
             (0..self.size().1)
                 .flat_map(|x| self.row(x).iter())
-                .map(|x| (*x).clamp(0, 255) as u8),
+                .map(|x| (*x).clamp(0.0, 255.0) as u8),
         );
         ret
     }
 }
 
-pub fn to_ppm_as_8bit(img: &[ImageRect<'_, i32>; 3]) -> Vec<u8> {
+pub fn to_ppm_as_8bit(img: &[ImageRect<'_, f32>; 3]) -> Vec<u8> {
     use std::io::Write;
     let mut ret = vec![];
     assert_eq!(img[0].size(), img[1].size());
@@ -96,7 +96,7 @@ pub fn to_ppm_as_8bit(img: &[ImageRect<'_, i32>; 3]) -> Vec<u8> {
             .flat_map(|y| {
                 (0..img[0].size().0).flat_map(move |x| [0, 1, 2].map(move |c| img[c].row(y)[x]))
             })
-            .map(|x| x.clamp(0, 255) as u8),
+            .map(|x| x.clamp(0.0, 255.0) as u8),
     );
     ret
 }

--- a/jxl/src/enc/numpy.rs
+++ b/jxl/src/enc/numpy.rs
@@ -41,7 +41,7 @@ fn numpy_header(xsize: usize, ysize: usize, num_channels: usize, num_frames: usi
     header
 }
 
-fn numpy_bytes(image_data: ImageData<i32>, num_channels: usize) -> Vec<u8> {
+fn numpy_bytes(image_data: ImageData<f32>, num_channels: usize) -> Vec<u8> {
     let mut ret = vec![];
     let size = image_data.size;
     let (width, height) = size;
@@ -52,7 +52,7 @@ fn numpy_bytes(image_data: ImageData<i32>, num_channels: usize) -> Vec<u8> {
         for channel in &frame.channels {
             assert_eq!(channel.size(), size);
         }
-        let channel_rects: &Vec<ImageRect<'_, i32>> =
+        let channel_rects: &Vec<ImageRect<'_, f32>> =
             &frame.channels.iter().map(|im| im.as_rect()).collect();
 
         ret.extend(
@@ -62,7 +62,7 @@ fn numpy_bytes(image_data: ImageData<i32>, num_channels: usize) -> Vec<u8> {
                         (0..num_channels).map(move |c| channel_rects[c].row(y)[x])
                     })
                 })
-                .flat_map(|x| ((x.clamp(0, 255) as f32) / 255.0f32).to_le_bytes()),
+                .flat_map(|x| (x.clamp(0.0, 255.0) / 255.0f32).to_le_bytes()),
         );
     }
     ret
@@ -72,7 +72,7 @@ fn numpy_bytes(image_data: ImageData<i32>, num_channels: usize) -> Vec<u8> {
 /// The data will be represented as little-endian 32-bit floats ('<f4').
 /// The shape of the NumPy array will be (num_frames, height, width, num_channels).
 ///
-pub fn to_numpy(image_data: ImageData<i32>) -> Result<Vec<u8>> {
+pub fn to_numpy(image_data: ImageData<f32>) -> Result<Vec<u8>> {
     if image_data.frames.is_empty()
         || image_data.frames[0].channels.is_empty()
         || image_data.size.0 == 0

--- a/jxl/src/enc/numpy.rs
+++ b/jxl/src/enc/numpy.rs
@@ -20,8 +20,8 @@ fn numpy_header(xsize: usize, ysize: usize, num_channels: usize, num_frames: usi
     //
     // The dtype '<f4' signifies little-endian 32-bit float.
     let header_dict_str = format!(
-        "{{'descr': '<f4', 'fortran_order': False, 'shape': ({}, {}, {}, {}), }}\n",
-        num_frames, ysize, xsize, num_channels
+        "{{'descr': '<f4', 'fortran_order': False, 'shape': \
+	 ({num_frames}, {ysize}, {xsize}, {num_channels}), }}\n"
     );
     let header_dict_len = header_dict_str.len();
     assert!(

--- a/jxl/src/features/patches.rs
+++ b/jxl/src/features/patches.rs
@@ -500,7 +500,7 @@ impl PatchesDictionary {
             // Safe access using get() and unwrap_or().  No need for the assert.
             let node = self.patch_tree.get(tree_idx as usize).unwrap_or_else(|| {
                 // TODO(firsching): Handle panic differently?
-                panic!("Invalid tree_idx: {}", tree_idx);
+                panic!("Invalid tree_idx: {tree_idx}");
             });
 
             if y <= node.y_center {

--- a/jxl/src/frame/modular.rs
+++ b/jxl/src/frame/modular.rs
@@ -18,7 +18,7 @@ use crate::{
         bit_depth::BitDepth, extra_channels::ExtraChannelInfo, frame_header::FrameHeader,
         modular::GroupHeader, ImageMetadata, JxlHeader,
     },
-    image::{Image, Rect},
+    image::{Image, ImageRect, ImageRectMut, Rect},
     util::{tracing_wrappers::*, CeilLog2},
 };
 
@@ -700,6 +700,25 @@ pub fn decode_hf_metadata(
                 }
             }
             num += 1;
+        }
+    }
+    Ok(())
+}
+
+pub fn fill_in_modular_rect(dst: &mut ImageRectMut<f32>, src: &ImageRect<i32>) -> Result<()> {
+    if src.size().0 != dst.size().0 || src.size().1 != dst.size().1 {
+        return Err(Error::CopyOfDifferentSize(
+            src.size().0,
+            src.size().1,
+            dst.size().0,
+            dst.size().1,
+        ));
+    }
+    let size = dst.size();
+    for i in 0..size.1 {
+        trace!("copying row {i} of {}", size.1);
+        for j in 0..size.0 {
+            dst.row(i)[j] = src.row(i)[j] as f32;
         }
     }
     Ok(())

--- a/jxl/src/frame/modular/transforms/apply.rs
+++ b/jxl/src/frame/modular/transforms/apply.rs
@@ -191,8 +191,8 @@ fn meta_apply_single_transform(
                 c.0 = add_transform_buffer(
                     c.1,
                     format!(
-                        "RCT (op {:?} perm {:?}) starting at channel {}, input {}",
-                        op, perm, begin_channel, i
+                        "RCT (op {op:?} perm {perm:?}) starting at channel {begin_channel}, \
+			 input {i}"
                     ),
                 );
                 buf_in[i] = c.0;
@@ -298,15 +298,15 @@ fn meta_apply_single_transform(
             let pchan = add_transform_buffer(
                 pchan_info,
                 format!(
-                    "Palette for palette transform starting at channel {} with {} channels",
-                    begin_channel, num_channels
+                    "Palette for palette transform starting at channel {begin_channel} with \
+		     {num_channels} channels"
                 ),
             );
             let inchan = add_transform_buffer(
                 channels[begin_channel].1,
                 format!(
-                    "Pixel data for palette transform starting at channel {} with {} channels",
-                    begin_channel, num_channels
+                    "Pixel data for palette transform starting at channel {begin_channel} with \
+		     {num_channels} channels",
                 ),
             );
             transform_steps.push(TransformStep::Palette {

--- a/jxl/src/render/test.rs
+++ b/jxl/src/render/test.rs
@@ -127,7 +127,7 @@ pub(super) fn test_stage_consistency<
             image_size,
             chunk_size,
         )
-        .unwrap_or_else(|_| panic!("error running pipeline with chunk size {}", chunk_size));
+        .unwrap_or_else(|_| panic!("error running pipeline with chunk size {chunk_size}"));
         stage = Some(s);
 
         for (o, bo) in output.iter().zip(base_output.iter()) {

--- a/jxl/src/util/fast_math.rs
+++ b/jxl/src/util/fast_math.rs
@@ -182,12 +182,8 @@ mod test {
             let rel_error = abs_error / expected;
             assert!(
                 rel_error < 3e-5,
-                "base: {}, exp: {}, rel_error: {}, expected: {}, actual: {}",
-                base,
-                exp,
-                rel_error,
-                expected,
-                actual
+                "base: {base}, exp: {exp}, rel_error: {rel_error}, expected: {expected}, \
+		 actual: {actual}",
             );
             Ok(())
         });

--- a/jxl/src/util/test.rs
+++ b/jxl/src/util/test.rs
@@ -150,12 +150,7 @@ pub fn read_pfm(b: &[u8]) -> Result<Vec<Image<f32>>, Error> {
     let channels = match line.trim() {
         "Pf" => 1,
         "PF" => 3,
-        &_ => {
-            return Err(Error::InvalidPFM(format!(
-                "invalid PFM type header {}",
-                line
-            )))
-        }
+        &_ => return Err(Error::InvalidPFM(format!("invalid PFM type header {line}"))),
     };
     line.clear();
     bf.read_line(&mut line)?;
@@ -164,16 +159,14 @@ pub fn read_pfm(b: &[u8]) -> Result<Vec<Image<f32>>, Error> {
         xres_str.trim().parse()?
     } else {
         return Err(Error::InvalidPFM(format!(
-            "invalid PFM resolution header {}",
-            line
+            "invalid PFM resolution header {line}",
         )));
     };
     let yres = if let Some(yres_str) = dims.next() {
         yres_str.trim().parse()?
     } else {
         return Err(Error::InvalidPFM(format!(
-            "invalid PFM resolution header {}",
-            line
+            "invalid PFM resolution header {line}",
         )));
     };
     line.clear();

--- a/jxl_cli/src/bin/jxlinspect.rs
+++ b/jxl_cli/src/bin/jxlinspect.rs
@@ -132,7 +132,7 @@ fn parse_jxl_codestream(data: &[u8], verbose: bool) -> Result<(), jxl::error::Er
     }
     if verbose {
         // Verbose output: Use Debug trait to print the FileHeaders
-        println!("{:#?}", file_header);
+        println!("{file_header:#?}");
     }
     // TODO(firsching): handle frames which are blended together, also within animations.
     if let Some(ref animation) = file_header.image_metadata.animation {
@@ -211,7 +211,7 @@ fn main() {
     let verbose = matches.get_flag("verbose");
 
     if verbose {
-        println!("Processing file: {}", filename);
+        println!("Processing file: {filename}");
     }
 
     let mut file = match fs::File::open(filename) {

--- a/jxl_cli/src/main.rs
+++ b/jxl_cli/src/main.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 
 use jxl::headers::JxlHeader;
 
-fn decode_jxl_codestream(data: &[u8]) -> Result<ImageData<i32>, Error> {
+fn decode_jxl_codestream(data: &[u8]) -> Result<ImageData<f32>, Error> {
     let mut br = BitReader::new(data);
     let file_header = FileHeader::read(&mut br)?;
     println!(
@@ -29,7 +29,7 @@ fn decode_jxl_codestream(data: &[u8]) -> Result<ImageData<i32>, Error> {
         let r = read_icc(&mut br)?;
         println!("found {}-byte ICC", r.len());
     };
-    let mut image_data: ImageData<i32> = ImageData {
+    let mut image_data: ImageData<f32> = ImageData {
         size: (
             file_header.size.xsize() as usize,
             file_header.size.ysize() as usize,
@@ -83,7 +83,7 @@ fn decode_jxl_codestream(data: &[u8]) -> Result<ImageData<i32>, Error> {
     Ok(image_data)
 }
 
-fn save_image(image_data: ImageData<i32>, output_filename: PathBuf) -> Result<(), Error> {
+fn save_image(image_data: ImageData<f32>, output_filename: PathBuf) -> Result<(), Error> {
     let fn_str: String = String::from(output_filename.to_string_lossy());
     let mut output_bytes: Vec<u8> = vec![];
     if fn_str.ends_with(".ppm") {

--- a/jxl_macros/src/lib.rs
+++ b/jxl_macros/src/lib.rs
@@ -210,6 +210,7 @@ struct U32 {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum Coder {
     WithoutConfig,
     U32(U32),


### PR DESCRIPTION
Since in vardct mode we pad the group size to 8x8 blocks, this requires a modification to ImageRect::copy_from to allow the source image to be bigger.