### PR TITLE
Reset the bit position of the per-section bit readers to zero.

### DIFF
--- a/jxl/src/bit_reader.rs
+++ b/jxl/src/bit_reader.rs
@@ -192,6 +192,7 @@ impl<'a> BitReader<'a> {
             ret.bit_buf &= (1u64 << (n * 8)) - 1;
             ret.data = &[];
         }
+        ret.total_bits_read = 0;
         debug!(?n, ret=?ret);
         Ok(ret)
     }


### PR DESCRIPTION
This does not affect the actual decoding, but this way we get comparable bit positions to libjxl in the logs.