### PR TITLE
Allow images with zero width to make delta palette decoding work.

### DIFF
--- a/jxl/src/frame/modular.rs
+++ b/jxl/src/frame/modular.rs
@@ -347,6 +347,25 @@ impl FullModularImage {
         }
 
         trace!(?section_buffer_indices);
+        #[cfg(feature = "tracing")]
+        for (section, indices) in section_buffer_indices.iter().enumerate() {
+            let section_name = match section {
+                0 => "LF global".to_string(),
+                1 => "LF groups".to_string(),
+                _ => format!("HF groups, pass {}", section - 2),
+            };
+            trace!("Modular channels in {section_name}");
+            for i in indices {
+                let bi = &buffer_info[*i];
+                let ci = bi.info;
+                trace!(
+                    "Channel size: {:?} shift: {:?} id: {}",
+                    ci.size,
+                    ci.shift,
+                    bi.channel_id
+                );
+            }
+        }
 
         let transform_steps = make_grids(
             frame_header,

--- a/jxl/src/image.rs
+++ b/jxl/src/image.rs
@@ -186,7 +186,8 @@ impl<T: ImageDataType> Image<T> {
         let total_size = xsize
             .checked_mul(ysize)
             .ok_or(Error::ImageSizeTooLarge(xsize, ysize))?;
-        if xsize == 0 || ysize == 0 {
+        // We need images with xsize == 0 for delta palette decoding
+        if ysize == 0 {
             return Err(Error::InvalidImageSize(xsize, ysize));
         }
         debug!("trying to allocate image");


### PR DESCRIPTION
This is needed since delta palette can have implicit deltas even when num_deltas is 0.