### PR TITLE
Avoid usage of an opaque pointer

### DIFF
--- a/jxl/src/frame.rs
+++ b/jxl/src/frame.rs
@@ -877,11 +877,10 @@ mod test {
     #[allow(clippy::type_complexity)]
     fn read_frames(
         image: &[u8],
-        callback: &mut dyn FnMut(&Frame) -> Result<(), Error>,
+        callback: impl FnMut(&Frame) -> Result<(), Error>,
     ) -> Result<(), Error> {
         let codestream = ContainerParser::collect_codestream(image).unwrap();
-        let mut options = DecodeOptions::new();
-        options.frame_callback = Some(callback);
+        let options = DecodeOptions::new().set_frame_callback(callback);
         decode_jxl_codestream(options, &codestream)?;
         Ok(())
     }

--- a/jxl_cli/src/main.rs
+++ b/jxl_cli/src/main.rs
@@ -124,7 +124,7 @@ fn main() -> Result<(), Error> {
     }
 
     let mut options = DecodeOptions::new();
-    options.xyb_output_linear = String::from(opt.output.to_string_lossy()).ends_with(".npy");
+    options = options.set_xyb_output_linear(opt.output.ends_with(".npy"));
     let (image_data, icc_bytes) = jxl::decode::decode_jxl_codestream(options, &codestream)?;
 
     let icc_result = save_icc(icc_bytes, opt.icc_out);


### PR DESCRIPTION
Opaque pointers usually hide from the compiler the underlying structure, which generally prevents code optimizations.