### PR TITLE
Add a few inline annotations

### DIFF
--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -265,6 +265,7 @@ fn predict_num_nonzeros(nzeros_map: &Image<u32>, bx: usize, by: usize) -> usize 
     }
 }
 
+#[inline(always)]
 fn adjust_quant_bias(c: usize, quant_i: i32, biases: &[f32; 4]) -> f32 {
     match quant_i {
         0 => 0.0,
@@ -278,6 +279,7 @@ fn adjust_quant_bias(c: usize, quant_i: i32, biases: &[f32; 4]) -> f32 {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[inline(always)]
 fn dequant_lane(
     scaled_dequant_x: f32,
     scaled_dequant_y: f32,
@@ -360,6 +362,7 @@ fn dequant_block<D: SimdDescriptor>(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[inline(always)]
 fn dequant_and_transform_to_pixels<D: SimdDescriptor>(
     d: D,
     quant_biases: &[f32; 4],

--- a/jxl/src/simd/scalar.rs
+++ b/jxl/src/simd/scalar.rs
@@ -39,6 +39,7 @@ impl F32SimdVec for F32VecScalar {
 
     const LEN: usize = 1;
 
+    #[inline(always)]
     fn load(_d: Self::Descriptor, mem: &[f32]) -> Self {
         Self(mem[0])
     }
@@ -49,6 +50,7 @@ impl F32SimdVec for F32VecScalar {
         Self::load(d, mem)
     }
 
+    #[inline(always)]
     fn store(&self, mem: &mut [f32]) {
         mem[0] = self.0;
     }
@@ -59,18 +61,22 @@ impl F32SimdVec for F32VecScalar {
         self.store(mem)
     }
 
+    #[inline(always)]
     fn mul_add(self, mul: Self, add: Self) -> Self {
         Self(self.0.mul_add(mul.0, add.0))
     }
 
+    #[inline(always)]
     fn splat(_d: Self::Descriptor, v: f32) -> Self {
         Self(v)
     }
 
+    #[inline(always)]
     fn abs(self) -> Self {
         Self(self.0.abs())
     }
 
+    #[inline(always)]
     fn max(self, other: Self) -> Self {
         Self(self.0.max(other.0))
     }

--- a/jxl/src/simd/x86_64/avx.rs
+++ b/jxl/src/simd/x86_64/avx.rs
@@ -192,6 +192,7 @@ impl F32SimdVec for F32VecAvx {
         F32VecAvx(_mm256_fmadd_ps(this.0, mul.0, add.0), this.1)
     });
 
+    #[inline(always)]
     fn splat(d: Self::Descriptor, v: f32) -> Self {
         // SAFETY: We know avx is available from the safety invariant on `d`.
         unsafe { Self(_mm256_set1_ps(v), d) }

--- a/jxl/src/simd/x86_64/avx512.rs
+++ b/jxl/src/simd/x86_64/avx512.rs
@@ -121,6 +121,7 @@ impl F32SimdVec for F32VecAvx512 {
         F32VecAvx512(_mm512_fmadd_ps(this.0, mul.0, add.0), this.1)
     });
 
+    #[inline(always)]
     fn splat(d: Self::Descriptor, v: f32) -> Self {
         // SAFETY: We know avx512f is available from the safety invariant on `d`.
         unsafe { Self(_mm512_set1_ps(v), d) }


### PR DESCRIPTION
Decoding a 8256×5504 image and writing the decoded PPM to `/dev/null` goes from 7.81s (±0.13s) to 7.47s (also ±0.13s).

Unstripped `jxl_cli` size goes from 49.4MB to 50.3MB; stripped size from 3.74MB to 3.75MB.