### PR TITLE
Type-erased low_memory_pipeline and start SIMD save.

### DIFF
--- a/jxl/src/image/internal.rs
+++ b/jxl/src/image/internal.rs
@@ -12,8 +12,7 @@ use std::{
 
 use crate::{
     error::{Error, Result},
-    simd::CACHE_LINE_BYTE_SIZE,
-    util::tracing_wrappers::*,
+    util::{CACHE_LINE_BYTE_SIZE, tracing_wrappers::*},
 };
 
 use super::Rect;

--- a/jxl/src/image/output_buffer.rs
+++ b/jxl/src/image/output_buffer.rs
@@ -83,6 +83,14 @@ impl<'a> JxlOutputBuffer<'a> {
         }
     }
 
+    /// Safety:
+    /// The caller must guarantee that the returned slice is not used for writing uninit data.
+    pub(crate) unsafe fn row_mut(&mut self, row: usize) -> &mut [MaybeUninit<u8>] {
+        // SAFETY: caller guarantees no uninit data is written, and we have write access to the
+        // data due to safety invariant.
+        unsafe { self.inner.row_mut(row) }
+    }
+
     #[inline]
     pub fn write_bytes(&mut self, row: usize, col: usize, bytes: &[u8]) {
         // SAFETY: We never use the returned slice to write uninit data, and we have write access

--- a/jxl/src/image/typed.rs
+++ b/jxl/src/image/typed.rs
@@ -5,7 +5,10 @@
 
 use std::{fmt::Debug, marker::PhantomData};
 
-use crate::{error::Result, simd::CACHE_LINE_BYTE_SIZE, util::tracing_wrappers::*};
+use crate::{
+    error::Result,
+    util::{CACHE_LINE_BYTE_SIZE, tracing_wrappers::*},
+};
 
 use super::{ImageDataType, OwnedRawImage, RawImageRect, RawImageRectMut, Rect};
 

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -11,10 +11,9 @@ use crate::BLOCK_DIM;
 use crate::api::JxlOutputBuffer;
 use crate::error::Result;
 use crate::headers::Orientation;
-use crate::image::{Image, ImageDataType, Rect};
+use crate::image::{Image, ImageDataType, OwnedRawImage, Rect};
 use crate::render::internal::Stage;
-use crate::simd::CACHE_LINE_BYTE_SIZE;
-use crate::util::{ShiftRightCeil, tracing_wrappers::*};
+use crate::util::{CACHE_LINE_BYTE_SIZE, ShiftRightCeil, tracing_wrappers::*};
 
 use super::RenderPipeline;
 use super::internal::{RenderPipelineShared, RunInOutStage, RunInPlaceStage};
@@ -27,7 +26,7 @@ mod save;
 
 struct InputBuffer {
     // One buffer per channel.
-    data: Vec<Option<Box<dyn Any>>>,
+    data: Vec<Option<OwnedRawImage>>,
     completed_passes: usize,
 }
 
@@ -375,9 +374,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             .shared
             .group_size_for_channel(channel, group_id, T::DATA_TYPE_ID);
         if let Some(buf) = self.input_buffers[group_id].data[channel].take() {
-            let img: Image<T> = *buf
-                .downcast()
-                .expect("inconsistent usage of pipeline buffers");
+            let img = Image::<T>::from_raw(buf);
             let bsz = img.size();
             assert!(sz.0 <= bsz.0);
             assert!(sz.1 <= bsz.1);
@@ -409,7 +406,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
         assert!(sz.1 <= bsz.1);
         assert!(sz.0 + BLOCK_DIM > bsz.0);
         assert!(sz.1 + BLOCK_DIM > bsz.1);
-        self.input_buffers[group_id].data[channel] = Some(Box::new(buf));
+        self.input_buffers[group_id].data[channel] = Some(buf.into_raw());
         self.shared.group_chan_ready_passes[group_id][channel] += num_passes;
     }
 

--- a/jxl/src/render/low_memory_pipeline/row_buffers.rs
+++ b/jxl/src/render/low_memory_pipeline/row_buffers.rs
@@ -3,38 +3,28 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::{any::Any, ops::Range};
-
-use half::f16;
+use std::ops::Range;
 
 use crate::{
     error::Result,
     image::{DataTypeTag, ImageDataType},
-    simd::{CACHE_LINE_BYTE_SIZE, num_per_cache_line},
-    util::ShiftRightCeil,
+    util::{
+        CACHE_LINE_BYTE_SIZE, CacheLine, num_per_cache_line, slice_from_cachelines,
+        slice_from_cachelines_mut,
+    },
 };
 
 /// Temporary storage for data rows. Note that the first pixel of the group is expected to be
 /// located *two cachelines worth of data* inside the row.
 pub struct RowBuffer {
-    // TODO(veluca): consider making this into a Vec<u8> and using casts instead, if we want to get
-    // rid of the double allocation & the typeid checking on access.
-    buffer: Box<dyn Any>,
-    // Distance (in number of elements) between the start of two rows.
+    buffer: Box<[CacheLine]>,
+    // Distance (in number of *cache lines*) between the start of two rows.
     row_stride: usize,
     // Number of rows that are actually stored.
     // TODO(veluca): consider padding this to a power of 2 and using & here. In *most* cases,
     // that's not a huge loss in memory usage (for most images, num_rows is 1/3/5/7, which would
     // become 1/4/8/8).
     num_rows: usize,
-}
-
-fn make_buffer<T: Default + Clone + 'static>(len: usize) -> Result<Box<dyn Any>> {
-    // TODO(veluca): allocate this aligned to a cache line.
-    let mut vec = Vec::<T>::new();
-    vec.try_reserve(len)?;
-    vec.resize(len, Default::default());
-    Ok(Box::new(vec))
 }
 
 impl RowBuffer {
@@ -44,24 +34,14 @@ impl RowBuffer {
         y_shift: usize,
         row_len: usize,
     ) -> Result<Self> {
-        // This is slightly wasteful (i.e. if y_shift = 2 and next_y_border = 1, it uses 4 more
-        // rows than would be necessary), but certainly sufficient.
-        let num_rows = (1 << y_shift) + 2 * (next_y_border.shrc(y_shift) << y_shift);
+        let num_rows = (1 << y_shift) + 2 * next_y_border;
         // Input offset is at *two* cachelines, and we need up to *three* cachelines on the other
         // side as the data might exceed xsize slightly.
-        let row_stride = row_len + 5 * (CACHE_LINE_BYTE_SIZE / data_type.size());
-        let buffer: Box<dyn Any> = match data_type {
-            DataTypeTag::U8 => make_buffer::<u8>(row_stride * num_rows)?,
-            DataTypeTag::I8 => make_buffer::<i8>(row_stride * num_rows)?,
-            DataTypeTag::U16 => make_buffer::<u16>(row_stride * num_rows)?,
-            DataTypeTag::F16 => make_buffer::<f16>(row_stride * num_rows)?,
-            DataTypeTag::I16 => make_buffer::<i16>(row_stride * num_rows)?,
-            DataTypeTag::U32 => make_buffer::<u32>(row_stride * num_rows)?,
-            DataTypeTag::F32 => make_buffer::<f32>(row_stride * num_rows)?,
-            DataTypeTag::I32 => make_buffer::<i32>(row_stride * num_rows)?,
-            DataTypeTag::F64 => make_buffer::<f64>(row_stride * num_rows)?,
-        };
-
+        let row_stride = (row_len * data_type.size()).div_ceil(CACHE_LINE_BYTE_SIZE) + 5;
+        let mut buffer = Vec::<CacheLine>::new();
+        buffer.try_reserve_exact(row_stride * num_rows)?;
+        buffer.resize(row_stride * num_rows, CacheLine::default());
+        let buffer = buffer.into_boxed_slice();
         Ok(Self {
             buffer,
             row_stride,
@@ -69,30 +49,17 @@ impl RowBuffer {
         })
     }
 
-    pub fn get_buf_mut<T: ImageDataType>(&mut self) -> &mut [T] {
-        &mut *self
-            .buffer
-            .downcast_mut::<Vec<T>>()
-            .expect("called get_buf with the wrong buffer type")
-    }
-
-    pub fn get_buf<T: ImageDataType>(&self) -> &[T] {
-        self.buffer
-            .downcast_ref::<Vec<T>>()
-            .expect("called get_buf with the wrong buffer type")
-    }
-
     pub fn get_row<T: ImageDataType>(&self, row: usize) -> &[T] {
         let row_idx = row % self.num_rows;
         let start = row_idx * self.row_stride;
-        &self.get_buf()[start..start + self.row_stride]
+        slice_from_cachelines(&self.buffer[start..start + self.row_stride])
     }
 
     pub fn get_row_mut<T: ImageDataType>(&mut self, row: usize) -> &mut [T] {
         let row_idx = row % self.num_rows;
         let stride = self.row_stride;
         let start = row_idx * stride;
-        &mut self.get_buf_mut()[start..start + stride]
+        slice_from_cachelines_mut(&mut self.buffer[start..start + stride])
     }
 
     // TODO(veluca): use some kind of smallvec.
@@ -107,17 +74,21 @@ impl RowBuffer {
         let start = first_row_idx * stride;
         let num_pre = (y.clone().count() + first_row_idx).saturating_sub(self.num_rows);
         let num_post = y.clone().count() - num_pre;
-        let buf = self.get_buf_mut::<T>();
+        let buf = &mut self.buffer[..];
         let (pre, post) = buf.split_at_mut(start);
         let pre_rows = pre.chunks_exact_mut(stride).take(num_pre);
         let post_rows = post.chunks_exact_mut(stride).take(num_post);
         post_rows
             .chain(pre_rows)
-            .map(|x| &mut x[xoffset..])
+            .map(|x| &mut slice_from_cachelines_mut(x)[xoffset..])
             .collect()
     }
 
     pub const fn x0_offset<T: ImageDataType>() -> usize {
         2 * num_per_cache_line::<T>()
+    }
+
+    pub const fn x0_byte_offset() -> usize {
+        2 * CACHE_LINE_BYTE_SIZE
     }
 }

--- a/jxl/src/render/low_memory_pipeline/save/identity.rs
+++ b/jxl/src/render/low_memory_pipeline/save/identity.rs
@@ -1,0 +1,76 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#![allow(unsafe_code)]
+
+use std::ops::Range;
+
+use crate::{
+    api::{Endianness, JxlDataFormat, JxlOutputBuffer},
+    render::low_memory_pipeline::row_buffers::RowBuffer,
+};
+
+pub(super) fn store(
+    input_buf: &[&RowBuffer],
+    input_y: usize,
+    xrange: Range<usize>,
+    output_buf: &mut JxlOutputBuffer,
+    output_y: usize,
+    data_format: JxlDataFormat,
+) -> usize {
+    let byte_start = xrange.start * data_format.bytes_per_sample() + RowBuffer::x0_byte_offset();
+    let byte_end = xrange.end * data_format.bytes_per_sample() + RowBuffer::x0_byte_offset();
+    let is_native_endian = match data_format {
+        JxlDataFormat::U8 { .. } => true,
+        JxlDataFormat::F16 { endianness, .. }
+        | JxlDataFormat::U16 { endianness, .. }
+        | JxlDataFormat::F32 { endianness, .. } => endianness == Endianness::native(),
+    };
+    // SAFETY: we never write uninit memory to the `output_row`.
+    let output_buf = unsafe { output_buf.row_mut(output_y) };
+    let output_buf = &mut output_buf[0..(byte_end - byte_start) * input_buf.len()];
+    match (
+        input_buf.len(),
+        data_format.bytes_per_sample(),
+        is_native_endian,
+    ) {
+        (1, _, true) => {
+            // We can just do a memcpy.
+            let input_buf = &input_buf[0].get_row::<u8>(input_y)[byte_start..byte_end];
+            assert_eq!(input_buf.len(), output_buf.len());
+            // SAFETY: we are copying `u8`s, which have an alignment of 1, from a slice of [u8] to
+            // a slice of [MaybeUninit<u8>] of the same length (as we checked just above). u8 and
+            // MaybeUninit<u8> have the same layout, and aliasing rules guarantee that the two
+            // slices are non-overlapping.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    input_buf.as_ptr(),
+                    output_buf.as_mut_ptr() as *mut u8,
+                    output_buf.len(),
+                );
+            }
+            input_buf.len() / data_format.bytes_per_sample()
+        }
+        (3, 4, true) => {
+            #[cfg(target_arch = "x86_64")]
+            {
+                let [a, b, c] = input_buf else { unreachable!() };
+                super::x86_64::interleave3_32b(
+                    &[
+                        &a.get_row(input_y)[byte_start..byte_end],
+                        &b.get_row(input_y)[byte_start..byte_end],
+                        &c.get_row(input_y)[byte_start..byte_end],
+                    ],
+                    output_buf,
+                )
+            }
+            #[cfg(not(target_arch = "x86_64"))]
+            {
+                0
+            }
+        }
+        _ => 0,
+    }
+}

