### PR TITLE
SIMDfy dequant_lanes

### DIFF
--- a/jxl/src/simd/scalar.rs
+++ b/jxl/src/simd/scalar.rs
@@ -5,13 +5,15 @@
 
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use super::{F32SimdVec, SimdDescriptor};
+use super::{F32SimdVec, I32SimdVec, SimdDescriptor, SimdMask};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ScalarDescriptor;
 
 impl SimdDescriptor for ScalarDescriptor {
     type F32Vec = F32VecScalar;
+    type I32Vec = I32VecScalar;
+    type Mask = MaskScalar;
     fn new() -> Option<Self> {
         Some(Self)
     }
@@ -38,6 +40,9 @@ impl SimdDescriptor for ScalarDescriptor {
 
 #[derive(Clone, Copy, Debug)]
 pub struct F32VecScalar(f32);
+
+#[derive(Clone, Copy, Debug)]
+pub struct MaskScalar(bool);
 
 impl F32SimdVec for F32VecScalar {
     type Descriptor = ScalarDescriptor;
@@ -146,6 +151,92 @@ impl MulAssign<F32VecScalar> for F32VecScalar {
 impl DivAssign<F32VecScalar> for F32VecScalar {
     fn div_assign(&mut self, rhs: F32VecScalar) {
         self.0 /= rhs.0;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct I32VecScalar(i32);
+
+impl I32SimdVec for I32VecScalar {
+    type Descriptor = ScalarDescriptor;
+    type F32Vec = F32VecScalar;
+    type Mask = MaskScalar;
+
+    const LEN: usize = 1;
+
+    #[inline(always)]
+    fn splat(_d: Self::Descriptor, v: i32) -> Self {
+        Self(v)
+    }
+
+    #[inline(always)]
+    fn load(_d: Self::Descriptor, mem: &[i32]) -> Self {
+        Self(mem[0])
+    }
+
+    #[inline(always)]
+    fn abs(self) -> Self {
+        Self(self.0.abs())
+    }
+
+    #[inline(always)]
+    fn as_f32(self) -> Self::F32Vec {
+        F32VecScalar(self.0 as f32)
+    }
+
+    #[inline(always)]
+    fn gt(self, other: Self) -> Self::Mask {
+        MaskScalar(self.0 > other.0)
+    }
+}
+
+impl Add<I32VecScalar> for I32VecScalar {
+    type Output = I32VecScalar;
+    fn add(self, rhs: I32VecScalar) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Sub<I32VecScalar> for I32VecScalar {
+    type Output = I32VecScalar;
+    fn sub(self, rhs: I32VecScalar) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl Mul<I32VecScalar> for I32VecScalar {
+    type Output = I32VecScalar;
+    fn mul(self, rhs: I32VecScalar) -> Self::Output {
+        Self(self.0 * rhs.0)
+    }
+}
+
+impl AddAssign<I32VecScalar> for I32VecScalar {
+    fn add_assign(&mut self, rhs: I32VecScalar) {
+        self.0 += rhs.0;
+    }
+}
+
+impl SubAssign<I32VecScalar> for I32VecScalar {
+    fn sub_assign(&mut self, rhs: I32VecScalar) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl MulAssign<I32VecScalar> for I32VecScalar {
+    fn mul_assign(&mut self, rhs: I32VecScalar) {
+        self.0 *= rhs.0;
+    }
+}
+
+impl SimdMask for MaskScalar {
+    type Descriptor = ScalarDescriptor;
+    type F32Vec = F32VecScalar;
+    type I32Vec = I32VecScalar;
+
+    #[inline(always)]
+    fn if_then_else_f32(self, if_true: Self::F32Vec, if_false: Self::F32Vec) -> Self::F32Vec {
+        F32VecScalar(if self.0 { if_true.0 } else { if_false.0 })
     }
 }
 

--- a/jxl/src/simd/x86_64/avx512.rs
+++ b/jxl/src/simd/x86_64/avx512.rs
@@ -3,19 +3,18 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+use super::super::{AvxDescriptor, F32SimdVec, I32SimdVec, SimdDescriptor, SimdMask};
 use std::{
     arch::x86_64::{
-        __m512, _mm512_add_ps, _mm512_andnot_si512, _mm512_castps_si512, _mm512_castsi512_ps,
-        _mm512_div_ps, _mm512_fmadd_ps, _mm512_fnmadd_ps, _mm512_loadu_ps, _mm512_mask_loadu_ps,
-        _mm512_mask_storeu_ps, _mm512_max_ps, _mm512_mul_ps, _mm512_set1_epi32, _mm512_set1_ps,
-        _mm512_setzero_ps, _mm512_storeu_ps, _mm512_sub_ps, _mm512_xor_si512,
+        __m512, __m512i, __mmask16, _mm512_abs_epi32, _mm512_add_epi32, _mm512_add_ps,
+        _mm512_andnot_si512, _mm512_castps_si512, _mm512_castsi512_ps, _mm512_cmpgt_epi32_mask,
+        _mm512_cvtepi32_ps, _mm512_div_ps, _mm512_fmadd_ps, _mm512_fnmadd_ps, _mm512_loadu_epi32,
+        _mm512_loadu_ps, _mm512_mask_blend_ps, _mm512_mask_loadu_ps, _mm512_mask_storeu_ps,
+        _mm512_max_ps, _mm512_mul_epi32, _mm512_mul_ps, _mm512_set1_epi32, _mm512_set1_ps,
+        _mm512_setzero_ps, _mm512_storeu_ps, _mm512_sub_epi32, _mm512_sub_ps, _mm512_xor_si512,
     },
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
-
-use crate::simd::AvxDescriptor;
-
-use super::super::{F32SimdVec, SimdDescriptor};
 
 // Safety invariant: this type is only ever constructed if avx512f is available.
 #[derive(Clone, Copy, Debug)]
@@ -37,6 +36,8 @@ impl Avx512Descriptor {
 
 impl SimdDescriptor for Avx512Descriptor {
     type F32Vec = F32VecAvx512;
+    type I32Vec = I32VecAvx512;
+    type Mask = MaskAvx512;
     fn new() -> Option<Self> {
         if is_x86_feature_detected!("avx512f") {
             // SAFETY: we just checked avx512f.
@@ -83,6 +84,10 @@ macro_rules! fn_avx {
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
 pub struct F32VecAvx512(__m512, Avx512Descriptor);
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct MaskAvx512(__mmask16, Avx512Descriptor);
 
 impl F32SimdVec for F32VecAvx512 {
     type Descriptor = Avx512Descriptor;
@@ -220,5 +225,99 @@ impl MulAssign<F32VecAvx512> for F32VecAvx512 {
 impl DivAssign<F32VecAvx512> for F32VecAvx512 {
     fn_avx!(this: &mut F32VecAvx512, fn div_assign(rhs: F32VecAvx512) {
         this.0 = _mm512_div_ps(this.0, rhs.0)
+    });
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct I32VecAvx512(__m512i, Avx512Descriptor);
+
+impl I32SimdVec for I32VecAvx512 {
+    type Descriptor = Avx512Descriptor;
+    type F32Vec = F32VecAvx512;
+    type Mask = MaskAvx512;
+
+    const LEN: usize = 16;
+
+    #[inline(always)]
+    fn load(d: Self::Descriptor, mem: &[i32]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available
+        // from the safety invariant on `d`.
+        Self(unsafe { _mm512_loadu_epi32(mem.as_ptr()) }, d)
+    }
+
+    #[inline(always)]
+    fn splat(d: Self::Descriptor, v: i32) -> Self {
+        // SAFETY: We know avx512f is available from the safety invariant on `d`.
+        unsafe { Self(_mm512_set1_epi32(v), d) }
+    }
+
+    fn_avx!(this: I32VecAvx512, fn as_f32() -> F32VecAvx512 {
+         F32VecAvx512(_mm512_cvtepi32_ps(this.0), this.1)
+    });
+
+    fn_avx!(this: I32VecAvx512, fn abs() -> I32VecAvx512 {
+        I32VecAvx512(
+            _mm512_abs_epi32(
+                this.0,
+            ),
+            this.1)
+    });
+
+    fn_avx!(this: I32VecAvx512, fn gt(rhs: I32VecAvx512) -> MaskAvx512 {
+        MaskAvx512(
+            _mm512_cmpgt_epi32_mask(this.0, rhs.0),
+            this.1
+        )
+    });
+}
+
+impl Add<I32VecAvx512> for I32VecAvx512 {
+    type Output = I32VecAvx512;
+    fn_avx!(this: I32VecAvx512, fn add(rhs: I32VecAvx512) -> I32VecAvx512 {
+        I32VecAvx512(_mm512_add_epi32(this.0, rhs.0), this.1)
+    });
+}
+
+impl Sub<I32VecAvx512> for I32VecAvx512 {
+    type Output = I32VecAvx512;
+    fn_avx!(this: I32VecAvx512, fn sub(rhs: I32VecAvx512) -> I32VecAvx512 {
+        I32VecAvx512(_mm512_sub_epi32(this.0, rhs.0), this.1)
+    });
+}
+
+impl Mul<I32VecAvx512> for I32VecAvx512 {
+    type Output = I32VecAvx512;
+    fn_avx!(this: I32VecAvx512, fn mul(rhs: I32VecAvx512) -> I32VecAvx512 {
+        I32VecAvx512(_mm512_mul_epi32(this.0, rhs.0), this.1)
+    });
+}
+
+impl AddAssign<I32VecAvx512> for I32VecAvx512 {
+    fn_avx!(this: &mut I32VecAvx512, fn add_assign(rhs: I32VecAvx512) {
+        this.0 = _mm512_add_epi32(this.0, rhs.0)
+    });
+}
+
+impl SubAssign<I32VecAvx512> for I32VecAvx512 {
+    fn_avx!(this: &mut I32VecAvx512, fn sub_assign(rhs: I32VecAvx512) {
+        this.0 = _mm512_sub_epi32(this.0, rhs.0)
+    });
+}
+
+impl MulAssign<I32VecAvx512> for I32VecAvx512 {
+    fn_avx!(this: &mut I32VecAvx512, fn mul_assign(rhs: I32VecAvx512) {
+        this.0 = _mm512_mul_epi32(this.0, rhs.0)
+    });
+}
+
+impl SimdMask for MaskAvx512 {
+    type Descriptor = Avx512Descriptor;
+    type F32Vec = F32VecAvx512;
+    type I32Vec = I32VecAvx512;
+
+    fn_avx!(this: MaskAvx512, fn if_then_else_f32(if_true: F32VecAvx512, if_false: F32VecAvx512) -> F32VecAvx512 {
+         F32VecAvx512(_mm512_mask_blend_ps(this.0, if_false.0, if_true.0), this.1)
     });
 }


### PR DESCRIPTION
Before: `dequant_and_transform_to_pixels_dispatch` took 2.2-2.3% of the total time according to `perf`

After: 1.7-1.8%

(Both figures with the simple pipeline)