### PR TITLE
No longer exposing orientation in the API.

### DIFF
--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -57,7 +57,6 @@ impl CodestreamParser {
                         bits_per_sample: data.bit_depth.bits_per_sample(),
                     }
                 },
-                orientation: data.orientation,
                 extra_channels: data
                     .extra_channel_info
                     .iter()

--- a/jxl/src/api/mod.rs
+++ b/jxl/src/api/mod.rs
@@ -23,8 +23,6 @@ pub use options::*;
 pub use output::*;
 pub use signature::*;
 
-use crate::headers::image_metadata::Orientation;
-
 /// This type represents the return value of a function that reads input from a bitstream. The
 /// variant `Complete` indicates that the operation was completed successfully, and its return
 /// value is available. The variant `NeedsMoreInput` indicates that more input is needed, and the
@@ -57,7 +55,6 @@ impl<T> ProcessingResult<T, ()> {
 pub struct JxlBasicInfo {
     pub size: (usize, usize),
     pub bit_depth: JxlBitDepth,
-    pub orientation: Orientation,
     pub extra_channels: Vec<JxlExtraChannel>,
     pub animation: Option<JxlAnimation>,
 }


### PR DESCRIPTION
IIRC we only exposed it since the API used to provide size pre-reorientation.