### PR TITLE
Fix public API issues for jxl_cli integration

### DIFF
--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -127,6 +127,8 @@ impl CodestreamParser {
             decoder_state.xyb_output_linear = decode_options.xyb_output_linear;
             decoder_state.render_spotcolors = decode_options.render_spot_colors;
             self.decoder_state = Some(decoder_state);
+            // Reset bit offset to 0 since we've consumed everything up to a byte boundary
+            self.non_section_bit_offset = 0;
             return Ok(());
         }
 
@@ -158,8 +160,7 @@ impl CodestreamParser {
             &TocNonserialized {
                 num_entries: num_toc_entries as u32,
             },
-        )
-        .unwrap();
+        )?;
         br.jump_to_byte_boundary()?;
         let frame = Frame::from_header_and_toc(
             self.frame_header.take().unwrap(),

--- a/jxl/src/api/inner/codestream_parser/sections.rs
+++ b/jxl/src/api/inner/codestream_parser/sections.rs
@@ -71,6 +71,10 @@ impl CodestreamParser {
             frame.prepare_render_pipeline()?;
             frame.finalize_lf()?;
             frame.decode_hf_group(0, 0, &mut br)?;
+            // Clear available_sections after processing the single-group special case.
+            // Without this, the assertion at line 160 would fail because available_sections
+            // would still contain the processed section.
+            self.available_sections.clear();
         } else {
             let mut lf_global_section = None;
             let mut lf_sections = vec![];


### PR DESCRIPTION
## Summary
This PR fixes several issues in #318 that prevent jxl_cli from working with the public API.

## Fixes
- **BitReader bug**: Fixed underflow in `skip_bits()` when called on a fresh BitReader
- **Refill closure bug**: Fixed incorrect return value in codestream parser 
- **Buffer slicing bug**: Fixed `SmallBuffer::take()` to only copy requested bytes
- **RGB buffer handling**: Fixed jxl_cli to properly allocate interleaved RGB buffers (12 bytes/pixel for f32)
- **Cropped image support**: Relaxed assertions in output functions to handle images where frame size differs from rendered size

## Test additions
- Added `test_skip_bits_on_fresh_reader` to catch the BitReader edge case
- Added `test_decode_basic_jxl` to verify basic public API functionality

## Known limitations
This PR enables basic single-frame JXL images to work, but there are still issues:
- Multi-frame (animated) JXL files fail with `SectionTooShort` errors
- Some test images still fail to decode properly
- The public API needs architectural changes to properly support streaming/partial decoding of large multi-frame images

These limitations will need to be addressed in future work.