### PR TITLE
Use benchmark groups to group by DCT sizes and compare implementations

### DIFF
--- a/jxl/benches/dct.rs
+++ b/jxl/benches/dct.rs
@@ -3,22 +3,25 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::measurement::Measurement;
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main};
 use jxl::var_dct::dct::{DCT1D, DCT1DImpl, IDCT1D, IDCT1DImpl, compute_scaled_dct, idct2d};
 use jxl_simd::{SimdDescriptor, bench_all_instruction_sets};
 
-fn bench_idct2d<D: SimdDescriptor>(d: D, c: &mut Criterion, name: &str) {
+fn bench_idct2d<D: SimdDescriptor>(d: D, c: &mut BenchmarkGroup<'_, impl Measurement>, name: &str) {
     fn run_size<D: SimdDescriptor, const ROWS: usize, const COLS: usize>(
-        c: &mut Criterion,
+        c: &mut BenchmarkGroup<'_, impl Measurement>,
         d: D,
         name: &str,
     ) where
         IDCT1DImpl<ROWS>: IDCT1D,
         IDCT1DImpl<COLS>: IDCT1D,
     {
+        let id = BenchmarkId::new(name, format_args!("{ROWS}x{COLS}"));
+
         let mut data = vec![1.0; ROWS * COLS];
         let mut scratch = vec![0.0; ROWS * COLS];
-        c.bench_function(&format!("{name}_{ROWS}x{COLS}"), |b| {
+        c.bench_function(id, |b| {
             b.iter(|| {
                 d.call(|d| idct2d::<_, ROWS, COLS>(d, &mut data, &mut scratch));
             })
@@ -49,22 +52,28 @@ fn bench_idct2d<D: SimdDescriptor>(d: D, c: &mut Criterion, name: &str) {
     run_size::<_, 256, 256>(c, d, name);
 }
 
-fn bench_compute_scaled_dct<D: SimdDescriptor>(d: D, c: &mut Criterion, name: &str) {
+fn bench_compute_scaled_dct<D: SimdDescriptor>(
+    d: D,
+    c: &mut BenchmarkGroup<'_, impl Measurement>,
+    name: &str,
+) {
     fn run_size<D: SimdDescriptor, const ROWS: usize, const COLS: usize>(
-        c: &mut Criterion,
+        c: &mut BenchmarkGroup<'_, impl Measurement>,
         d: D,
         name: &str,
     ) where
         DCT1DImpl<ROWS>: DCT1D,
         DCT1DImpl<COLS>: DCT1D,
     {
+        let id = BenchmarkId::new(name, format_args!("{ROWS}x{COLS}"));
+
         let input_vec = vec![vec![1.0; COLS]; ROWS];
         let mut input = [[0.0; COLS]; ROWS];
         for (i, row) in input_vec.iter().enumerate() {
             input[i].copy_from_slice(row);
         }
         let mut output = vec![0.0; ROWS * COLS];
-        c.bench_function(&format!("{name}_{ROWS}x{COLS}"), |b| {
+        c.bench_function(id, |b| {
             b.iter(|| {
                 d.call(|d| compute_scaled_dct::<_, ROWS, COLS>(d, input, &mut output));
             })
@@ -85,17 +94,26 @@ fn bench_compute_scaled_dct<D: SimdDescriptor>(d: D, c: &mut Criterion, name: &s
 }
 
 fn idct_benches(c: &mut Criterion) {
-    bench_all_instruction_sets!(bench_idct2d, c);
+    let mut group = c.benchmark_group("idct2d");
+    let g = &mut group;
+
+    bench_all_instruction_sets!(bench_idct2d, g);
+
+    group.finish();
 }
 
 fn compute_scaled_dct_benches(c: &mut Criterion) {
-    bench_all_instruction_sets!(bench_compute_scaled_dct, c);
+    let mut group = c.benchmark_group("compute_scaled_dct");
+    let g = &mut group;
+
+    bench_all_instruction_sets!(bench_compute_scaled_dct, g);
+
+    group.finish();
 }
 
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(50);
-    targets = idct_benches,
-    compute_scaled_dct_benches
+    targets = idct_benches, compute_scaled_dct_benches
 );
 criterion_main!(benches);

--- a/jxl_simd/src/scalar.rs
+++ b/jxl_simd/src/scalar.rs
@@ -220,7 +220,7 @@ macro_rules! bench_all_instruction_sets {
         $name(
             $crate::ScalarDescriptor::new().unwrap(),
             $criterion,
-            &format!("{}_scalar", stringify!($name)),
+            "scalar",
         );
     };
 }

--- a/jxl_simd/src/x86_64/mod.rs
+++ b/jxl_simd/src/x86_64/mod.rs
@@ -95,26 +95,36 @@ macro_rules! bench_all_instruction_sets {
             #[target_feature(enable = "avx512f")]
             fn inner(
                 d: $crate::Avx512Descriptor,
-                criterion: &mut criterion::Criterion,
+                criterion: &mut ::criterion::BenchmarkGroup<
+                    '_,
+                    impl ::criterion::measurement::Measurement,
+                >,
                 name: &str,
             ) {
                 $name(d, criterion, name)
             }
             // SAFETY: we just checked for avx512f.
-            unsafe { inner(d, $criterion, &format!("{}_avx512", stringify!($name))) };
+            unsafe { inner(d, $criterion, "avx512") };
         }
         if let Some(d) = $crate::AvxDescriptor::new() {
             #[target_feature(enable = "avx2,fma")]
-            fn inner(d: $crate::AvxDescriptor, criterion: &mut criterion::Criterion, name: &str) {
+            fn inner(
+                d: $crate::AvxDescriptor,
+                criterion: &mut ::criterion::BenchmarkGroup<
+                    '_,
+                    impl ::criterion::measurement::Measurement,
+                >,
+                name: &str,
+            ) {
                 $name(d, criterion, name)
             }
             // SAFETY: we just checked for avx2 and fma.
-            unsafe { inner(d, $criterion, &format!("{}_avx", stringify!($name))) };
+            unsafe { inner(d, $criterion, "avx") };
         }
         $name(
             $crate::ScalarDescriptor::new().unwrap(),
             $criterion,
-            &format!("{}_scalar", stringify!($name)),
+            "scalar",
         );
     };
 }


### PR DESCRIPTION
Benchmark groups give nice-looking criterion.rs report like this:

<img width="1800" height="1800" alt="benchmark index" src="https://github.com/user-attachments/assets/221dab1c-d48a-4397-8097-7b3a9c74c483" />

<img width="2000" height="720" alt="violin plot" src="https://github.com/user-attachments/assets/2b980961-1be0-446a-93da-2ed5d23fc463" />
