### PR TITLE
Fixes for decoding lossless_pfm conformance test image.

### DIFF
--- a/jxl/src/entropy_coding/hybrid_uint.rs
+++ b/jxl/src/entropy_coding/hybrid_uint.rs
@@ -55,7 +55,8 @@ impl HybridUint {
         let bits_in_token = self.lsb_in_token + self.msb_in_token;
         let nbits =
             self.split_exponent - bits_in_token + ((symbol - self.split_token) >> bits_in_token);
-        if nbits > 29 {
+        // To match the behaviour of libjxl, we limit nbits to 31.
+        if nbits > 31 {
             return Err(Error::IntegerTooLarge(nbits));
         }
         let low = symbol & ((1 << self.lsb_in_token) - 1);

--- a/jxl/src/frame/modular.rs
+++ b/jxl/src/frame/modular.rs
@@ -228,7 +228,7 @@ pub struct FullModularImage {
 }
 
 impl FullModularImage {
-    #[instrument(level = "debug", skip_all, ret)]
+    #[instrument(level = "debug", skip_all)]
     pub fn read(
         frame_header: &FrameHeader,
         image_metadata: &ImageMetadata,

--- a/jxl/src/frame/modular/transforms/palette.rs
+++ b/jxl/src/frame/modular/transforms/palette.rs
@@ -221,7 +221,7 @@ pub fn do_palette_step_general(
                         palette_entry
                     };
                     out.data.as_rect_mut().row(y)[x] = val;
-                    wp_state.update_errors(val as i64, (x, y), w);
+                    wp_state.update_errors(val, (x, y), w);
                 }
             }
         }

--- a/jxl/src/frame/modular/tree.rs
+++ b/jxl/src/frame/modular/tree.rs
@@ -61,7 +61,7 @@ const MULTIPLIER_BITS_CONTEXT: usize = 5;
 const NUM_TREE_CONTEXTS: usize = 6;
 
 impl Tree {
-    #[instrument(level = "debug", skip(br), ret, err)]
+    #[instrument(level = "debug", skip(br), err)]
     pub fn read(br: &mut BitReader, size_limit: usize) -> Result<Tree> {
         assert!(size_limit <= u32::MAX as usize);
         trace!(pos = br.total_bits_read());
@@ -242,15 +242,15 @@ impl Tree {
         property_buffer[7] = left;
 
         // Local gradient
-        property_buffer[8] = left - property_buffer[9];
-        property_buffer[9] = left + top - topleft;
+        property_buffer[8] = left.wrapping_sub(property_buffer[9]);
+        property_buffer[9] = left.wrapping_add(top).wrapping_sub(topleft);
 
         // FFV1 context properties
-        property_buffer[10] = left - topleft;
-        property_buffer[11] = topleft - top;
-        property_buffer[12] = top - topright;
-        property_buffer[13] = top - toptop;
-        property_buffer[14] = left - leftleft;
+        property_buffer[10] = left.wrapping_sub(topleft);
+        property_buffer[11] = topleft.wrapping_sub(top);
+        property_buffer[12] = top.wrapping_sub(topright);
+        property_buffer[13] = top.wrapping_sub(toptop);
+        property_buffer[14] = left.wrapping_sub(leftleft);
 
         // Weighted predictor property.
         let (wp_pred, property) =


### PR DESCRIPTION
Uses wrapping_add and wrapping_sub for i32 operations.

Disable error for reading more than 29 bits for a symbol.