### PR TITLE
Support outputting to non-sRGB colorspaces

### DIFF
--- a/jxl/src/api/color.rs
+++ b/jxl/src/api/color.rs
@@ -29,7 +29,7 @@ const K_BRADFORD_INV: Matrix3x3<f64> = [
 ];
 
 #[allow(clippy::too_many_arguments)]
-fn primaries_to_xyz(
+pub(crate) fn primaries_to_xyz(
     rx: f32,
     ry: f32,
     gx: f32,
@@ -98,7 +98,7 @@ fn primaries_to_xyz(
     Ok(result_matrix)
 }
 
-fn adapt_to_xyz_d50(wx: f32, wy: f32) -> Result<Matrix3x3<f64>, Error> {
+pub(crate) fn adapt_to_xyz_d50(wx: f32, wy: f32) -> Result<Matrix3x3<f64>, Error> {
     if !((0.0..=1.0).contains(&wx) && (wy > 0.0 && wy <= 1.0)) {
         return Err(Error::IccInvalidWhitePoint(
             wx,
@@ -160,7 +160,7 @@ fn adapt_to_xyz_d50(wx: f32, wy: f32) -> Result<Matrix3x3<f64>, Error> {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn primaries_to_xyz_d50(
+pub(crate) fn primaries_to_xyz_d50(
     rx: f32,
     ry: f32,
     gx: f32,

--- a/jxl/src/render/stages/from_linear.rs
+++ b/jxl/src/render/stages/from_linear.rs
@@ -142,10 +142,10 @@ impl TryFrom<CustomTransferFunction> for TransferFunction {
             match ctf.transfer_function {
                 TransferFunction::BT709 => Ok(Self::Bt709),
                 TransferFunction::Unknown => Err(()),
-                TransferFunction::Linear => Err(()),
+                TransferFunction::Linear => Ok(Self::Gamma(1.0)),
                 TransferFunction::SRGB => Ok(Self::Srgb),
                 TransferFunction::PQ => Err(()),
-                TransferFunction::DCI => Ok(Self::Gamma(2.6f32.recip())),
+                TransferFunction::DCI => Ok(Self::Gamma(2.6_f32.recip())),
                 TransferFunction::HLG => Err(()),
             }
         }

--- a/jxl/src/render/stages/from_linear.rs
+++ b/jxl/src/render/stages/from_linear.rs
@@ -115,7 +115,7 @@ impl RenderPipelineStage for FromLinearStage {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TransferFunction {
     Bt709,
     Srgb,

--- a/jxl/src/render/stages/to_linear.rs
+++ b/jxl/src/render/stages/to_linear.rs
@@ -5,6 +5,7 @@
 
 use crate::color::tf;
 use crate::headers::color_encoding::CustomTransferFunction;
+use crate::render::stages::from_linear;
 use crate::render::{RenderPipelineInPlaceStage, RenderPipelineStage};
 
 /// Convert encoded non-linear color samples to display-referred linear color samples.
@@ -118,44 +119,7 @@ impl RenderPipelineStage for ToLinearStage {
     }
 }
 
-#[derive(Debug)]
-pub enum TransferFunction {
-    Bt709,
-    Srgb,
-    Pq {
-        /// Original Intensity Target
-        intensity_target: f32,
-    },
-    Hlg {
-        /// Original Intensity Target
-        intensity_target: f32,
-        luminance_rgb: [f32; 3],
-    },
-    /// Gamma in range `(0, 1]`
-    Gamma(f32),
-}
-
-impl TryFrom<CustomTransferFunction> for TransferFunction {
-    type Error = ();
-
-    fn try_from(ctf: CustomTransferFunction) -> Result<Self, ()> {
-        use crate::headers::color_encoding::TransferFunction;
-
-        if ctf.have_gamma {
-            Ok(Self::Gamma(ctf.gamma()))
-        } else {
-            match ctf.transfer_function {
-                TransferFunction::BT709 => Ok(Self::Bt709),
-                TransferFunction::Unknown => Err(()),
-                TransferFunction::Linear => Err(()),
-                TransferFunction::SRGB => Ok(Self::Srgb),
-                TransferFunction::PQ => Err(()),
-                TransferFunction::DCI => Ok(Self::Gamma(2.6f32.recip())),
-                TransferFunction::HLG => Err(()),
-            }
-        }
-    }
-}
+pub type TransferFunction = from_linear::TransferFunction;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
This is required for conformance with sections L.2.2 / F.2 of the spec (blending when `save_before_ct` is false).
