### PR TITLE
Avoid .round() in PPM/PNG output

### DIFF
--- a/jxl_cli/src/enc/png.rs
+++ b/jxl_cli/src/enc/png.rs
@@ -161,10 +161,10 @@ pub fn to_png<Writer: Write>(
             for y in 0..height {
                 for x in 0..width {
                     for c in 0..num_channels {
+                        // + 0.5 instead of round is fine since we clamp to non-negative
                         data[(y * width + x) * num_channels + c] =
-                            (frame.channels[c].as_rect().row(y)[x] * 255.0)
-                                .clamp(0.0, 255.0)
-                                .round() as u8;
+                            ((frame.channels[c].as_rect().row(y)[x] * 255.0).clamp(0.0, 255.0)
+                                + 0.5) as u8;
                     }
                 }
             }
@@ -176,9 +176,10 @@ pub fn to_png<Writer: Write>(
             for y in 0..height {
                 for x in 0..width {
                     for c in 0..num_channels {
-                        let pixel = (frame.channels[c].as_rect().row(y)[x] * 65535.0)
+                        // + 0.5 instead of round is fine since we clamp to non-negative
+                        let pixel = ((frame.channels[c].as_rect().row(y)[x] * 65535.0)
                             .clamp(0.0, 65535.0)
-                            .round() as u16;
+                            + 0.5) as u16;
                         let index = 2 * ((y * width + x) * num_channels + c);
                         data[index] = (pixel >> 8) as u8;
                         data[index + 1] = (pixel & 0xFF) as u8;

--- a/jxl_cli/src/enc/pnm.rs
+++ b/jxl_cli/src/enc/pnm.rs
@@ -24,7 +24,8 @@ impl ToU8ForWriting for u16 {
 
 impl ToU8ForWriting for f32 {
     fn to_u8_for_writing(self) -> u8 {
-        (self * 255.0).clamp(0.0, 255.0).round() as u8
+        // + 0.5 instead of round is fine since we clamp to non-negative
+        ((self * 255.0).clamp(0.0, 255.0) + 0.5) as u8
     }
 }
 


### PR DESCRIPTION
This makes jxl_cli about 6-8% faster when outputting to PPM, although the speedup when outputting to PNG seems negligible.