### PR TITLE
Use padded frame size in PatchesDictionary::read

### DIFF
--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -159,8 +159,8 @@ impl Frame {
             info!("decoding patches");
             Some(PatchesDictionary::read(
                 br,
-                self.header.width as usize,
-                self.header.height as usize,
+                self.header.size_padded().0,
+                self.header.size_padded().1,
                 self.decoder_state.extra_channel_info().len(),
                 &self.decoder_state.reference_frames,
             )?)


### PR DESCRIPTION
This aligns patch boundary checks with libjxl by using header.size_padded() to prevent PatchesOutOfBounds errors on images with non-aligned dimensions.