### PR TITLE
Introduced color-eyre into the CLI tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +103,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +197,33 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -283,6 +334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +401,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +421,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -396,6 +469,7 @@ name = "jxl_cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "color-eyre",
  "exr",
  "half",
  "jxl",
@@ -524,6 +598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +617,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "paste"
@@ -711,6 +800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +941,16 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -166,7 +166,6 @@ impl JxlDecoder<WithFrameInfo> {
 mod tests {
     use super::*;
     use crate::api::{JxlColorType::Rgb, JxlDecoderOptions, JxlOutputBuffer};
-    use crate::error::Error;
     use jxl_macros::for_each_test_file;
     use std::mem::MaybeUninit;
     use std::path::Path;

--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 use std::collections::TryReserveError;
-use std::path::PathBuf;
 
 use thiserror::Error;
 
@@ -59,8 +58,6 @@ pub enum Error {
     InvalidLinearBelow(bool, f32),
     #[error("Overflow when computing a bitstream size")]
     SizeOverflow,
-    #[error("File truncated")]
-    FileTruncated,
     #[error("Invalid ISOBMMF container")]
     InvalidBox,
     #[error("ICC is too large")]
@@ -227,14 +224,6 @@ pub enum Error {
     InvalidNumNonZeros(usize, usize),
     #[error("Invalid AC: {0} nonzeros after decoding block")]
     EndOfBlockResidualNonZeros(usize),
-    #[error("File not found {0}")]
-    FileNotFound(PathBuf),
-    #[error("Failed to read input file: {0}")]
-    InputReadFailure(std::io::Error),
-    #[error("Output format not supported: try .ppm, .pgm, .png or .npy")]
-    OutputWriteFailure,
-    #[error("Output format not supported: try .ppm, .pgm, .png or .npy")]
-    OutputFormatNotSupported,
     #[error("Unknown transfer function for ICC profile")]
     TransferFunctionUnknown,
     #[error("Attempting to write out of Bounds when writing ICC")]
@@ -255,12 +244,6 @@ pub enum Error {
     IccUnsupportedTransferFunction,
     #[error("Table size too large when writing ICC: {0}")]
     IccTableSizeExceeded(usize),
-    #[error("Invalid number of channels for PNG output ({0})")]
-    PNGInvalidNumChannels(usize),
-    #[error("Writing of {0} channels not yet implemented for EXR output")]
-    EXRInvalidNumChannels(usize),
-    #[error("EXR requires a linear colorspace (got {0})")]
-    EXRInvalidColorSpace(String),
     #[error("Invalid CMS configuration: requested ICC but no CMS is configured")]
     ICCOutputNoCMS,
     #[error("I/O error: {0}")]

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -12,6 +12,7 @@ lcms2 = "6.1.0"
 half = "2.4.1"
 png = "0.17.16"
 exr = { version = "1.73.0", optional = true }
+color-eyre = "0.6.5"
 
 [dev-dependencies]
 jxl_macros = { path = "../jxl_macros" }

--- a/jxl_cli/src/enc/png.rs
+++ b/jxl_cli/src/enc/png.rs
@@ -6,8 +6,10 @@
 use jxl::api::{
     JxlColorEncoding, JxlColorProfile, JxlPrimaries, JxlTransferFunction, JxlWhitePoint,
 };
+
+use color_eyre::eyre::{Result, WrapErr, eyre};
 use jxl::decode::ImageData;
-use jxl::error::{Error, Result};
+use jxl::error::Error;
 use jxl::headers::color_encoding::RenderingIntent;
 
 use std::borrow::Cow;
@@ -19,7 +21,10 @@ fn png_color(num_channels: usize) -> Result<png::ColorType> {
         2 => Ok(png::ColorType::GrayscaleAlpha),
         3 => Ok(png::ColorType::Rgb),
         4 => Ok(png::ColorType::Rgba),
-        _ => Err(Error::PNGInvalidNumChannels(num_channels)),
+        _ => Err(eyre!(
+            "Invalid number of channels for PNG output {:?}",
+            num_channels
+        )),
     }
 }
 
@@ -76,7 +81,7 @@ fn encode_png(
         || image_data.size.0 == 0
         || image_data.size.1 == 0
     {
-        return Err(Error::NoFrames);
+        return Err(Error::NoFrames).wrap_err("Invalid JXL image");
     }
     let size = image_data.size;
     let (width, height) = size;

--- a/jxl_macros/src/lib.rs
+++ b/jxl_macros/src/lib.rs
@@ -736,9 +736,8 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
                 let test_name = Ident::new(&test_name, fn_name.span());
                 tests.push(quote! {
                     #[test]
-                    fn #test_name() -> Result<(), Error> {
-                        #fn_name(&Path::new(#pathname)
-                        )
+                    fn #test_name() {
+                        #fn_name(&Path::new(#pathname)).unwrap()
                     }
                 });
             }


### PR DESCRIPTION
- Removed errors from jxl::errors that are only used by CLI tools.
- Made the for_each_test_file macro not require a particular type of Result for the wrapped function.