### PR TITLE
Refactor row iteration in 'ImageRect::to_image`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Inflation <2375962+inflation@users.noreply.github.com>
 Jacob Abel <jacobabel@nullpo.dev>
 Zoltan Szabadka
 Caio <c410.f3r@gmail.com>
+Louis Dispa <louis.dispa@outlook.fr>

--- a/jxl/src/image.rs
+++ b/jxl/src/image.rs
@@ -355,7 +355,11 @@ impl<'a, T: ImageDataType> ImageRect<'a, T> {
         let total_size = self.rect.size.0 * self.rect.size.1;
         let mut data = vec![];
         data.try_reserve_exact(total_size)?;
-        data.extend((0..self.rect.size.1).flat_map(|x| self.row(x).iter()));
+
+        for row_idx in 0..self.rect.size.1 {
+            data.extend_from_slice(self.row(row_idx));
+        }
+
         Ok(Image {
             size: self.rect.size,
             data,


### PR DESCRIPTION
Hello, 
out of curiosity I ran a flamegraph of jxl_cli with the new `--speedtest` option.
Then I found a weird function call stack with an iterator in the `ImageRect<'a, T>::to_image`.

Here is a proposition to optimise the function by switching from `flat_map/iter` to an explicit loop with
`extend_from_slice`. If this is not relevant I am sorry for the spam.

I ran benchmarks on every conformance_test_images on a mac air m1 with this fish shell command :
```fish
for file in jxl/resources/test/conformance_test_images/*.jxl
    set basename (basename $file)
    echo "Benchmarking: $basename"
    hyperfine -n jxl_cli_opti "./jxl_cli_opti --speedtest $file test.png" -n jxl_cli_main "./jxl_cli_main --speedtest $file test.png" -N --warmup 2
end
```


Here are the results :

File | Optimized Time | Main Time | Speedup |
|------|----------------|-----------|---------|
| alpha_nonpremultiplied.jxl | 250.7 ms | 342.5 ms | 1.37x |
| alpha_premultiplied.jxl | 219.5 ms | 337.9 ms | 1.54x |
| alpha_triangles.jxl | 275.6 ms | 367.9 ms | 1.33x |
| animation_icos4d.jxl | 204.3 ms | 293.3 ms | 1.44x |
| animation_icos4d_5.jxl | 202.7 ms | 295.2 ms | 1.46x |
| animation_newtons_cradle.jxl | 415.1 ms | 982.7 ms | 2.37x |
| animation_spline.jxl | 777.6 ms | 1.299 s | 1.67x |
| animation_spline_5.jxl | 768.7 ms | 1.255 s | 1.63x |
| bench_oriented_brg.jxl | 30.4 ms | 43.5 ms | 1.43x |
| bench_oriented_brg_5.jxl | 30.5 ms | 41.3 ms | 1.35x |
| bicycles.jxl | 235.6 ms | 265.4 ms | 1.13x |
| bike.jxl | 991.5 ms | 1.478 s | 1.49x |
| bike_5.jxl | 993.1 ms | 1.499 s | 1.51x |
| blendmodes.jxl | 1.254 s | 1.784 s | 1.42x |
| blendmodes_5.jxl | 1.271 s | 1.779 s | 1.40x |
| cafe.jxl | 129.8 ms | 237.6 ms | 1.83x |
| cafe_5.jxl | 134.9 ms | 238.6 ms | 1.77x |
| cmyk_layers.jxl | 80.1 ms | 168.8 ms | 2.11x |
| delta_palette.jxl | 75.5 ms | 98.1 ms | 1.30x |
| grayscale.jxl | 7.0 ms | 9.4 ms | 1.35x |
| grayscale_5.jxl | 6.9 ms | 9.5 ms | 1.38x |
| grayscale_jpeg.jxl | 4.4 ms | 5.4 ms | 1.23x |
| grayscale_jpeg_5.jxl | 4.6 ms | 5.3 ms | 1.16x |
| grayscale_public_university.jxl | 1.367 s | 1.734 s | 1.27x |
| lossless_pfm.jxl | 80.8 ms | 93.6 ms | 1.16x |
| lz77_flower.jxl | 84.0 ms | 94.5 ms | 1.13x |
| noise.jxl | 69.3 ms | 131.6 ms | 1.90x |
| noise_5.jxl | 68.7 ms | 132.2 ms | 1.92x |
| opsin_inverse.jxl | 42.8 ms | 64.8 ms | 1.51x |
| opsin_inverse_5.jxl | 43.0 ms | 64.9 ms | 1.51x |
| patches.jxl | 431.6 ms | 667.7 ms | 1.55x |
| patches_5.jxl | 432.8 ms | 665.5 ms | 1.54x |
| progressive.jxl | 2.582 s | 3.604 s | 1.40x |
| progressive_5.jxl | 2.582 s | 3.606 s | 1.40x |
| spot.jxl | 229.6 ms | 314.5 ms | 1.37x |
| sunset_logo.jxl | 1.130 s | 1.473 s | 1.30x |
| upsampling.jxl | 68.7 ms | 107.8 ms | 1.57x |
| upsampling_5.jxl | 69.9 ms | 104.5 ms | 1.50x |

Average speedup: 1.49x 
Range: 1.13x - 2.37x