### PR TITLE
Prepare for multithreaded pipeline runner

### DIFF
--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -85,11 +85,12 @@ pub trait RenderPipelineStage: Any + std::fmt::Display {
     /// Process one chunk of row. The semantics of this function are detailed in the
     /// documentation of the various types of stages.
     fn process_row_chunk(
-        &mut self,
+        &self,
         position: (usize, usize),
         xsize: usize,
         // one for each channel
         row: &mut [<Self::Type as RenderPipelineStageInfo>::RowType<'_>],
+        state: Option<&mut dyn Any>,
     );
 
     /// Returns the new size of the image after this stage. Should be implemented by
@@ -102,6 +103,14 @@ pub trait RenderPipelineStage: Any + std::fmt::Display {
     /// Should be implemented by `RenderPipelineExtendStage` stages.
     fn original_data_origin(&self) -> (isize, isize) {
         (0, 0)
+    }
+
+    /// Initializes thread local state for the stage. Returns `Ok(None)` if no state is needed.
+    ///
+    /// This method returns `Box<dyn Any>` for dyn compatibility. `process_row_chunk` should
+    /// downcast the state to the desired type.
+    fn init_local_state(&self) -> Result<Option<Box<dyn Any>>> {
+        Ok(None)
     }
 }
 

--- a/jxl/src/render/stages/blending.rs
+++ b/jxl/src/render/stages/blending.rs
@@ -77,10 +77,11 @@ impl RenderPipelineStage for BlendingStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let num_ec = self.extra_channels.len();
         let fg_y0 = self.frame_origin.1 + position.1 as isize;

--- a/jxl/src/render/stages/chroma_upsample.rs
+++ b/jxl/src/render/stages/chroma_upsample.rs
@@ -33,10 +33,11 @@ impl RenderPipelineStage for HorizontalChromaUpsample {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (input, output) = &mut row[0];
         for i in 0..xsize {
@@ -75,10 +76,11 @@ impl RenderPipelineStage for VerticalChromaUpsample {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (input, output) = &mut row[0];
         for i in 0..xsize {

--- a/jxl/src/render/stages/convert.rs
+++ b/jxl/src/render/stages/convert.rs
@@ -33,10 +33,11 @@ impl RenderPipelineStage for ConvertU8F32Stage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[u8]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (input, output) = &mut row[0];
         for i in 0..xsize {
@@ -79,10 +80,11 @@ impl RenderPipelineStage for ConvertModularXYBToF32Stage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[i32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let [scale_x, scale_y, scale_b] = self.scale;
         let [
@@ -136,10 +138,11 @@ impl RenderPipelineStage for ConvertModularToF32Stage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[i32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (input, output) = &mut row[0];
         for i in 0..xsize {

--- a/jxl/src/render/stages/epf.rs
+++ b/jxl/src/render/stages/epf.rs
@@ -56,10 +56,11 @@ impl RenderPipelineStage for Epf0Stage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         (xpos, ypos): (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         assert!(row.len() == 3, "Expected 3 channels, got {}", row.len());
 
@@ -249,10 +250,11 @@ impl RenderPipelineStage for Epf1Stage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         (xpos, ypos): (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         assert!(row.len() == 3, "Expected 3 channels, got {}", row.len());
 
@@ -400,10 +402,11 @@ impl RenderPipelineStage for Epf2Stage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         (xpos, ypos): (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         assert!(row.len() == 3, "Expected 3 channels, got {}", row.len());
 

--- a/jxl/src/render/stages/extend.rs
+++ b/jxl/src/render/stages/extend.rs
@@ -64,10 +64,11 @@ impl RenderPipelineStage for ExtendToImageDimensionsStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let num_ec = self.extra_channels.len();
         let num_c = 3 + num_ec;

--- a/jxl/src/render/stages/from_linear.rs
+++ b/jxl/src/render/stages/from_linear.rs
@@ -60,10 +60,11 @@ impl RenderPipelineStage for FromLinearStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let [row_r, row_g, row_b] = row else {
             panic!(

--- a/jxl/src/render/stages/gaborish.rs
+++ b/jxl/src/render/stages/gaborish.rs
@@ -40,10 +40,11 @@ impl RenderPipelineStage for GaborishStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (rows_in, ref mut rows_out) = row[0];
         let row_out = &mut rows_out[0][..xsize];

--- a/jxl/src/render/stages/nearest_neighbor.rs
+++ b/jxl/src/render/stages/nearest_neighbor.rs
@@ -33,10 +33,11 @@ impl RenderPipelineStage for NearestNeighbourUpsample {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[u8]], &mut [&mut [u8]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (input, output) = &mut row[0];
         for i in 0..xsize {

--- a/jxl/src/render/stages/noise.rs
+++ b/jxl/src/render/stages/noise.rs
@@ -34,10 +34,11 @@ impl RenderPipelineStage for ConvolveNoiseStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (input, output) = &mut row[0];
         for x in 0..xsize {
@@ -100,10 +101,11 @@ impl RenderPipelineStage for AddNoiseStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let norm_const = 0.22;
         let ytox = self.color_correlation.y_to_x_lf();

--- a/jxl/src/render/stages/splines.rs
+++ b/jxl/src/render/stages/splines.rs
@@ -44,10 +44,11 @@ impl RenderPipelineStage for SplinesStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         self.splines.draw_segments(row, position, xsize);
     }

--- a/jxl/src/render/stages/spot.rs
+++ b/jxl/src/render/stages/spot.rs
@@ -38,10 +38,11 @@ impl RenderPipelineStage for SpotColorStage {
 
     // `row` should only contain color channels and the spot channel.
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let [row_r, row_g, row_b, row_s] = row else {
             panic!(

--- a/jxl/src/render/stages/to_linear.rs
+++ b/jxl/src/render/stages/to_linear.rs
@@ -63,10 +63,11 @@ impl RenderPipelineStage for ToLinearStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let [row_r, row_g, row_b] = row else {
             panic!(

--- a/jxl/src/render/stages/upsample.rs
+++ b/jxl/src/render/stages/upsample.rs
@@ -64,10 +64,11 @@ impl<const N: usize, const SHIFT: u8> RenderPipelineStage for Upsample<N, SHIFT>
     /// Processes a chunk of a row, applying NxN upsampling using a 5x5 kernel.
     /// Each input value expands into a NxN region in the output, based on neighboring inputs.
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [(&[&[f32]], &mut [&mut [f32]])],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let (input, output) = &mut row[0];
 

--- a/jxl/src/render/stages/xyb.rs
+++ b/jxl/src/render/stages/xyb.rs
@@ -44,10 +44,11 @@ impl RenderPipelineStage for XybToLinearSrgbStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         let [row_x, row_y, row_b] = row else {
             panic!(

--- a/jxl/src/render/stages/ycbcr.rs
+++ b/jxl/src/render/stages/ycbcr.rs
@@ -37,10 +37,11 @@ impl RenderPipelineStage for YcbcrToRgbStage {
     }
 
     fn process_row_chunk(
-        &mut self,
+        &self,
         _position: (usize, usize),
         xsize: usize,
         row: &mut [&mut [f32]],
+        _state: Option<&mut dyn std::any::Any>,
     ) {
         // pixels are stored in `Cb Y Cr` order to mimic XYB colorspace
         let [row_cb, row_y, row_cr] = row else {


### PR DESCRIPTION
- Receive `&self` at `process_row_chunk`.
- Add ability to create and receive thread-local state to `RenderPipelineStage`. Though I'm not sure if this is the best interface...
  - Rayon has [`.try_for_each_init()`][rayon] that allows creating thread-local state.

[rayon]: https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.try_for_each_init