### PR TITLE
Reduce allocas

### DIFF
--- a/jxl/src/entropy_coding/context_map.rs
+++ b/jxl/src/entropy_coding/context_map.rs
@@ -18,8 +18,7 @@ fn move_to_front(v: &mut [u8], index: u8) {
 }
 
 fn inverse_move_to_front(v: &mut [u8]) {
-    use array_init::array_init;
-    let mut mtf: [u8; 256] = array_init(|x| x as u8);
+    let mut mtf: [u8; 256] = std::array::from_fn(|x| x as u8);
     for val in v.iter_mut() {
         let index = *val;
         *val = mtf[index as usize];


### PR DESCRIPTION
`DeriveInput` and `Expr` have more than 128 bytes but aren't fully used in the associates functions, as such, they are now passed as references rather than values. These modifications don't impact performance as they are restricted in the macro crate but they are nice to have regardless.