### PR TITLE
Add call method to SimdDescriptor trait for feature context pattern

### DIFF
--- a/jxl/src/simd/mod.rs
+++ b/jxl/src/simd/mod.rs
@@ -40,6 +40,11 @@ pub trait SimdDescriptor: Sized + Copy + Debug + Send + Sync {
     fn new() -> Option<Self>;
 
     fn transpose<const ROWS: usize, const COLS: usize>(self, input: &[f32], output: &mut [f32]);
+
+    /// Calls the given closure within a target feature context.
+    /// This enables establishing an unbroken chain of inline functions from the feature-annotated
+    /// gateway up to the closure, allowing SIMD intrinsics to be used safely.
+    fn call<R>(self, f: impl FnOnce(Self) -> R) -> R;
 }
 
 pub trait F32SimdVec:
@@ -226,4 +231,36 @@ mod test {
 
     test_instruction!(abs, |a: Floats| { a.abs() });
     test_instruction!(max, |a: Floats, b: Floats| { a.max(b) });
+
+    // Test that the call method works, compiles, and can capture arguments
+    fn test_call<D: SimdDescriptor>(d: D) {
+        // Test basic call functionality
+        let result = d.call(|_d| 42);
+        assert_eq!(result, 42);
+
+        // Test with capturing variables
+        let multiplier = 3.0f32;
+        let addend = 5.0f32;
+
+        // Test SIMD operations inside call with captures
+        let input = vec![1.0f32; D::F32Vec::LEN * 4];
+        let mut output = vec![0.0f32; D::F32Vec::LEN * 4];
+
+        d.call(|d| {
+            let mult_vec = D::F32Vec::splat(d, multiplier);
+            let add_vec = D::F32Vec::splat(d, addend);
+
+            for idx in (0..input.len()).step_by(D::F32Vec::LEN) {
+                let vec = D::F32Vec::load(d, &input[idx..]);
+                let result = vec * mult_vec + add_vec;
+                result.store(&mut output[idx..]);
+            }
+        });
+
+        // Verify results
+        for &val in &output {
+            assert_eq!(val, 1.0 * multiplier + addend);
+        }
+    }
+    test_all_instruction_sets!(test_call);
 }

--- a/jxl/src/simd/scalar.rs
+++ b/jxl/src/simd/scalar.rs
@@ -29,6 +29,11 @@ impl SimdDescriptor for ScalarDescriptor {
             }
         }
     }
+
+    fn call<R>(self, f: impl FnOnce(Self) -> R) -> R {
+        // No special features needed for scalar implementation
+        f(self)
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/jxl/src/simd/x86_64/avx.rs
+++ b/jxl/src/simd/x86_64/avx.rs
@@ -112,6 +112,15 @@ impl SimdDescriptor for AvxDescriptor {
         }
         // TODO: reserve the above for `ROWS.min(COLS) <= 4` and add an 8×8 version
     }
+
+    fn call<R>(self, f: impl FnOnce(Self) -> R) -> R {
+        #[target_feature(enable = "avx2,fma")]
+        unsafe fn inner<R>(d: AvxDescriptor, f: impl FnOnce(AvxDescriptor) -> R) -> R {
+            f(d)
+        }
+        // SAFETY: the safety invariant on `self` guarantees avx2 and fma.
+        unsafe { inner(self, f) }
+    }
 }
 
 // TODO(veluca): retire this macro once we have #[unsafe(target_feature)].

--- a/jxl/src/simd/x86_64/avx512.rs
+++ b/jxl/src/simd/x86_64/avx512.rs
@@ -51,6 +51,15 @@ impl SimdDescriptor for Avx512Descriptor {
         // TODO: implement an AVX-512-specific version
         self.as_avx().transpose::<ROWS, COLS>(input, output)
     }
+
+    fn call<R>(self, f: impl FnOnce(Self) -> R) -> R {
+        #[target_feature(enable = "avx512f")]
+        unsafe fn inner<R>(d: Avx512Descriptor, f: impl FnOnce(Avx512Descriptor) -> R) -> R {
+            f(d)
+        }
+        // SAFETY: the safety invariant on `self` guarantees avx512f.
+        unsafe { inner(self, f) }
+    }
 }
 
 // TODO(veluca): retire this macro once we have #[unsafe(target_feature)].


### PR DESCRIPTION
This implements the SIMD feature gateway pattern that allows establishing an unbroken chain of inline functions from target_feature-annotated code to arbitrary closures. This enables using SIMD intrinsics at any depth without needing to annotate entire call trees.

Changes:
- Add call<R>(self, f: impl FnOnce(Self) -> R) -> R method to SimdDescriptor trait
- Implement call for ScalarDescriptor (direct call, no features needed)
- Implement call for AvxDescriptor with #[target_feature(enable = "avx2,fma")]
- Implement call for Avx512Descriptor with #[target_feature(enable = "avx512f")]
- Add comprehensive test using test_all_instruction_sets! macro

The pattern uses an inner function with target_feature annotation as a "feature gateway" that's called from an unsafe outer function. This enables establishing the feature context while allowing the compiler to make optimal inlining decisions.

The call method allows closures to capture variables and perform SIMD operations safely within the appropriate feature context.