--- a/jxl/src/render/low_memory_pipeline/save/x86_64.rs
+++ b/jxl/src/render/low_memory_pipeline/save/x86_64.rs
@@ -1,0 +1,168 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#![allow(unsafe_code)]
+
+use std::{
+    arch::x86_64::{
+        __m256i, __m512i, _mm256_add_epi32, _mm256_blend_epi32, _mm256_loadu_si256,
+        _mm256_permutevar8x32_epi32, _mm256_set1_epi32, _mm256_storeu_si256, _mm512_loadu_si512,
+        _mm512_mask_permutevar_epi32, _mm512_permutex2var_epi32, _mm512_storeu_si512,
+    },
+    mem::MaybeUninit,
+};
+
+#[target_feature(enable = "avx2")]
+fn load_avx2_u32(data: &[u32; 8]) -> __m256i {
+    // SAFETY: `data` has the correct size.
+    unsafe { _mm256_loadu_si256(data.as_ptr() as *const _) }
+}
+
+#[target_feature(enable = "avx2")]
+fn load_avx2(data: &[u8; 32]) -> __m256i {
+    // SAFETY: `data` has the correct size.
+    unsafe { _mm256_loadu_si256(data.as_ptr() as *const _) }
+}
+
+#[target_feature(enable = "avx2")]
+fn store_avx2(data: __m256i, out: &mut [MaybeUninit<u8>; 32]) {
+    // SAFETY: `data` has the correct size.
+    unsafe { _mm256_storeu_si256(out.as_mut_ptr() as *mut _, data) }
+}
+
+#[target_feature(enable = "avx512f")]
+fn load_avx512_u32(data: &[u32; 16]) -> __m512i {
+    // SAFETY: `data` has the correct size.
+    unsafe { _mm512_loadu_si512(data.as_ptr() as *const _) }
+}
+
+#[target_feature(enable = "avx512f")]
+fn load_avx512(data: &[u8; 64]) -> __m512i {
+    // SAFETY: `data` has the correct size.
+    unsafe { _mm512_loadu_si512(data.as_ptr() as *const _) }
+}
+
+#[target_feature(enable = "avx512f")]
+fn store_avx512(data: __m512i, out: &mut [MaybeUninit<u8>; 64]) {
+    // SAFETY: `data` has the correct size.
+    unsafe { _mm512_storeu_si512(out.as_mut_ptr() as *mut _, data) }
+}
+
+#[target_feature(enable = "avx2")]
+fn interleave3_32b_avx2(inp: &[&[u8]; 3], out: &mut [MaybeUninit<u8>]) -> usize {
+    let [a, b, c] = inp;
+
+    let idx_a0 = load_avx2_u32(&[0, 0, 0, 1, 0, 0, 2, 0]);
+    // c1 = idx_a0 + 2
+    // b2 = idx_a0 + 5
+
+    let idx_b0 = load_avx2_u32(&[0, 0, 0, 0, 1, 0, 0, 2]);
+    // a1 = idx_b0 + 3
+    // c2 = idx_b0 + 5
+
+    let idx_c0 = load_avx2_u32(&[0, 0, 0, 0, 0, 1, 0, 0]);
+    // b1 = idx_c0 + 3
+    // a2 = idx_c0 + 6
+
+    let two = _mm256_set1_epi32(2);
+    let three = _mm256_set1_epi32(3);
+    let five = _mm256_set1_epi32(5);
+    let six = _mm256_set1_epi32(6);
+
+    const LEN: usize = 32;
+    let mut processed = 0;
+    for (((a, b), c), out) in a
+        .chunks_exact(LEN)
+        .zip(b.chunks_exact(LEN))
+        .zip(c.chunks_exact(LEN))
+        .zip(out.chunks_exact_mut(LEN * 3))
+    {
+        let a = load_avx2(a.try_into().unwrap());
+        let b = load_avx2(b.try_into().unwrap());
+        let c = load_avx2(c.try_into().unwrap());
+
+        let a0 = _mm256_permutevar8x32_epi32(a, idx_a0);
+        let b0 = _mm256_permutevar8x32_epi32(b, idx_b0);
+        let c0 = _mm256_permutevar8x32_epi32(c, idx_c0);
+        let out0 = _mm256_blend_epi32::<0b10010010>(a0, b0);
+        let out0 = _mm256_blend_epi32::<0b00100100>(out0, c0);
+
+        let a1 = _mm256_permutevar8x32_epi32(a, _mm256_add_epi32(idx_b0, three));
+        let b1 = _mm256_permutevar8x32_epi32(b, _mm256_add_epi32(idx_c0, three));
+        let c1 = _mm256_permutevar8x32_epi32(c, _mm256_add_epi32(idx_a0, two));
+        let out1 = _mm256_blend_epi32::<0b00100100>(a1, b1);
+        let out1 = _mm256_blend_epi32::<0b01001001>(out1, c1);
+
+        let a2 = _mm256_permutevar8x32_epi32(a, _mm256_add_epi32(idx_c0, six));
+        let b2 = _mm256_permutevar8x32_epi32(b, _mm256_add_epi32(idx_a0, five));
+        let c2 = _mm256_permutevar8x32_epi32(c, _mm256_add_epi32(idx_b0, five));
+        let out2 = _mm256_blend_epi32::<0b01001001>(a2, b2);
+        let out2 = _mm256_blend_epi32::<0b10010010>(out2, c2);
+
+        store_avx2(out0, (&mut out[0..LEN]).try_into().unwrap());
+        store_avx2(out1, (&mut out[LEN..2 * LEN]).try_into().unwrap());
+        store_avx2(out2, (&mut out[2 * LEN..3 * LEN]).try_into().unwrap());
+        processed += LEN / 4;
+    }
+
+    processed
+}
+
+#[inline(never)]
+#[target_feature(enable = "avx512f")]
+fn interleave3_32b_avx512(inp: &[&[u8]; 3], out: &mut [MaybeUninit<u8>]) -> usize {
+    let [a, b, c] = inp;
+
+    let idx_ab0 = load_avx512_u32(&[0, 16, 0, 1, 17, 0, 2, 18, 0, 3, 19, 0, 4, 20, 0, 5]);
+    let idx_c0 = load_avx512_u32(&[0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0]);
+
+    let idx_ab1 = load_avx512_u32(&[21, 0, 6, 22, 0, 7, 23, 0, 8, 24, 0, 9, 25, 0, 10, 26]);
+    let idx_c1 = load_avx512_u32(&[0, 5, 0, 0, 6, 0, 0, 7, 0, 0, 8, 0, 0, 9, 0, 0]);
+
+    let idx_ab2 = load_avx512_u32(&[0, 11, 27, 0, 12, 28, 0, 13, 29, 0, 14, 30, 0, 15, 31, 0]);
+    let idx_c2 = load_avx512_u32(&[10, 0, 0, 11, 0, 0, 12, 0, 0, 13, 0, 0, 14, 0, 0, 15]);
+
+    const LEN: usize = 64;
+    let mut processed = 0;
+    for (((a, b), c), out) in a
+        .chunks_exact(LEN)
+        .zip(b.chunks_exact(LEN))
+        .zip(c.chunks_exact(LEN))
+        .zip(out.chunks_exact_mut(LEN * 3))
+    {
+        let a = load_avx512(a.try_into().unwrap());
+        let b = load_avx512(b.try_into().unwrap());
+        let c = load_avx512(c.try_into().unwrap());
+
+        let out0 = _mm512_permutex2var_epi32(a, idx_ab0, b);
+        let out0 = _mm512_mask_permutevar_epi32(out0, 0b0100100100100100, idx_c0, c);
+
+        let out1 = _mm512_permutex2var_epi32(a, idx_ab1, b);
+        let out1 = _mm512_mask_permutevar_epi32(out1, 0b0010010010010010, idx_c1, c);
+
+        let out2 = _mm512_permutex2var_epi32(a, idx_ab2, b);
+        let out2 = _mm512_mask_permutevar_epi32(out2, 0b1001001001001001, idx_c2, c);
+
+        store_avx512(out0, (&mut out[0..LEN]).try_into().unwrap());
+        store_avx512(out1, (&mut out[LEN..2 * LEN]).try_into().unwrap());
+        store_avx512(out2, (&mut out[2 * LEN..3 * LEN]).try_into().unwrap());
+        processed += LEN / 4;
+    }
+
+    processed
+}
+
+/// Safety note: does not write uninit data in `out`.
+pub(super) fn interleave3_32b(inp: &[&[u8]; 3], out: &mut [MaybeUninit<u8>]) -> usize {
+    if is_x86_feature_detected!("avx512f") {
+        // SAFETY: we just checked for avx512f.
+        unsafe { interleave3_32b_avx512(inp, out) }
+    } else if is_x86_feature_detected!("avx2") {
+        // SAFETY: we just checked for avx2.
+        unsafe { interleave3_32b_avx2(inp, out) }
+    } else {
+        0
+    }
+}

