### PR TITLE
Update CI.

### DIFF
--- a/.github/workflows/post_merge.yml
+++ b/.github/workflows/post_merge.yml
@@ -25,8 +25,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install latest rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.8.0
 
       - name: Run arbtest with extended budget
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,7 +52,10 @@ jobs:
           components: clippy, rustfmt
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.8.0
+        with:
+          prefix-key: ${{ matrix.os }}-${{ matrix.check }}-${{ matrix.features }}
+
 
       # format
       - name: Cargo fmt (check)


### PR DESCRIPTION
- Bump rust-cache to v2.8.0
- Ensure to install the same version of Rust in the PR and the post-merge workflows.