### PR TITLE
Allow casting from a avx512 descriptor to a avx descriptor.

### DIFF
--- a/jxl/src/simd/x86_64/avx.rs
+++ b/jxl/src/simd/x86_64/avx.rs
@@ -16,14 +16,22 @@ use super::super::{F32SimdVec, SimdDescriptor};
 
 // Safety invariant: this type is only ever constructed if avx2 and fma are available.
 #[derive(Clone, Copy, Debug)]
-pub struct AvxDescriptor;
+pub struct AvxDescriptor(());
+
+impl AvxDescriptor {
+    /// Safety:
+    /// The caller must guarantee that the "avx2" and "fma" target features are available.
+    pub unsafe fn new_unchecked() -> Self {
+        Self(())
+    }
+}
 
 impl SimdDescriptor for AvxDescriptor {
     type F32Vec = F32VecAvx;
     fn new() -> Option<Self> {
         if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
             // SAFETY: we just checked avx2 and fma.
-            Some(Self)
+            Some(unsafe { Self::new_unchecked() })
         } else {
             None
         }

--- a/jxl/src/simd/x86_64/avx512.rs
+++ b/jxl/src/simd/x86_64/avx512.rs
@@ -12,18 +12,34 @@ use std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
+use crate::simd::AvxDescriptor;
+
 use super::super::{F32SimdVec, SimdDescriptor};
 
 // Safety invariant: this type is only ever constructed if avx512f is available.
 #[derive(Clone, Copy, Debug)]
-pub struct Avx512Descriptor;
+pub struct Avx512Descriptor(());
+
+#[allow(unused)]
+impl Avx512Descriptor {
+    /// Safety:
+    /// The caller must guarantee that the "avx512f" target feature is available.
+    pub unsafe fn new_unchecked() -> Self {
+        Self(())
+    }
+    pub fn as_avx(&self) -> AvxDescriptor {
+        // SAFETY: the safety invariant on `self` guarantees avx512f is available, which implies
+        // avx2 and fma.
+        unsafe { AvxDescriptor::new_unchecked() }
+    }
+}
 
 impl SimdDescriptor for Avx512Descriptor {
     type F32Vec = F32VecAvx512;
     fn new() -> Option<Self> {
         if is_x86_feature_detected!("avx512f") {
             // SAFETY: we just checked avx512f.
-            Some(Self)
+            Some(Self(()))
         } else {
             None
         }


### PR DESCRIPTION
Also prevent constructing Avx(512)Descriptor without calling new().