### PR TITLE
Fixed broken frame_header

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -230,6 +230,8 @@ mod tests {
                 }
             };
 
+            decoder_with_frame_info.frame_header();
+
             // Prepare output buffers
             let mut output_buffers: Vec<Vec<MaybeUninit<u8>>> = Vec::new();
 

--- a/jxl/src/api/inner.rs
+++ b/jxl/src/api/inner.rs
@@ -71,17 +71,14 @@ impl JxlDecoderInner {
     }
 
     pub fn frame_header(&self) -> Option<JxlFrameHeader> {
-        let file_header = self.codestream_parser.file_header.as_ref()?;
-        let frame = self.codestream_parser.frame.as_ref()?;
-        let header = frame.header();
-
+        let frame_header = self.codestream_parser.frame.as_ref()?.header();
         Some(JxlFrameHeader {
-            name: header.name.clone(),
-            duration: file_header
-                .image_metadata
+            name: frame_header.name.clone(),
+            duration: self
+                .codestream_parser
                 .animation
                 .as_ref()
-                .map(|anim| header.duration(anim)),
+                .map(|anim| frame_header.duration(anim)),
         })
     }
     /// Number of passes we have full data for.

--- a/jxl/src/api/inner/codestream_parser.rs
+++ b/jxl/src/api/inner/codestream_parser.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     error::{Error, Result},
     frame::{DecoderState, Frame, Section},
-    headers::{FileHeader, frame_header::FrameHeader},
+    headers::{Animation, FileHeader, frame_header::FrameHeader},
     icc::IncrementalIccReader,
 };
 
@@ -39,6 +39,7 @@ pub(super) struct CodestreamParser {
     // These fields are populated once image information is available.
     decoder_state: Option<DecoderState>,
     pub(super) basic_info: Option<JxlBasicInfo>,
+    pub(super) animation: Option<Animation>,
     pub(super) embedded_color_profile: Option<JxlColorProfile>,
     pub(super) output_color_profile: Option<JxlColorProfile>,
     pub(super) pixel_format: Option<JxlPixelFormat>,
@@ -70,6 +71,7 @@ impl CodestreamParser {
             icc_parser: None,
             decoder_state: None,
             basic_info: None,
+            animation: None,
             embedded_color_profile: None,
             output_color_profile: None,
             pixel_format: None,

--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -34,6 +34,7 @@ impl CodestreamParser {
             br.skip_bits(self.non_section_bit_offset as usize)?;
             let file_header = FileHeader::read(&mut br)?;
             let data = &file_header.image_metadata;
+            self.animation = data.animation.clone();
             self.basic_info = Some(JxlBasicInfo {
                 size: (
                     file_header.size.xsize() as usize,
@@ -157,7 +158,6 @@ impl CodestreamParser {
             self.non_section_buf.consume(br.total_bits_read() / 8);
 
             // We now have image information.
-            // TODO(veluca): generate BasicInfo.
             let mut decoder_state = DecoderState::new(self.file_header.take().unwrap());
             decoder_state.xyb_output_linear = decode_options.xyb_output_linear;
             decoder_state.render_spotcolors = decode_options.render_spot_colors;


### PR DESCRIPTION
- Added smoke test for getting frame header from decoder.
- Fixed bug caused by frame header being taken from codestream parser during parsing.