--- a/jxl/src/render/simple_pipeline/extend.rs
+++ b/jxl/src/render/simple_pipeline/extend.rs
@@ -6,8 +6,7 @@
 use crate::{
     image::{Image, ImageDataType},
     render::stages::ExtendToImageDimensionsStage,
-    simd::round_up_size_to_two_cache_lines,
-    util::tracing_wrappers::*,
+    util::{round_up_size_to_two_cache_lines, tracing_wrappers::*},
 };
 
 impl ExtendToImageDimensionsStage {

--- a/jxl/src/render/simple_pipeline/run_stage.rs
+++ b/jxl/src/render/simple_pipeline/run_stage.rs
@@ -11,8 +11,7 @@ use crate::{
         RenderPipelineInOutStage, RenderPipelineInPlaceStage, RunInOutStage, RunInPlaceStage,
         internal::PipelineBuffer,
     },
-    simd::round_up_size_to_two_cache_lines,
-    util::tracing_wrappers::*,
+    util::{round_up_size_to_two_cache_lines, tracing_wrappers::*},
 };
 
 impl PipelineBuffer for Image<f64> {

--- a/jxl/src/render/stages/xyb.rs
+++ b/jxl/src/render/stages/xyb.rs
@@ -266,10 +266,8 @@ mod test {
     use crate::headers::encodings::Empty;
     use crate::image::Image;
     use crate::render::test::make_and_run_simple_pipeline;
-    use crate::simd::{
-        ScalarDescriptor, SimdDescriptor, round_up_size_to_two_cache_lines,
-        test_all_instruction_sets,
-    };
+    use crate::simd::{ScalarDescriptor, SimdDescriptor, test_all_instruction_sets};
+    use crate::util::round_up_size_to_two_cache_lines;
     use crate::util::test::assert_all_almost_abs_eq;
 
     #[test]

--- a/jxl/src/simd/mod.rs
+++ b/jxl/src/simd/mod.rs
@@ -27,23 +27,6 @@ pub(crate) use scalar::test_all_instruction_sets;
 
 pub(crate) use scalar::ScalarDescriptor;
 
-pub const CACHE_LINE_BYTE_SIZE: usize = 64;
-
-pub const fn num_per_cache_line<T>() -> usize {
-    // Post-mono check that T is smaller than a cache line and has size a power of 2.
-    // This prevents some of the silliest mistakes.
-    const {
-        assert!(std::mem::size_of::<T>() <= CACHE_LINE_BYTE_SIZE);
-        assert!(std::mem::size_of::<T>().is_power_of_two());
-    }
-    CACHE_LINE_BYTE_SIZE / std::mem::size_of::<T>()
-}
-
-pub fn round_up_size_to_two_cache_lines<T>(size: usize) -> usize {
-    let n = const { num_per_cache_line::<T>() * 2 };
-    size.div_ceil(n) * n
-}
-
 pub trait SimdDescriptor: Sized + Copy + Debug + Send + Sync {
     type F32Vec: F32SimdVec<Descriptor = Self>;
 

--- a/jxl/src/util/cacheline.rs
+++ b/jxl/src/util/cacheline.rs
@@ -1,0 +1,67 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#![allow(unsafe_code)]
+
+use crate::image::ImageDataType;
+
+pub const CACHE_LINE_BYTE_SIZE: usize = 64;
+
+pub const fn num_per_cache_line<T>() -> usize {
+    // Post-mono check that T is smaller than a cache line and has size a power of 2.
+    // This prevents some of the silliest mistakes.
+    const {
+        assert!(std::mem::size_of::<T>() <= CACHE_LINE_BYTE_SIZE);
+        assert!(std::mem::size_of::<T>().is_power_of_two());
+    }
+    CACHE_LINE_BYTE_SIZE / std::mem::size_of::<T>()
+}
+
+pub fn round_up_size_to_two_cache_lines<T>(size: usize) -> usize {
+    let n = const { num_per_cache_line::<T>() * 2 };
+    size.div_ceil(n) * n
+}
+
+#[derive(Clone)]
+#[repr(C, align(64))]
+pub struct CacheLine([u8; CACHE_LINE_BYTE_SIZE]);
+
+impl Default for CacheLine {
+    fn default() -> Self {
+        CacheLine([0; CACHE_LINE_BYTE_SIZE])
+    }
+}
+
+pub fn slice_from_cachelines<T: ImageDataType>(slice: &[CacheLine]) -> &[T] {
+    const { assert!(64usize.is_multiple_of(std::mem::align_of::<T>())) };
+    const { assert!(CACHE_LINE_BYTE_SIZE.is_multiple_of(std::mem::size_of::<T>())) };
+    const { assert!(CACHE_LINE_BYTE_SIZE == 64) };
+    // SAFETY: CacheLine is 64 bytes with no padding, with higher alignment requirements than T.
+    // T is guaranteed to be a bag-of-bits type by the safety requirements of ImageDataType.
+    // The other safety requirements follow from the data pointer and length being obtained from a
+    // slice.
+    unsafe {
+        std::slice::from_raw_parts(
+            slice.as_ptr() as *const T,
+            slice.len() * (CACHE_LINE_BYTE_SIZE / std::mem::size_of::<T>()),
+        )
+    }
+}
+
+pub fn slice_from_cachelines_mut<T: ImageDataType>(slice: &mut [CacheLine]) -> &mut [T] {
+    const { assert!(64usize.is_multiple_of(std::mem::align_of::<T>())) };
+    const { assert!(CACHE_LINE_BYTE_SIZE.is_multiple_of(std::mem::size_of::<T>())) };
+    const { assert!(CACHE_LINE_BYTE_SIZE == 64) };
+    // SAFETY: CacheLine is 64 bytes with no padding, with higher alignment requirements than T.
+    // T is guaranteed to be a bag-of-bits type by the safety requirements of ImageDataType.
+    // The other safety requirements follow from the data pointer and length being obtained from a
+    // slice.
+    unsafe {
+        std::slice::from_raw_parts_mut(
+            slice.as_ptr() as *mut T,
+            slice.len() * (CACHE_LINE_BYTE_SIZE / std::mem::size_of::<T>()),
+        )
+    }
+}

--- a/jxl/src/util/mod.rs
+++ b/jxl/src/util/mod.rs
@@ -7,6 +7,7 @@
 pub mod test;
 
 mod bits;
+mod cacheline;
 mod concat_slice;
 mod fast_math;
 mod linalg;
@@ -19,6 +20,7 @@ mod vec_helpers;
 mod xorshift128plus;
 
 pub use bits::*;
+pub use cacheline::*;
 pub use concat_slice::*;
 pub use fast_math::*;
 pub use linalg::*;


### PR DESCRIPTION
Faster saving is only implemented for 4-byte-per-pixel output and 3 channels, or 1 channel with any size.

Roughly 15-20% speedup.