### PR TITLE
Unroll Epf0 SAD accumulation loop.

### DIFF
--- a/jxl/src/render/stages/epf.rs
+++ b/jxl/src/render/stages/epf.rs
@@ -87,51 +87,118 @@ impl RenderPipelineStage for Epf0Stage {
 
             // Compute SADs
             let mut sads = [0.0; 12];
-            const SADS_OFF: [[isize; 2]; 12] = [
-                [-2, 0],
-                [-1, -1],
-                [-1, 0],
-                [-1, 1],
-                [0, -2],
-                [0, -1],
-                [0, 1],
-                [0, 2],
-                [1, -1],
-                [1, 0],
-                [1, 1],
-                [2, 0],
-            ];
-            for ((input_c, _), scale) in row.iter().zip(self.channel_scale) {
-                const PLUS_OFF: [[isize; 2]; 5] = [[0, 0], [-1, 0], [0, -1], [1, 0], [0, 1]];
-                for (sads_i, sad_off) in sads.iter_mut().zip(SADS_OFF) {
-                    let sad = PLUS_OFF.iter().fold(0.0, |acc, off| {
-                        let r_pos = (3 + off[0], 3 + off[1] + x as isize);
-                        let c_pos = (r_pos.0 + sad_off[0], r_pos.1 + sad_off[1]);
-                        let r11 = input_c[r_pos.0 as usize][r_pos.1 as usize];
-                        let c11 = input_c[c_pos.0 as usize][c_pos.1 as usize];
-                        acc + (r11 - c11).abs()
-                    });
-                    *sads_i += sad * scale;
-                }
+            for ((input_c, _), scale) in row.iter_mut().zip(self.channel_scale) {
+                let p30 = input_c[0][3 + x];
+                let p21 = input_c[1][2 + x];
+                let p31 = input_c[1][3 + x];
+                let p41 = input_c[1][4 + x];
+                let p12 = input_c[2][1 + x];
+                let p22 = input_c[2][2 + x];
+                let p32 = input_c[2][3 + x];
+                let p42 = input_c[2][4 + x];
+                let p52 = input_c[2][5 + x];
+                let p03 = input_c[3][x];
+                let p13 = input_c[3][1 + x];
+                let p23 = input_c[3][2 + x];
+                let p33 = input_c[3][3 + x];
+                let p43 = input_c[3][4 + x];
+                let p53 = input_c[3][5 + x];
+                let p63 = input_c[3][6 + x];
+                let p14 = input_c[4][1 + x];
+                let p24 = input_c[4][2 + x];
+                let p34 = input_c[4][3 + x];
+                let p44 = input_c[4][4 + x];
+                let p54 = input_c[4][5 + x];
+                let p25 = input_c[5][2 + x];
+                let p35 = input_c[5][3 + x];
+                let p45 = input_c[5][4 + x];
+                let p36 = input_c[6][3 + x];
+                let d32_30 = (p32 - p30).abs();
+                let d32_21 = (p32 - p21).abs();
+                let d32_31 = (p32 - p31).abs();
+                let d32_41 = (p32 - p41).abs();
+                let d32_12 = (p32 - p12).abs();
+                let d32_22 = (p32 - p22).abs();
+                let d32_42 = (p32 - p42).abs();
+                let d32_52 = (p32 - p52).abs();
+                let d32_23 = (p32 - p23).abs();
+                let d32_34 = (p32 - p34).abs();
+                let d32_43 = (p32 - p43).abs();
+                let d32_33 = (p32 - p33).abs();
+                let d23_21 = (p23 - p21).abs();
+                let d23_12 = (p23 - p12).abs();
+                let d23_22 = (p23 - p22).abs();
+                let d23_03 = (p23 - p03).abs();
+                let d23_13 = (p23 - p13).abs();
+                let d23_33 = (p23 - p33).abs();
+                let d23_43 = (p23 - p43).abs();
+                let d23_14 = (p23 - p14).abs();
+                let d23_24 = (p23 - p24).abs();
+                let d23_34 = (p23 - p34).abs();
+                let d23_25 = (p23 - p25).abs();
+                let d33_31 = (p33 - p31).abs();
+                let d33_22 = (p33 - p22).abs();
+                let d33_42 = (p33 - p42).abs();
+                let d33_13 = (p33 - p13).abs();
+                let d33_43 = (p33 - p43).abs();
+                let d33_53 = (p33 - p53).abs();
+                let d33_24 = (p33 - p24).abs();
+                let d33_34 = (p33 - p34).abs();
+                let d33_44 = (p33 - p44).abs();
+                let d33_35 = (p33 - p35).abs();
+                let d43_41 = (p43 - p41).abs();
+                let d43_42 = (p43 - p42).abs();
+                let d43_52 = (p43 - p52).abs();
+                let d43_53 = (p43 - p53).abs();
+                let d43_63 = (p43 - p63).abs();
+                let d43_34 = (p43 - p34).abs();
+                let d43_44 = (p43 - p44).abs();
+                let d43_54 = (p43 - p54).abs();
+                let d43_45 = (p43 - p45).abs();
+                let d34_14 = (p34 - p14).abs();
+                let d34_24 = (p34 - p24).abs();
+                let d34_44 = (p34 - p44).abs();
+                let d34_54 = (p34 - p54).abs();
+                let d34_25 = (p34 - p25).abs();
+                let d34_35 = (p34 - p35).abs();
+                let d34_45 = (p34 - p45).abs();
+                let d34_36 = (p34 - p36).abs();
+                sads[0] += (d32_30 + d23_21 + d33_31 + d43_41 + d32_34) * scale;
+                sads[1] += (d32_21 + d23_12 + d33_22 + d32_43 + d23_34) * scale;
+                sads[2] += (d32_31 + d23_22 + d32_33 + d43_42 + d33_34) * scale;
+                sads[3] += (d32_41 + d32_23 + d33_42 + d43_52 + d43_34) * scale;
+                sads[4] += (d32_12 + d23_03 + d33_13 + d23_43 + d34_14) * scale;
+                sads[5] += (d32_22 + d23_13 + d23_33 + d33_43 + d34_24) * scale;
+                sads[6] += (d32_42 + d23_33 + d33_43 + d43_53 + d34_44) * scale;
+                sads[7] += (d32_52 + d23_43 + d33_53 + d43_63 + d34_54) * scale;
+                sads[8] += (d32_23 + d23_14 + d33_24 + d43_34 + d34_25) * scale;
+                sads[9] += (d32_33 + d23_24 + d33_34 + d43_44 + d34_35) * scale;
+                sads[10] += (d32_43 + d23_34 + d33_44 + d43_54 + d34_45) * scale;
+                sads[11] += (d32_34 + d23_25 + d33_35 + d43_45 + d34_36) * scale;
             }
-
             // Compute output based on SADs
-            let vsm = sad_mul[ix];
-            let inv_sigma = row_sigma[bx] * vsm;
+            let inv_sigma = row_sigma[bx] * sad_mul[ix];
+            let mut w = 1.0;
+            for sad in sads.iter_mut() {
+                *sad = (*sad * inv_sigma + 1.0).max(0.0);
+                w += *sad;
+            }
+            let inv_w = 1.0 / w;
             for (input_c, output_c) in row.iter_mut() {
-                let mut cc = input_c[3][3 + x];
-                let mut weight = 1.0;
-                for (sad, sad_off) in sads.iter().zip(SADS_OFF) {
-                    let c_pos = (3 + sad_off[0], 3 + sad_off[1] + x as isize);
-                    let c = input_c[c_pos.0 as usize][c_pos.1 as usize];
-                    let w = (sad * inv_sigma + 1.0).max(0.0);
-
-                    weight += w;
-                    cc += c * w;
-                }
-
-                let inv_w = 1.0 / weight;
-                output_c[0][x] = cc * inv_w;
+                output_c[0][x] = (input_c[3][3 + x]
+                    + input_c[1][3 + x] * sads[0]
+                    + input_c[2][2 + x] * sads[1]
+                    + input_c[2][3 + x] * sads[2]
+                    + input_c[2][4 + x] * sads[3]
+                    + input_c[3][1 + x] * sads[4]
+                    + input_c[3][2 + x] * sads[5]
+                    + input_c[3][4 + x] * sads[6]
+                    + input_c[3][5 + x] * sads[7]
+                    + input_c[4][2 + x] * sads[8]
+                    + input_c[4][3 + x] * sads[9]
+                    + input_c[4][4 + x] * sads[10]
+                    + input_c[5][3 + x] * sads[11])
+                    * inv_w;
             }
         }
     }


### PR DESCRIPTION
Decreased progressive_5 decoding time from about 6.5s to about 5.1s.