### PR TITLE
Define separate output and coded channel ids in ModularBufferInfo.

### DIFF
--- a/jxl/src/frame/modular.rs
+++ b/jxl/src/frame/modular.rs
@@ -187,8 +187,10 @@ impl ModularBuffer {
 #[derive(Debug)]
 struct ModularBufferInfo {
     info: ChannelInfo,
-    // Only accurate for output and coded channels.
-    channel_id: usize,
+    // Only accurate for coded channels.
+    coded_channel_id: usize,
+    // Only accurate for output channels.
+    output_channel_id: usize,
     is_output: bool,
     is_coded: bool,
     #[allow(dead_code)]
@@ -287,7 +289,7 @@ impl FullModularImage {
             .enumerate()
             .filter_map(|(i, b)| {
                 if b.is_coded {
-                    Some((b.channel_id, i))
+                    Some((b.coded_channel_id, i))
                 } else {
                     None
                 }
@@ -343,7 +345,7 @@ impl FullModularImage {
 
         // Ensure that the channel list in each group is sorted by actual channel ID.
         for list in section_buffer_indices.iter_mut() {
-            list.sort_by_key(|x| buffer_info[*x].channel_id);
+            list.sort_by_key(|x| buffer_info[*x].coded_channel_id);
         }
 
         trace!(?section_buffer_indices);
@@ -359,10 +361,12 @@ impl FullModularImage {
                 let bi = &buffer_info[*i];
                 let ci = bi.info;
                 trace!(
-                    "Channel size: {:?} shift: {:?} id: {}",
+                    "Channel size: {:?} shift: {:?} coded id: {} output id: {} output: {}",
                     ci.size,
                     ci.shift,
-                    bi.channel_id
+                    bi.coded_channel_id,
+                    bi.output_channel_id,
+                    bi.is_output,
                 );
             }
         }
@@ -442,7 +446,7 @@ impl FullModularImage {
         let mut maybe_output = |bi: &mut ModularBufferInfo, grid: usize| -> Result<()> {
             if bi.is_output {
                 on_output(
-                    bi.channel_id,
+                    bi.output_channel_id,
                     grid,
                     &bi.buffer_grid[grid].data.borrow().as_ref().unwrap().data,
                 )?;

--- a/jxl/src/frame/modular/transforms/apply.rs
+++ b/jxl/src/frame/modular/transforms/apply.rs
@@ -435,7 +435,8 @@ pub fn meta_apply_transforms(
     for chan in channels.iter() {
         buffer_info.push(ModularBufferInfo {
             info: chan.1,
-            channel_id: chan.0,
+            coded_channel_id: 0,
+            output_channel_id: chan.0,
             is_output: true,
             is_coded: false,
             description: format!(
@@ -452,7 +453,8 @@ pub fn meta_apply_transforms(
     let mut add_transform_buffer = |info, description| {
         buffer_info.push(ModularBufferInfo {
             info,
-            channel_id: 0,
+            coded_channel_id: 0,
+            output_channel_id: 0,
             is_output: false,
             is_coded: false,
             description,
@@ -479,7 +481,7 @@ pub fn meta_apply_transforms(
     // actually coded.
     for (chid, chan) in channels.iter().enumerate() {
         buffer_info[chan.0].is_coded = true;
-        buffer_info[chan.0].channel_id = chid;
+        buffer_info[chan.0].coded_channel_id = chid;
     }
 
     debug!(?transform_steps);


### PR DESCRIPTION
This fixes a crash in the render pipeline for palettized images when we attempt to index output channels by the id of the coded channel.