### PR TITLE
Cleaned up jxl_cli

### DIFF
--- a/jxl_cli/src/main.rs
+++ b/jxl_cli/src/main.rs
@@ -314,7 +314,6 @@ fn with_api(opt: Opt) -> Result<()> {
 
         let mut output_vecs = vec![vec![0u8; num_pixels * samples_per_pixel * 4]];
         for _ in 0..extra_channels {
-            eprintln!("added extra output vec");
             output_vecs.push(vec![0u8; num_pixels * 4]);
         }
 


### PR DESCRIPTION
Cleaned up jxl_cli somewhat, and made it make assumptions that match closer to what the API actually does.

- Look for an extra channel of type Alpha to find the alpha channel index.
- Check that the alpha channel index is actually the first channel after the colors.
- Assume 1 channel if Grayscale, otherwise 3, like the API currently does.