### PR TITLE
Let `Image`s have a "default rect".

### DIFF
--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -120,8 +120,6 @@ pub enum Error {
     ImageSizeTooLarge(usize, usize),
     #[error("Invalid image size: {0}x{1}")]
     InvalidImageSize(usize, usize),
-    #[error("Rect out of bounds: {0}x{1}+{2}+{3} rect in {4}x{5} view")]
-    RectOutOfBounds(usize, usize, usize, usize, usize, usize),
     // Generic arithmetic overflow. Prefer using other errors if possible.
     #[error("Arithmetic overflow")]
     ArithmeticOverflow,

--- a/jxl/src/features/patches.rs
+++ b/jxl/src/features/patches.rs
@@ -726,12 +726,10 @@ impl PatchesDictionary {
 
             for (c, fg_ptr) in fg.iter_mut().enumerate().take(3) {
                 *fg_ptr = &(reference_frames[ref_pos.reference].as_ref().unwrap().frame[c]
-                    .as_rect()
                     .row(ref_pos_y)[ref_x0..ref_x1]);
             }
             for i in 0..num_ec {
                 fg[3 + i] = &(reference_frames[ref_pos.reference].as_ref().unwrap().frame[3 + i]
-                    .as_rect()
                     .row(ref_pos_y)[ref_x0..ref_x1]);
             }
 
@@ -1473,7 +1471,7 @@ mod tests {
             let mut frame_channels = Vec::new();
             for v in rows.iter() {
                 let mut img = Image::new((N, 1))?;
-                img.as_rect_mut().row(0).copy_from_slice(v);
+                img.row_mut(0).copy_from_slice(v);
                 frame_channels.push(img);
             }
             Ok(Some(ReferenceFrame {

--- a/jxl/src/frame/adaptive_lf_smoothing.rs
+++ b/jxl/src/frame/adaptive_lf_smoothing.rs
@@ -49,16 +49,13 @@ pub fn adaptive_lf_smoothing(lf_factors: [f32; 3], lf_image: &mut [Image<f32>; 3
     ];
     for c in 0..3 {
         for y in [0, ysize - 1] {
-            smoothed[c]
-                .as_rect_mut()
-                .row(y)
-                .copy_from_slice(lf_image[c].as_rect().row(y));
+            smoothed[c].row_mut(y).copy_from_slice(lf_image[c].row(y));
         }
     }
     for y in 1..ysize - 1 {
         for x in [0, xsize - 1] {
             for c in 0..3 {
-                smoothed[c].as_rect_mut().row(y)[x] = lf_image[c].as_rect().row(y)[x];
+                smoothed[c].row_mut(y)[x] = lf_image[c].row(y)[x];
             }
         }
         for x in 1..xsize - 1 {
@@ -67,30 +64,30 @@ pub fn adaptive_lf_smoothing(lf_factors: [f32; 3], lf_image: &mut [Image<f32>; 3
                 lf_factors[0],
                 gap,
                 x,
-                lf_image[0].as_rect().row(y - 1),
-                lf_image[0].as_rect().row(y),
-                lf_image[0].as_rect().row(y + 1),
+                lf_image[0].row(y - 1),
+                lf_image[0].row(y),
+                lf_image[0].row(y + 1),
             );
             let (mc_y, sm_y, gap) = compute_pixel_channel(
                 lf_factors[1],
                 gap,
                 x,
-                lf_image[1].as_rect().row(y - 1),
-                lf_image[1].as_rect().row(y),
-                lf_image[1].as_rect().row(y + 1),
+                lf_image[1].row(y - 1),
+                lf_image[1].row(y),
+                lf_image[1].row(y + 1),
             );
             let (mc_b, sm_b, gap) = compute_pixel_channel(
                 lf_factors[2],
                 gap,
                 x,
-                lf_image[2].as_rect().row(y - 1),
-                lf_image[2].as_rect().row(y),
-                lf_image[2].as_rect().row(y + 1),
+                lf_image[2].row(y - 1),
+                lf_image[2].row(y),
+                lf_image[2].row(y + 1),
             );
             let factor = (3.0 - 4.0 * gap).max(0.0);
-            smoothed[0].as_rect_mut().row(y)[x] = (sm_x - mc_x) * factor + mc_x;
-            smoothed[1].as_rect_mut().row(y)[x] = (sm_y - mc_y) * factor + mc_y;
-            smoothed[2].as_rect_mut().row(y)[x] = (sm_b - mc_b) * factor + mc_b;
+            smoothed[0].row_mut(y)[x] = (sm_x - mc_x) * factor + mc_x;
+            smoothed[1].row_mut(y)[x] = (sm_y - mc_y) * factor + mc_y;
+            smoothed[2].row_mut(y)[x] = (sm_b - mc_b) * factor + mc_b;
         }
     }
     *lf_image = smoothed;

--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -380,14 +380,13 @@ impl Frame {
             let bits_to_float = |bits: u32| f32::from_bits((bits >> 9) | 0x3F800000);
             for i in 0..3 {
                 let mut buf = pipeline!(self, p, p.get_buffer_for_group(num_channels + i, group)?);
-                let mut rect = buf.as_rect_mut();
-                let (xsize, ysize) = rect.size();
+                let (xsize, ysize) = buf.size();
                 const FLOATS_PER_BATCH: usize =
                     Xorshift128Plus::N * std::mem::size_of::<u64>() / std::mem::size_of::<f32>();
                 let mut batch = [0u64; Xorshift128Plus::N];
 
                 for y in 0..ysize {
-                    let row = rect.row(y);
+                    let row = buf.row_mut(y);
                     for batch_index in 0..xsize.div_ceil(FLOATS_PER_BATCH) {
                         rng.fill(&mut batch);
                         let batch_size =

--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -413,8 +413,8 @@ mod test {
                 panic!("no lf_image");
             };
             for y in 0..146 {
-                let sample_cb_row = lf_image[0].as_rect().row(y);
-                let sample_cr_row = lf_image[2].as_rect().row(y);
+                let sample_cb_row = lf_image[0].row(y);
+                let sample_cr_row = lf_image[2].row(y);
                 for x in 0..146 {
                     let sample_cb = sample_cb_row[x];
                     let sample_cr = sample_cr_row[x];

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -8,7 +8,7 @@ use std::array::from_fn;
 use crate::{
     error::{Error, Result},
     headers::modular::WeightedHeader,
-    image::{Image, ImageRect},
+    image::Image,
     util::floor_log2_nonzero,
 };
 use num_derive::FromPrimitive;
@@ -64,7 +64,7 @@ pub struct PredictionData {
 }
 
 impl PredictionData {
-    pub fn get(rect: ImageRect<i32>, x: usize, y: usize) -> Self {
+    pub fn get(rect: &Image<i32>, x: usize, y: usize) -> Self {
         let left = if x > 0 {
             rect.row(y)[x - 1]
         } else if y > 0 {
@@ -103,12 +103,12 @@ impl PredictionData {
 
     #[allow(clippy::too_many_arguments)]
     pub fn get_with_neighbors(
-        rect: ImageRect<i32>,
-        rect_left: Option<ImageRect<i32>>,
-        rect_top: Option<ImageRect<i32>>,
-        rect_top_left: Option<ImageRect<i32>>,
-        rect_right: Option<ImageRect<i32>>,
-        rect_top_right: Option<ImageRect<i32>>,
+        rect: &Image<i32>,
+        rect_left: Option<&Image<i32>>,
+        rect_top: Option<&Image<i32>>,
+        rect_top_left: Option<&Image<i32>>,
+        rect_right: Option<&Image<i32>>,
+        rect_top_right: Option<&Image<i32>>,
         x: usize,
         y: usize,
         xsize: usize,
@@ -341,13 +341,12 @@ impl<'a> WeightedPredictorState<'a> {
 
     pub fn save_state(&self, wp_image: &mut Image<i32>, xsize: usize) {
         wp_image
-            .as_rect_mut()
-            .row(0)
+            .row_mut(0)
             .copy_from_slice(&self.error[xsize + 2..]);
     }
 
     pub fn restore_state(&mut self, wp_image: &Image<i32>, xsize: usize) {
-        self.error[xsize + 2..].copy_from_slice(wp_image.as_rect().row(0));
+        self.error[xsize + 2..].copy_from_slice(wp_image.row(0));
     }
 
     pub fn update_errors(&mut self, correct_val: i32, pos: (usize, usize), xsize: usize) {

--- a/jxl/src/frame/modular/transforms/rct.rs
+++ b/jxl/src/frame/modular/transforms/rct.rs
@@ -20,8 +20,6 @@ pub fn do_rct_step(buffers: &mut [&mut ModularChannel], op: RctOp, perm: RctPerm
         unreachable!("incorrect buffer count for RCT");
     };
 
-    let buffers = [r, g, b];
-
     'rct: {
         let apply_rct: fn(i32, i32, i32) -> (i32, i32, i32) = match op {
             RctOp::Noop => break 'rct,
@@ -47,17 +45,17 @@ pub fn do_rct_step(buffers: &mut [&mut ModularChannel], op: RctOp, perm: RctPerm
         };
 
         for pos_y in 0..size.1 {
+            let rows = [&mut **r, &mut **g, &mut **b].map(|x| x.data.row_mut(pos_y));
+            #[allow(clippy::needless_range_loop)]
             for pos_x in 0..size.0 {
-                let [v0, v1, v2] = [0, 1, 2].map(|x| buffers[x].data.as_rect().row(pos_y)[pos_x]);
+                let [v0, v1, v2] = [0, 1, 2].map(|c| rows[c][pos_x]);
                 let (w0, w1, w2) = apply_rct(v0, v1, v2);
-                for (i, p) in [w0, w1, w2].iter().enumerate() {
-                    buffers[i].data.as_rect_mut().row(pos_y)[pos_x] = *p;
+                for (c, p) in [w0, w1, w2].iter().enumerate() {
+                    rows[c][pos_x] = *p;
                 }
             }
         }
     }
-
-    let [r, g, b] = buffers;
 
     // Note: Gbr and Brg use the *inverse* permutation compared to libjxl, because we *first* write
     // to the buffers and then permute them, while in libjxl the buffers to be written to are

--- a/jxl/src/frame/modular/tree.rs
+++ b/jxl/src/frame/modular/tree.rs
@@ -222,7 +222,7 @@ impl Tree {
         property_buffer: &mut [i32],
     ) -> PredictionResult {
         let img = &buffers[index].data;
-        let prediction_data = PredictionData::get(img.as_rect(), x, y);
+        let prediction_data = PredictionData::get(img, x, y);
         let PredictionData {
             left,
             top,
@@ -269,7 +269,7 @@ impl Tree {
         let num_refs = references.size().0;
         if num_refs != 0 {
             let ref_properties = &mut property_buffer[NUM_NONREF_PROPERTIES..];
-            ref_properties[..num_refs].copy_from_slice(&references.as_rect().row(x)[..num_refs]);
+            ref_properties[..num_refs].copy_from_slice(&references.row(x)[..num_refs]);
         }
 
         trace!(?property_buffer, "new properties");

--- a/jxl/src/frame/quant_weights.rs
+++ b/jxl/src/frame/quant_weights.rs
@@ -22,6 +22,7 @@ use crate::{
         modular::{ModularChannel, ModularStreamId, decode::decode_modular_subbitstream},
     },
     headers::{bit_depth::BitDepth, frame_header::FrameHeader},
+    image::Rect,
 };
 use jxl_transforms::transform_map::*;
 
@@ -254,7 +255,14 @@ impl QuantEncoding {
                 )?;
                 let mut qtable = Vec::with_capacity(required_size_x * required_size_y * 3);
                 for channel in image.iter_mut() {
-                    for entry in channel.data.as_rect().iter() {
+                    for entry in channel
+                        .data
+                        .get_rect(Rect {
+                            size: (required_size_x, required_size_y),
+                            origin: (0, 0),
+                        })
+                        .iter()
+                    {
                         qtable.push(entry);
                         if entry <= 0 {
                             return Err(InvalidRawQuantTable);

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -14,6 +14,7 @@ use crate::error::{Error, Result};
 use crate::features::epf::create_sigma_image;
 use crate::headers::frame_header::Encoding;
 use crate::headers::{Orientation, color_encoding::ColorSpace, extra_channels::ExtraChannel};
+use crate::image::Rect;
 use crate::render::{
     LowMemoryRenderPipeline, RenderPipeline, RenderPipelineBuilder, SimpleRenderPipeline, stages::*,
 };
@@ -87,16 +88,24 @@ impl Frame {
 
         if let Some(ref_images) = &mut self.reference_frame_data {
             buffers.extend(ref_images.iter_mut().map(|img| {
+                let rect = Rect {
+                    size: img.size(),
+                    origin: (0, 0),
+                };
                 Some(JxlOutputBuffer::from_image_rect_mut(
-                    img.as_rect_mut().into_raw(),
+                    img.get_rect_mut(rect).into_raw(),
                 ))
             }));
         };
 
         if let Some(lf_images) = &mut self.lf_frame_data {
             buffers.extend(lf_images.iter_mut().map(|img| {
+                let rect = Rect {
+                    size: img.size(),
+                    origin: (0, 0),
+                };
                 Some(JxlOutputBuffer::from_image_rect_mut(
-                    img.as_rect_mut().into_raw(),
+                    img.get_rect_mut(rect).into_raw(),
                 ))
             }));
         };

--- a/jxl/src/image/internal.rs
+++ b/jxl/src/image/internal.rs
@@ -170,6 +170,10 @@ impl RawImageBuffer {
         if rect.size.0 == 0 || rect.size.1 == 0 {
             return Self::empty();
         }
+        // More helpful message in debug builds (not needed for safety).
+        if cfg!(debug_assertions) {
+            rect.check_within(self.byte_size());
+        }
         assert!(rect.origin.1 < self.num_rows);
         assert!(rect.origin.1.checked_add(rect.size.1).unwrap() <= self.num_rows);
         assert!(rect.origin.0 < self.bytes_per_row);

--- a/jxl/src/image/rect.rs
+++ b/jxl/src/image/rect.rs
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use crate::error::{Error, Result};
-
 use super::DataTypeTag;
 
 #[derive(Clone, Copy, Debug)]
@@ -15,30 +13,14 @@ pub struct Rect {
 }
 
 impl Rect {
-    pub fn is_within(&self, size: (usize, usize)) -> Result<()> {
-        if self
-            .origin
-            .0
-            .checked_add(self.size.0)
-            .ok_or(Error::ArithmeticOverflow)?
-            > size.0
-            || self
-                .origin
-                .1
-                .checked_add(self.size.1)
-                .ok_or(Error::ArithmeticOverflow)?
-                > size.1
+    pub fn check_within(&self, size: (usize, usize)) {
+        if self.origin.0.checked_add(self.size.0).unwrap() > size.0
+            || self.origin.1.checked_add(self.size.1).unwrap() > size.1
         {
-            Err(Error::RectOutOfBounds(
-                self.size.0,
-                self.size.1,
-                self.origin.0,
-                self.origin.1,
-                size.0,
-                size.1,
-            ))
-        } else {
-            Ok(())
+            panic!(
+                "Rect out of bounds: {}x{}+{}+{} rect in {}x{} view",
+                self.size.0, self.size.1, self.origin.0, self.origin.1, size.0, size.1
+            );
         }
     }
 

--- a/jxl/src/image/test.rs
+++ b/jxl/src/image/test.rs
@@ -14,10 +14,7 @@ impl<T: ImageDataType> Image<T> {
     pub fn new_random<R: rand::Rng>(size: (usize, usize), rng: &mut R) -> Result<Image<T>> {
         let mut img = Self::new(size)?;
         for y in 0..size.1 {
-            img.as_rect_mut()
-                .row(y)
-                .iter_mut()
-                .for_each(|x| *x = T::random(rng));
+            img.row_mut(y).iter_mut().for_each(|x| *x = T::random(rng));
         }
         Ok(img)
     }
@@ -26,13 +23,9 @@ impl<T: ImageDataType> Image<T> {
     pub fn new_range(size: (usize, usize), start: f32, step: f32) -> Result<Image<T>> {
         let mut img = Self::new(size)?;
         for y in 0..size.1 {
-            img.as_rect_mut()
-                .row(y)
-                .iter_mut()
-                .enumerate()
-                .for_each(|(x, val)| {
-                    *val = T::from_f64((start + step * (y * size.0 + x) as f32) as f64)
-                });
+            img.row_mut(y).iter_mut().enumerate().for_each(|(x, val)| {
+                *val = T::from_f64((start + step * (y * size.0 + x) as f32) as f64)
+            });
         }
         Ok(img)
     }
@@ -48,41 +41,29 @@ fn rect_basic() -> Result<()> {
     let mut image = Image::<u8>::new((32, 42))?;
     assert_eq!(
         image
-            .as_rect_mut()
-            .rect(Rect {
+            .get_rect_mut(Rect {
                 origin: (31, 40),
                 size: (1, 1)
-            })?
+            })
             .size(),
         (1, 1)
     );
     assert_eq!(
         image
-            .as_rect_mut()
-            .rect(Rect {
+            .get_rect_mut(Rect {
                 origin: (0, 0),
                 size: (1, 1)
-            })?
+            })
             .size(),
         (1, 1)
     );
-    assert!(
-        image
-            .as_rect_mut()
-            .rect(Rect {
-                origin: (30, 30),
-                size: (3, 3)
-            })
-            .is_err()
-    );
     image
-        .as_rect_mut()
-        .rect(Rect {
+        .get_rect_mut(Rect {
             origin: (30, 30),
             size: (1, 1),
-        })?
+        })
         .row(0)[0] = 1;
-    assert_eq!(image.as_rect_mut().row(30)[30], 1);
+    assert_eq!(image.row(30)[30], 1);
     Ok(())
 }
 

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -14,8 +14,9 @@ use crate::api::JxlOutputBuffer;
 use crate::error::Result;
 use crate::headers::Orientation;
 use crate::image::{Image, ImageDataType, OwnedRawImage, Rect};
+use crate::render::MAX_BORDER;
 use crate::render::internal::Stage;
-use crate::util::{CACHE_LINE_BYTE_SIZE, ShiftRightCeil, tracing_wrappers::*};
+use crate::util::{ShiftRightCeil, tracing_wrappers::*};
 
 use super::RenderPipeline;
 use super::internal::{RenderPipelineShared, RunInOutStage, RunInPlaceStage};
@@ -323,10 +324,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
         }
         border_pixels_per_stage.reverse();
 
-        for c in 0..nc {
-            let (bx, _) = border_pixels_per_stage[0];
-            assert!(bx * shared.channel_info[0][c].ty.unwrap().size() <= 2 * CACHE_LINE_BYTE_SIZE);
-        }
+        assert!(border_pixels_per_stage[0].0 <= MAX_BORDER);
 
         let downsampling_for_stage = shared
             .stages

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -93,27 +93,18 @@ impl LowMemoryRenderPipeline {
 
         // Previous group horizontally, if any.
         if gx > 0 && extrax != 0 {
-            let input_buf = self.input_buffers[base_gid - 1].data[c]
-                .as_ref()
-                .unwrap()
-                .as_rect();
+            let input_buf = self.input_buffers[base_gid - 1].data[c].as_ref().unwrap();
             let input_row = input_buf.row(input_y);
             output_row[x0_offset - extrax..x0_offset]
                 .copy_from_slice(&input_row[input_buf.byte_size().0 - extrax..]);
         }
-        let input_buf = self.input_buffers[base_gid].data[c]
-            .as_ref()
-            .unwrap()
-            .as_rect();
+        let input_buf = self.input_buffers[base_gid].data[c].as_ref().unwrap();
         let input_row = input_buf.row(input_y);
         let gxs = input_buf.byte_size().0; // bytes
         output_row[x0_offset..x0_offset + gxs].copy_from_slice(input_row);
         // Next group horizontally, if any.
         if gx + 1 < self.shared.group_count.0 && extrax != 0 {
-            let input_buf = &self.input_buffers[base_gid + 1].data[c]
-                .as_ref()
-                .unwrap()
-                .as_rect();
+            let input_buf = self.input_buffers[base_gid + 1].data[c].as_ref().unwrap();
             let input_row = input_buf.row(input_y);
             output_row[gxs + x0_offset..gxs + x0_offset + extrax]
                 .copy_from_slice(&input_row[..extrax]);

--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -9,7 +9,8 @@ use std::any::Any;
 use crate::{
     api::JxlOutputBuffer,
     error::Result,
-    image::{Image, ImageDataType},
+    image::{DataTypeTag, Image, ImageDataType},
+    util::CACHE_LINE_BYTE_SIZE,
 };
 
 mod builder;
@@ -20,6 +21,24 @@ mod simple_pipeline;
 pub mod stages;
 #[cfg(test)]
 mod test;
+
+const MAX_BORDER: usize = 9;
+
+pub const fn input_image_offset_tag(tag: DataTypeTag) -> (usize, usize) {
+    (CACHE_LINE_BYTE_SIZE / tag.size(), MAX_BORDER)
+}
+
+pub const fn input_image_offset<T: ImageDataType>() -> (usize, usize) {
+    input_image_offset_tag(T::DATA_TYPE_ID)
+}
+
+pub const fn input_image_total_padding_tag(tag: DataTypeTag) -> (usize, usize) {
+    (4 * CACHE_LINE_BYTE_SIZE / tag.size(), MAX_BORDER * 2)
+}
+
+pub const fn input_image_total_padding<T: ImageDataType>() -> (usize, usize) {
+    input_image_total_padding_tag(T::DATA_TYPE_ID)
+}
 
 pub(crate) use builder::RenderPipelineBuilder;
 pub(crate) use low_memory_pipeline::LowMemoryRenderPipeline;

--- a/jxl/src/render/simple_pipeline/extend.rs
+++ b/jxl/src/render/simple_pipeline/extend.rs
@@ -51,10 +51,9 @@ impl ExtendToImageDimensionsStage {
         for c in 0..numc {
             for in_y in in_y0..in_y1 {
                 debug!("copy row: {in_y}");
-                let in_row = input_buffers[c].as_rect().row(in_y);
+                let in_row = input_buffers[c].row(in_y);
                 let y = (in_y as isize + origin.1) as usize;
-                output_buffers[c].as_rect_mut().row(y)[x0..x1]
-                    .copy_from_slice(&in_row[in_x0..in_x1]);
+                output_buffers[c].row_mut(y)[x0..x1].copy_from_slice(&in_row[in_x0..in_x1]);
             }
         }
         // Fill in rows above and below the original data.
@@ -66,7 +65,7 @@ impl ExtendToImageDimensionsStage {
                 for (c, buf) in output_buffers.iter_mut().enumerate() {
                     self.process_row_chunk((x, y), xsize, c, &mut buffer);
                     for (ix, px) in buffer.iter().enumerate().take(xsize) {
-                        buf.as_rect_mut().row(y)[x + ix] = px.to_f64();
+                        buf.row_mut(y)[x + ix] = px.to_f64();
                     }
                 }
             }
@@ -86,7 +85,7 @@ impl ExtendToImageDimensionsStage {
                 for (c, buf) in output_buffers.iter_mut().enumerate() {
                     self.process_row_chunk((x, y), xsize, c, &mut buffer);
                     for (ix, px) in buffer.iter().enumerate().take(xsize) {
-                        buf.as_rect_mut().row(y)[x + ix] = px.to_f64();
+                        buf.row_mut(y)[x + ix] = px.to_f64();
                     }
                 }
             }

--- a/jxl/src/render/simple_pipeline/mod.rs
+++ b/jxl/src/render/simple_pipeline/mod.rs
@@ -98,8 +98,7 @@ impl RenderPipeline for SimpleRenderPipeline {
         assert_eq!(ty, T::DATA_TYPE_ID);
         for y in 0..sz.1 {
             for x in 0..sz.0 {
-                self.input_buffers[channel].as_rect_mut().row(y + off.1)[x + off.0] =
-                    buf.as_rect().row(y)[x].to_f64();
+                self.input_buffers[channel].row_mut(y + off.1)[x + off.0] = buf.row(y)[x].to_f64();
             }
         }
         self.shared.group_chan_ready_passes[group_id][channel] += num_passes;

--- a/jxl/src/render/simple_pipeline/run_stage.rs
+++ b/jxl/src/render/simple_pipeline/run_stage.rs
@@ -47,8 +47,7 @@ impl<T: RenderPipelineInPlaceStage> RunInPlaceStage<Image<f64>> for T {
                 let xsize = size.0.min(x + chunk_size) - x;
                 debug!("position: {x}x{y} xsize: {xsize}");
                 for c in 0..numc {
-                    let in_rect = buffers[c].as_rect();
-                    let in_row = in_rect.row(y);
+                    let in_row = buffers[c].row(y);
                     for ix in 0..xsize {
                         buffer[c][ix] = T::Type::from_f64(in_row[x + ix]);
                     }
@@ -56,8 +55,7 @@ impl<T: RenderPipelineInPlaceStage> RunInPlaceStage<Image<f64>> for T {
                 let mut row: Vec<_> = buffer.iter_mut().map(|x| x as &mut [_]).collect();
                 self.process_row_chunk((x, y), xsize, &mut row, state.as_deref_mut());
                 for c in 0..numc {
-                    let mut out_rect = buffers[c].as_rect_mut();
-                    let out_row = out_rect.row(y);
+                    let out_row = buffers[c].row_mut(y);
                     for ix in 0..xsize {
                         out_row[x + ix] = buffer[c][ix].to_f64();
                     }
@@ -143,10 +141,9 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<Image<f64>> for T {
                 let xs = xsize as i64;
                 debug!("position: {x}x{y} xsize: {xsize}");
                 for c in 0..numc {
-                    let in_rect = input_buffers[c].as_rect();
                     for iy in -border_y..=border_y {
                         let imgy = mirror(y as i64 + iy, input_size.1 as i64);
-                        let in_row = in_rect.row(imgy);
+                        let in_row = input_buffers[c].row(imgy);
                         let buf_in_row = &mut buffer_in[c][(iy + border_y) as usize];
                         for ix in (-border_x..0).chain(xs..xs + border_x) {
                             let imgx = mirror(x as i64 + ix, input_size.0 as i64);
@@ -182,9 +179,8 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<Image<f64>> for T {
                 let stripe_ysize =
                     (1usize << Self::SHIFT.1).min(output_size.1 - (y << Self::SHIFT.1));
                 for c in 0..numc {
-                    let mut out_rect = output_buffers[c].as_rect_mut();
                     for iy in 0..stripe_ysize {
-                        let out_row = out_rect.row((y << Self::SHIFT.1) + iy);
+                        let out_row = output_buffers[c].row_mut((y << Self::SHIFT.1) + iy);
                         for ix in 0..stripe_xsize {
                             out_row[(x << Self::SHIFT.0) + ix] = buffer_out[c][iy][ix].to_f64();
                         }

--- a/jxl/src/render/stages/blending.rs
+++ b/jxl/src/render/stages/blending.rs
@@ -126,7 +126,6 @@ impl RenderPipelineInPlaceStage for BlendingStage {
                     .as_ref()
                     .unwrap()
                     .frame[c]
-                    .as_rect()
                     .row(fg_y0)[fg_x0..fg_x1]);
             }
         }
@@ -136,7 +135,6 @@ impl RenderPipelineInPlaceStage for BlendingStage {
                     .as_ref()
                     .unwrap()
                     .frame[3 + i]
-                    .as_rect()
                     .row(fg_y0)[fg_x0..fg_x1]);
             }
         }

--- a/jxl/src/render/stages/chroma_upsample.rs
+++ b/jxl/src/render/stages/chroma_upsample.rs
@@ -122,14 +122,11 @@ mod test {
     #[test]
     fn test_hchr() -> Result<()> {
         let mut input = Image::new((3, 1))?;
-        input
-            .as_rect_mut()
-            .row(0)
-            .copy_from_slice(&[1.0f32, 2.0, 4.0]);
+        input.row_mut(0).copy_from_slice(&[1.0f32, 2.0, 4.0]);
         let stage = HorizontalChromaUpsample::new(0);
         let output: Vec<Image<f32>> =
             make_and_run_simple_pipeline(stage, &[input], (6, 1), 0, 256)?;
-        assert_eq!(output[0].as_rect().row(0), [1.0, 1.25, 1.75, 2.5, 3.5, 4.0]);
+        assert_eq!(output[0].row(0), [1.0, 1.25, 1.75, 2.5, 3.5, 4.0]);
         Ok(())
     }
 
@@ -145,18 +142,18 @@ mod test {
     #[test]
     fn test_vchr() -> Result<()> {
         let mut input = Image::new((1, 3))?;
-        input.as_rect_mut().row(0)[0] = 1.0f32;
-        input.as_rect_mut().row(1)[0] = 2.0f32;
-        input.as_rect_mut().row(2)[0] = 4.0f32;
+        input.row_mut(0)[0] = 1.0f32;
+        input.row_mut(1)[0] = 2.0f32;
+        input.row_mut(2)[0] = 4.0f32;
         let stage = VerticalChromaUpsample::new(0);
         let output: Vec<Image<f32>> =
             make_and_run_simple_pipeline(stage, &[input], (1, 6), 0, 256)?;
-        assert_eq!(output[0].as_rect().row(0)[0], 1.0);
-        assert_eq!(output[0].as_rect().row(1)[0], 1.25);
-        assert_eq!(output[0].as_rect().row(2)[0], 1.75);
-        assert_eq!(output[0].as_rect().row(3)[0], 2.5);
-        assert_eq!(output[0].as_rect().row(4)[0], 3.5);
-        assert_eq!(output[0].as_rect().row(5)[0], 4.0);
+        assert_eq!(output[0].row(0)[0], 1.0);
+        assert_eq!(output[0].row(1)[0], 1.25);
+        assert_eq!(output[0].row(2)[0], 1.75);
+        assert_eq!(output[0].row(3)[0], 2.5);
+        assert_eq!(output[0].row(4)[0], 3.5);
+        assert_eq!(output[0].row(5)[0], 4.0);
         Ok(())
     }
 }

--- a/jxl/src/render/stages/epf/epf0.rs
+++ b/jxl/src/render/stages/epf/epf0.rs
@@ -66,7 +66,7 @@ simd_function!(
     assert_eq!(input_rows.len(), 3);
     assert_eq!(output_rows.len(), 3);
 
-    let row_sigma = stage.sigma.as_rect().row(ypos / BLOCK_DIM);
+    let row_sigma = stage.sigma.row(ypos / BLOCK_DIM);
 
     const { assert!(D::F32Vec::LEN <= 16) };
 

--- a/jxl/src/render/stages/epf/epf1.rs
+++ b/jxl/src/render/stages/epf/epf1.rs
@@ -66,7 +66,7 @@ fn epf1_process_row_chunk(
     assert_eq!(input_rows.len(), 3);
     assert_eq!(output_rows.len(), 3);
 
-    let row_sigma = stage.sigma.as_rect().row(ypos / BLOCK_DIM);
+    let row_sigma = stage.sigma.row(ypos / BLOCK_DIM);
 
     let sm = stage.sigma_scale * 1.65;
     let bsm = sm * stage.border_sad_mul;

--- a/jxl/src/render/stages/epf/epf2.rs
+++ b/jxl/src/render/stages/epf/epf2.rs
@@ -68,7 +68,7 @@ fn epf2_process_row_chunk(
         panic!("Expected 3 channels, got {}", input_rows.len());
     };
 
-    let row_sigma = stage.sigma.as_rect().row(ypos / BLOCK_DIM);
+    let row_sigma = stage.sigma.row(ypos / BLOCK_DIM);
 
     const { assert!(D::F32Vec::LEN <= 16) };
 

--- a/jxl/src/render/stages/extend.rs
+++ b/jxl/src/render/stages/extend.rs
@@ -75,7 +75,7 @@ impl ExtendToImageDimensionsStage {
             self.ec_blending_info[c - 3].source as usize
         };
         let bg = if let Some(bg) = self.reference_frames[source].as_ref() {
-            bg.frame[c].as_rect().row(y0)
+            bg.frame[c].row(y0)
         } else {
             self.zeros.as_slice()
         };

--- a/jxl/src/render/stages/from_linear.rs
+++ b/jxl/src/render/stages/from_linear.rs
@@ -241,9 +241,9 @@ mod test {
         let output =
             make_and_run_simple_pipeline(stage, &[input_r, input_g, input_b], (1, 1), 0, 256)?;
 
-        assert_all_almost_abs_eq(output[0].as_rect().row(0), &[0.75], 1e-3);
-        assert_all_almost_abs_eq(output[1].as_rect().row(0), &[0.75], 1e-3);
-        assert_all_almost_abs_eq(output[2].as_rect().row(0), &[0.75], 1e-3);
+        assert_all_almost_abs_eq(output[0].row(0), &[0.75], 1e-3);
+        assert_all_almost_abs_eq(output[1].row(0), &[0.75], 1e-3);
+        assert_all_almost_abs_eq(output[2].row(0), &[0.75], 1e-3);
 
         Ok(())
     }
@@ -260,9 +260,9 @@ mod test {
         let output =
             make_and_run_simple_pipeline(stage, &[input_r, input_g, input_b], (1, 1), 0, 256)?;
 
-        assert_all_almost_abs_eq(output[0].as_rect().row(0), &[0.58], 1e-3);
-        assert_all_almost_abs_eq(output[1].as_rect().row(0), &[0.58], 1e-3);
-        assert_all_almost_abs_eq(output[2].as_rect().row(0), &[0.58], 1e-3);
+        assert_all_almost_abs_eq(output[0].row(0), &[0.58], 1e-3);
+        assert_all_almost_abs_eq(output[1].row(0), &[0.58], 1e-3);
+        assert_all_almost_abs_eq(output[2].row(0), &[0.58], 1e-3);
 
         Ok(())
     }

--- a/jxl/src/render/stages/gaborish.rs
+++ b/jxl/src/render/stages/gaborish.rs
@@ -131,15 +131,14 @@ mod test {
     #[test]
     fn checkerboard() -> Result<()> {
         let mut image = Image::new((2, 2))?;
-        image.as_rect_mut().row(0).copy_from_slice(&[0.0, 1.0]);
-        image.as_rect_mut().row(1).copy_from_slice(&[1.0, 0.0]);
+        image.row_mut(0).copy_from_slice(&[0.0, 1.0]);
+        image.row_mut(1).copy_from_slice(&[1.0, 0.0]);
 
         let stage = GaborishStage::new(0, 0.115169525, 0.061248592);
         let output = make_and_run_simple_pipeline(stage, &[image], (2, 2), 0, 256)?;
-        let output = output[0].as_rect();
 
-        assert_all_almost_abs_eq(output.row(0), &[0.20686048, 0.7931395], 1e-6);
-        assert_all_almost_abs_eq(output.row(1), &[0.7931395, 0.20686048], 1e-6);
+        assert_all_almost_abs_eq(output[0].row(0), &[0.20686048, 0.7931395], 1e-6);
+        assert_all_almost_abs_eq(output[0].row(1), &[0.7931395, 0.20686048], 1e-6);
 
         Ok(())
     }

--- a/jxl/src/render/stages/nearest_neighbor.rs
+++ b/jxl/src/render/stages/nearest_neighbor.rs
@@ -83,8 +83,8 @@ mod test {
             for x in 0..image_size.0 {
                 let ix = x / 2;
                 let iy = y / 2;
-                let i = input[0].as_rect().row(iy)[ix];
-                let o = output[0].as_rect().row(y)[x];
+                let i = input[0].row(iy)[ix];
+                let o = output[0].row(y)[x];
                 assert_eq!(
                     i, o,
                     "mismatch at output position {x}x{y}: {i} vs output {o}"

--- a/jxl/src/render/stages/noise.rs
+++ b/jxl/src/render/stages/noise.rs
@@ -165,11 +165,10 @@ mod test {
         let stage = ConvolveNoiseStage::new(0);
         let output: Vec<Image<f32>> =
             make_and_run_simple_pipeline(stage, &[input], (2, 2), 0, 256)?;
-        let rect = output[0].as_rect();
-        assert_almost_abs_eq(rect.row(0)[0], 7.2, 1e-6);
-        assert_almost_abs_eq(rect.row(0)[1], 2.4, 1e-6);
-        assert_almost_abs_eq(rect.row(1)[0], -2.4, 1e-6);
-        assert_almost_abs_eq(rect.row(1)[1], -7.2, 1e-6);
+        assert_almost_abs_eq(output[0].row(0)[0], 7.2, 1e-6);
+        assert_almost_abs_eq(output[0].row(0)[1], 2.4, 1e-6);
+        assert_almost_abs_eq(output[0].row(1)[0], -2.4, 1e-6);
+        assert_almost_abs_eq(output[0].row(1)[1], -7.2, 1e-6);
         Ok(())
     }
 
@@ -274,10 +273,9 @@ mod test {
             ],
         ];
         for c in 0..3 {
-            let rect = output[c].as_rect();
-            for y in 0..rect.size().1 {
-                for x in 0..rect.size().0 {
-                    assert_almost_abs_eq(rect.row(y)[x], want_out[c][y][x], 1e-5);
+            for y in 0..output[c].size().1 {
+                for x in 0..output[c].size().0 {
+                    assert_almost_abs_eq(output[c].row(y)[x], want_out[c][y][x], 1e-5);
                 }
             }
         }

--- a/jxl/src/render/stages/splines.rs
+++ b/jxl/src/render/stages/splines.rs
@@ -112,11 +112,7 @@ mod test {
         )?;
         for c in 0..3 {
             for row in 0..size.1 {
-                assert_all_almost_abs_eq(
-                    output[c].as_rect().row(row),
-                    want_image[c].as_rect().row(row),
-                    1e-3,
-                );
+                assert_all_almost_abs_eq(output[c].row(row), want_image[c].row(row), 1e-3);
             }
         }
         Ok(())

--- a/jxl/src/render/stages/spot.rs
+++ b/jxl/src/render/stages/spot.rs
@@ -92,22 +92,10 @@ mod test {
         let mut input_g = Image::new((3, 1))?;
         let mut input_b = Image::new((3, 1))?;
         let mut input_s = Image::new((3, 1))?;
-        input_r
-            .as_rect_mut()
-            .row(0)
-            .copy_from_slice(&[1.0, 0.0, 0.0]);
-        input_g
-            .as_rect_mut()
-            .row(0)
-            .copy_from_slice(&[0.0, 1.0, 0.0]);
-        input_b
-            .as_rect_mut()
-            .row(0)
-            .copy_from_slice(&[0.0, 0.0, 1.0]);
-        input_s
-            .as_rect_mut()
-            .row(0)
-            .copy_from_slice(&[1.0, 1.0, 1.0]);
+        input_r.row_mut(0).copy_from_slice(&[1.0, 0.0, 0.0]);
+        input_g.row_mut(0).copy_from_slice(&[0.0, 1.0, 0.0]);
+        input_b.row_mut(0).copy_from_slice(&[0.0, 0.0, 1.0]);
+        input_s.row_mut(0).copy_from_slice(&[1.0, 1.0, 1.0]);
 
         let stage = SpotColorStage::new(0, [0.5; 4]);
         let output = make_and_run_simple_pipeline(
@@ -118,9 +106,9 @@ mod test {
             256,
         )?;
 
-        assert_all_almost_abs_eq(output[0].as_rect().row(0), &[0.75, 0.25, 0.25], 1e-6);
-        assert_all_almost_abs_eq(output[1].as_rect().row(0), &[0.25, 0.75, 0.25], 1e-6);
-        assert_all_almost_abs_eq(output[2].as_rect().row(0), &[0.25, 0.25, 0.75], 1e-6);
+        assert_all_almost_abs_eq(output[0].row(0), &[0.75, 0.25, 0.25], 1e-6);
+        assert_all_almost_abs_eq(output[1].row(0), &[0.25, 0.75, 0.25], 1e-6);
+        assert_all_almost_abs_eq(output[2].row(0), &[0.25, 0.25, 0.75], 1e-6);
 
         Ok(())
     }

--- a/jxl/src/render/stages/to_linear.rs
+++ b/jxl/src/render/stages/to_linear.rs
@@ -204,9 +204,9 @@ mod test {
         let output =
             make_and_run_simple_pipeline(stage, &[input_r, input_g, input_b], (1, 1), 0, 256)?;
 
-        assert_all_almost_abs_eq(output[0].as_rect().row(0), &[0.203], 1e-3);
-        assert_all_almost_abs_eq(output[1].as_rect().row(0), &[0.203], 1e-3);
-        assert_all_almost_abs_eq(output[2].as_rect().row(0), &[0.203], 1e-3);
+        assert_all_almost_abs_eq(output[0].row(0), &[0.203], 1e-3);
+        assert_all_almost_abs_eq(output[1].row(0), &[0.203], 1e-3);
+        assert_all_almost_abs_eq(output[2].row(0), &[0.203], 1e-3);
 
         Ok(())
     }
@@ -224,9 +224,9 @@ mod test {
         let output =
             make_and_run_simple_pipeline(stage, &[input_r, input_g, input_b], (1, 1), 0, 256)?;
 
-        assert_all_almost_abs_eq(output[0].as_rect().row(0), &[0.203], 1e-3);
-        assert_all_almost_abs_eq(output[1].as_rect().row(0), &[0.203], 1e-3);
-        assert_all_almost_abs_eq(output[2].as_rect().row(0), &[0.203], 1e-3);
+        assert_all_almost_abs_eq(output[0].row(0), &[0.203], 1e-3);
+        assert_all_almost_abs_eq(output[1].row(0), &[0.203], 1e-3);
+        assert_all_almost_abs_eq(output[2].row(0), &[0.203], 1e-3);
 
         Ok(())
     }

--- a/jxl/src/render/stages/upsample.rs
+++ b/jxl/src/render/stages/upsample.rs
@@ -105,7 +105,6 @@ pub type Upsample8x = Upsample<8, 3>;
 
 #[cfg(test)]
 mod test {
-
     use super::*;
     use crate::{
         error::Result, headers::CustomTransformDataNonserialized, image::Image,
@@ -155,7 +154,7 @@ mod test {
             make_and_run_simple_pipeline(stage, &[input], image_size, 0, 123)?;
         for x in 0..image_size.0 {
             for y in 0..image_size.1 {
-                assert_almost_abs_eq(output[0].as_rect().row(y)[x], val, 0.0000001);
+                assert_almost_abs_eq(output[0].row(y)[x], val, 0.0000001);
             }
         }
         Ok(())
@@ -172,7 +171,7 @@ mod test {
             make_and_run_simple_pipeline(stage, &[input], image_size, 0, 123)?;
         for x in 0..image_size.0 {
             for y in 0..image_size.1 {
-                assert_almost_abs_eq(output[0].as_rect().row(y)[x], val, 0.00001);
+                assert_almost_abs_eq(output[0].row(y)[x], val, 0.00001);
             }
         }
         Ok(())
@@ -189,7 +188,7 @@ mod test {
             make_and_run_simple_pipeline(stage, &[input], image_size, 0, 123)?;
         for x in 0..image_size.0 {
             for y in 0..image_size.1 {
-                assert_almost_abs_eq(output[0].as_rect().row(y)[x], val, 0.00001);
+                assert_almost_abs_eq(output[0].row(y)[x], val, 0.00001);
             }
         }
         Ok(())
@@ -200,19 +199,19 @@ mod test {
         let eps = 0.0000001;
         let mut input = Image::new((7, 7))?;
         // Put a single "1.0" in the middle of the image.
-        input.as_rect_mut().row(3)[3] = 1.0f32;
+        input.row_mut(3)[3] = 1.0f32;
         let ups_factors = ups_factors();
         let stage = Upsample2x::new(&ups_factors, 0);
         let output: Vec<Image<f32>> =
             make_and_run_simple_pipeline(stage, &[input], (14, 14), 0, 77)?;
-        assert_eq!(output[0].as_rect().size(), (14, 14));
+        assert_eq!(output[0].size(), (14, 14));
         // Check we have a border with zeros
         for i in 0..14 {
             for j in 0..2 {
-                assert_almost_abs_eq(output[0].as_rect().row(j)[i], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(i)[j], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(13 - j)[i], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(i)[13 - j], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(j)[i], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(i)[j], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(13 - j)[i], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(i)[13 - j], 0.0, eps);
             }
         }
         // Define the mapping for the symmetric top-left kernel
@@ -232,8 +231,8 @@ mod test {
             for dj in 0..2 {
                 for i in 0..kernel_size {
                     for j in 0..kernel_size {
-                        let output_value = output[0].as_rect().row(kernel_offset + di + 2 * i)
-                            [kernel_offset + dj + 2 * j];
+                        let output_value =
+                            output[0].row(kernel_offset + di + 2 * i)[kernel_offset + dj + 2 * j];
                         let mapped_i = if di == 0 { kernel_size - 1 - i } else { i };
                         let mapped_j = if dj == 0 { kernel_size - 1 - j } else { j };
                         let weight_index = index_map[mapped_i][mapped_j];
@@ -255,21 +254,21 @@ mod test {
         let eps = 0.0000001;
         let mut input = Image::new((7, 7))?;
         // Put a single "1.0" in the middle of the image.
-        input.as_rect_mut().row(3)[3] = 1.0f32;
+        input.row_mut(3)[3] = 1.0f32;
         let ups_factors = ups_factors();
         let stage = Upsample4x::new(&ups_factors, 0);
         let output: Vec<Image<f32>> =
             make_and_run_simple_pipeline(stage, &[input], (28, 28), 0, 1024)?;
 
-        assert_eq!(output[0].as_rect().size(), (28, 28));
+        assert_eq!(output[0].size(), (28, 28));
 
         // Check we have a border with zeros
         for i in 0..28 {
             for j in 0..4 {
-                assert_almost_abs_eq(output[0].as_rect().row(j)[i], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(i)[j], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(27 - j)[i], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(i)[27 - j], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(j)[i], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(i)[j], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(27 - j)[i], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(i)[27 - j], 0.0, eps);
             }
         }
 
@@ -291,7 +290,7 @@ mod test {
         let kernel_size = 5;
         let kernel_offset = 4;
         let weights = &ups_factors.weights4;
-        let row_size = output[0].as_rect().size().0;
+        let row_size = output[0].size().0;
         let column_size = row_size;
         for di in 0..4 {
             for dj in 0..4 {
@@ -302,15 +301,13 @@ mod test {
                         let offset_i = kernel_offset + i;
                         let offset_j = kernel_offset + j;
                         // Testing symmetry
-                        let output_value = output[0].as_rect().row(offset_i)[offset_j];
+                        let output_value = output[0].row(offset_i)[offset_j];
                         let output_value_mirrored_right =
-                            output[0].as_rect().row(row_size - offset_i - 1)[offset_j];
-                        let output_value_mirrored_down = output[0]
-                            .as_rect()
-                            .row(row_size - offset_i - 1)[column_size - offset_j - 1];
-                        let output_value_mirrored_down_right = output[0]
-                            .as_rect()
-                            .row(row_size - offset_i - 1)[column_size - offset_j - 1];
+                            output[0].row(row_size - offset_i - 1)[offset_j];
+                        let output_value_mirrored_down =
+                            output[0].row(row_size - offset_i - 1)[column_size - offset_j - 1];
+                        let output_value_mirrored_down_right =
+                            output[0].row(row_size - offset_i - 1)[column_size - offset_j - 1];
 
                         assert_almost_abs_eq(output_value, output_value_mirrored_right, eps);
                         assert_almost_abs_eq(output_value, output_value_mirrored_down, eps);
@@ -346,21 +343,21 @@ mod test {
         let eps = 0.0000001;
         let mut input = Image::new((7, 7))?;
         // Put a single "1.0" in the middle of the image.
-        input.as_rect_mut().row(3)[3] = 1.0f32;
+        input.row_mut(3)[3] = 1.0f32;
         let ups_factors = ups_factors();
         let stage = Upsample8x::new(&ups_factors, 0);
         let output: Vec<Image<f32>> =
             make_and_run_simple_pipeline(stage, &[input], (56, 56), 0, 1024)?;
 
-        assert_eq!(output[0].as_rect().size(), (56, 56));
+        assert_eq!(output[0].size(), (56, 56));
 
         // Check we have a border with zeros
         for i in 0..56 {
             for j in 0..8 {
-                assert_almost_abs_eq(output[0].as_rect().row(j)[i], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(i)[j], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(55 - j)[i], 0.0, eps);
-                assert_almost_abs_eq(output[0].as_rect().row(i)[55 - j], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(j)[i], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(i)[j], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(55 - j)[i], 0.0, eps);
+                assert_almost_abs_eq(output[0].row(i)[55 - j], 0.0, eps);
             }
         }
 
@@ -452,7 +449,7 @@ mod test {
         let kernel_size = 5;
         let kernel_offset = 8;
         let weights = &ups_factors.weights8;
-        let row_size = output[0].as_rect().size().0;
+        let row_size = output[0].size().0;
         let column_size = row_size;
         for di in 0..8 {
             for dj in 0..8 {
@@ -463,15 +460,13 @@ mod test {
                         let offset_i = kernel_offset + i;
                         let offset_j = kernel_offset + j;
                         // Testing symmetry
-                        let output_value = output[0].as_rect().row(offset_i)[offset_j];
+                        let output_value = output[0].row(offset_i)[offset_j];
                         let output_value_mirrored_right =
-                            output[0].as_rect().row(row_size - offset_i - 1)[offset_j];
-                        let output_value_mirrored_down = output[0]
-                            .as_rect()
-                            .row(row_size - offset_i - 1)[column_size - offset_j - 1];
-                        let output_value_mirrored_down_right = output[0]
-                            .as_rect()
-                            .row(row_size - offset_i - 1)[column_size - offset_j - 1];
+                            output[0].row(row_size - offset_i - 1)[offset_j];
+                        let output_value_mirrored_down =
+                            output[0].row(row_size - offset_i - 1)[column_size - offset_j - 1];
+                        let output_value_mirrored_down_right =
+                            output[0].row(row_size - offset_i - 1)[column_size - offset_j - 1];
 
                         assert_almost_abs_eq(output_value, output_value_mirrored_right, eps);
                         assert_almost_abs_eq(output_value, output_value_mirrored_down, eps);

--- a/jxl/src/render/stages/xyb.rs
+++ b/jxl/src/render/stages/xyb.rs
@@ -285,25 +285,22 @@ mod test {
         let mut input_y = Image::new((3, 1))?;
         let mut input_b = Image::new((3, 1))?;
         input_x
-            .as_rect_mut()
-            .row(0)
+            .row_mut(0)
             .copy_from_slice(&[0.028100073, -0.015386105, 0.0]);
         input_y
-            .as_rect_mut()
-            .row(0)
+            .row_mut(0)
             .copy_from_slice(&[0.4881882, 0.71478134, 0.2781282]);
         input_b
-            .as_rect_mut()
-            .row(0)
+            .row_mut(0)
             .copy_from_slice(&[0.471659, 0.43707693, 0.66613984]);
 
         let stage = XybStage::new(0, OutputColorInfo::default());
         let output =
             make_and_run_simple_pipeline(stage, &[input_x, input_y, input_b], (3, 1), 0, 256)?;
 
-        assert_all_almost_abs_eq(output[0].as_rect().row(0), &[1.0, 0.0, 0.0], 1e-6);
-        assert_all_almost_abs_eq(output[1].as_rect().row(0), &[0.0, 1.0, 0.0], 1e-6);
-        assert_all_almost_abs_eq(output[2].as_rect().row(0), &[0.0, 0.0, 1.0], 1e-6);
+        assert_all_almost_abs_eq(output[0].row(0), &[1.0, 0.0, 0.0], 1e-6);
+        assert_all_almost_abs_eq(output[1].row(0), &[0.0, 1.0, 0.0], 1e-6);
+        assert_all_almost_abs_eq(output[2].row(0), &[0.0, 0.0, 1.0], 1e-6);
 
         Ok(())
     }

--- a/jxl/src/render/stages/ycbcr.rs
+++ b/jxl/src/render/stages/ycbcr.rs
@@ -90,25 +90,22 @@ mod test {
         let mut input_cb = Image::new((3, 1))?;
         let mut input_cr = Image::new((3, 1))?;
         input_y
-            .as_rect_mut()
-            .row(0)
+            .row_mut(0)
             .copy_from_slice(&[-0.20296079, 0.08503921, -0.3879608]);
         input_cb
-            .as_rect_mut()
-            .row(0)
+            .row_mut(0)
             .copy_from_slice(&[-0.16873589, -0.3312641, 0.5]);
         input_cr
-            .as_rect_mut()
-            .row(0)
+            .row_mut(0)
             .copy_from_slice(&[0.5, -0.41868758, -0.08131241]);
 
         let stage = YcbcrToRgbStage::new(0);
         let output =
             make_and_run_simple_pipeline(stage, &[input_cb, input_y, input_cr], (3, 1), 0, 256)?;
 
-        assert_all_almost_abs_eq(output[0].as_rect().row(0), &[1.0, 0.0, 0.0], 1e-6);
-        assert_all_almost_abs_eq(output[1].as_rect().row(0), &[0.0, 1.0, 0.0], 1e-6);
-        assert_all_almost_abs_eq(output[2].as_rect().row(0), &[0.0, 0.0, 1.0], 1e-6);
+        assert_all_almost_abs_eq(output[0].row(0), &[1.0, 0.0, 0.0], 1e-6);
+        assert_all_almost_abs_eq(output[1].row(0), &[0.0, 1.0, 0.0], 1e-6);
+        assert_all_almost_abs_eq(output[2].row(0), &[0.0, 0.0, 1.0], 1e-6);
 
         Ok(())
     }

--- a/jxl/src/render/test.rs
+++ b/jxl/src/render/test.rs
@@ -75,10 +75,10 @@ fn extract_group_rect<T: ImageDataType>(
         image.size(),
         log_group_size
     );
-    let rect = image.as_rect().rect(Rect { origin, size }).unwrap();
+    let rect = image.get_rect(Rect { origin, size });
     let mut out = Image::new(rect.size()).unwrap();
     for y in 0..out.size().1 {
-        out.as_rect_mut().row(y).copy_from_slice(rect.row(y));
+        out.row_mut(y).copy_from_slice(rect.row(y));
     }
     Ok(out)
 }
@@ -159,8 +159,13 @@ fn make_and_run_simple_pipeline_impl<InputT: ImageDataType, OutputT: ImageDataTy
     let mut buf_ptrs: Vec<_> = outputs
         .iter_mut()
         .map(|x| {
+            let size = x.size();
             Some(JxlOutputBuffer::from_image_rect_mut(
-                x.as_rect_mut().into_raw(),
+                x.get_rect_mut(Rect {
+                    size,
+                    origin: (0, 0),
+                })
+                .into_raw(),
             ))
         })
         .collect();
@@ -225,7 +230,7 @@ pub(super) fn test_stage_consistency<S: RenderPipelineTestableStage<V>, V>(
         .unwrap_or_else(|_| panic!("error running pipeline with chunk size {chunk_size}"));
 
         for (o, bo) in output.iter().zip(base_output.iter()) {
-            check_equal_images(bo.as_rect(), o.as_rect());
+            check_equal_images(bo, o);
         }
 
         Ok(())

--- a/jxl/src/util/test.rs
+++ b/jxl/src/util/test.rs
@@ -14,7 +14,7 @@ use crate::{
     container::ContainerParser,
     error::Error as JXLError,
     headers::{FileHeader, JxlHeader, encodings::*, frame_header::TocNonserialized},
-    image::{Image, ImageDataType, ImageRect},
+    image::{Image, ImageDataType},
 };
 
 use num_traits::AsPrimitive;
@@ -200,7 +200,7 @@ pub fn assert_all_almost_abs_eq<T: AsPrimitive<f64> + Debug + Copy, V: AsRef<[T]
     }
 }
 
-pub fn check_equal_images<T: ImageDataType>(a: ImageRect<T>, b: ImageRect<T>) {
+pub fn check_equal_images<T: ImageDataType>(a: &Image<T>, b: &Image<T>) {
     assert_eq!(a.size(), b.size());
     let mismatch_info = |x: usize, y: usize| -> String {
         let msg = format!(
@@ -256,7 +256,7 @@ pub fn write_pfm(image: Vec<Image<f32>>, mut buf: impl Write) -> Result<(), Erro
     for row in 0..size.1 {
         for col in 0..size.0 {
             for c in image.iter() {
-                b = c.as_rect().row(size.1 - row - 1)[col].to_be_bytes();
+                b = c.row(size.1 - row - 1)[col].to_be_bytes();
                 buf.write_all(&b)?;
             }
         }
@@ -306,7 +306,7 @@ pub fn read_pfm(b: &[u8]) -> Result<Vec<Image<f32>>, Error> {
         for col in 0..xres {
             for chan in res.iter_mut() {
                 bf.read_exact(&mut buf)?;
-                chan.as_rect_mut().row(yres - row - 1)[col] = if endianness < 0.0 {
+                chan.row_mut(yres - row - 1)[col] = if endianness < 0.0 {
                     f32::from_le_bytes(buf)
                 } else {
                     f32::from_be_bytes(buf)

--- a/jxl_cli/src/bin/jxlinspect.rs
+++ b/jxl_cli/src/bin/jxlinspect.rs
@@ -10,7 +10,7 @@ use jxl::api::{
     ProcessingResult,
 };
 use jxl::headers::extra_channels::ExtraChannel;
-use jxl::image::Image;
+use jxl::image::{Image, Rect};
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
@@ -160,7 +160,13 @@ fn parse_jxl(path: &Path) -> Result<()> {
 
             let mut output_bufs: Vec<JxlOutputBuffer<'_>> = outputs
                 .iter_mut()
-                .map(|x| JxlOutputBuffer::from_image_rect_mut(x.as_rect_mut().into_raw()))
+                .map(|x| {
+                    let rect = Rect {
+                        size: x.size(),
+                        origin: (0, 0),
+                    };
+                    JxlOutputBuffer::from_image_rect_mut(x.get_rect_mut(rect).into_raw())
+                })
                 .collect();
 
             decoder_with_image_info = advance_decoder!(decoder_with_frame_info, &mut output_bufs)?;

--- a/jxl_cli/src/enc/exr.rs
+++ b/jxl_cli/src/enc/exr.rs
@@ -119,7 +119,7 @@ mod jxl_exr {
                 let mut samples = vec![f16::ZERO; height * width];
                 for y in 0..height {
                     for x in 0..width {
-                        samples[y * width + x] = f16::from_f32(channel.as_rect().row(y)[x]);
+                        samples[y * width + x] = f16::from_f32(channel.row(y)[x]);
                     }
                 }
                 FlatSamples::F16(samples)
@@ -127,7 +127,7 @@ mod jxl_exr {
                 let mut samples = vec![0.0; height * width];
                 for y in 0..height {
                     for x in 0..width {
-                        samples[y * width + x] = channel.as_rect().row(y)[x];
+                        samples[y * width + x] = channel.row(y)[x];
                     }
                 }
                 FlatSamples::F32(samples)

--- a/jxl_cli/src/enc/numpy.rs
+++ b/jxl_cli/src/enc/numpy.rs
@@ -5,7 +5,6 @@
 
 use crate::DecodeOutput;
 use jxl::error::{Error, Result};
-use jxl::image::ImageRect;
 use std::io::Write;
 
 fn numpy_header<Writer: Write>(
@@ -65,12 +64,10 @@ fn numpy_bytes<Writer: Write>(
         for channel in &frame.channels {
             assert_eq!(channel.size(), image_data.size);
         }
-        let channel_rects: &Vec<ImageRect<'_, f32>> =
-            &frame.channels.iter().map(|im| im.as_rect()).collect();
 
         for y in 0..height {
             for x in 0..width {
-                for channel in channel_rects {
+                for channel in frame.channels.iter() {
                     writer.write_all(&channel.row(y)[x].clamp(0.0, 1.0).to_le_bytes())?;
                 }
             }

--- a/jxl_cli/src/enc/png.rs
+++ b/jxl_cli/src/enc/png.rs
@@ -199,8 +199,7 @@ pub fn to_png<Writer: Write>(
                     for c in 0..num_channels {
                         // + 0.5 instead of round is fine since we clamp to non-negative
                         data[(y * width + x) * num_channels + c] =
-                            ((frame.channels[c].as_rect().row(y)[x] * 255.0).clamp(0.0, 255.0)
-                                + 0.5) as u8;
+                            ((frame.channels[c].row(y)[x] * 255.0).clamp(0.0, 255.0) + 0.5) as u8;
                     }
                 }
             }
@@ -218,8 +217,7 @@ pub fn to_png<Writer: Write>(
                 for x in 0..width {
                     for c in 0..num_channels {
                         // + 0.5 instead of round is fine since we clamp to non-negative
-                        let pixel = ((frame.channels[c].as_rect().row(y)[x] * 65535.0)
-                            .clamp(0.0, 65535.0)
+                        let pixel = ((frame.channels[c].row(y)[x] * 65535.0).clamp(0.0, 65535.0)
                             + 0.5) as u16;
                         let index = 2 * ((y * width + x) * num_channels + c);
                         data[index] = (pixel >> 8) as u8;

--- a/jxl_cli/src/enc/pnm.rs
+++ b/jxl_cli/src/enc/pnm.rs
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use jxl::{error::Result, image::ImageRect};
+use jxl::{error::Result, image::Image};
 use std::io::Write;
 
 pub trait ToU8ForWriting {
@@ -41,7 +41,7 @@ impl ToU8ForWriting for half::f16 {
     }
 }
 
-pub fn to_pgm_as_8bit<Writer: Write>(img: &ImageRect<'_, f32>, writer: &mut Writer) -> Result<()> {
+pub fn to_pgm_as_8bit<Writer: Write>(img: &Image<f32>, writer: &mut Writer) -> Result<()> {
     write!(writer, "P5\n{} {}\n255\n", img.size().0, img.size().1)?;
     for y in 0..img.size().1 {
         for x in img.row(y).iter() {
@@ -51,10 +51,7 @@ pub fn to_pgm_as_8bit<Writer: Write>(img: &ImageRect<'_, f32>, writer: &mut Writ
     Ok(())
 }
 
-pub fn to_ppm_as_8bit<Writer: Write>(
-    img: &[ImageRect<'_, f32>; 3],
-    writer: &mut Writer,
-) -> Result<()> {
+pub fn to_ppm_as_8bit<Writer: Write>(img: [&Image<f32>; 3], writer: &mut Writer) -> Result<()> {
     assert_eq!(img[0].size(), img[1].size());
     assert_eq!(img[0].size(), img[2].size());
     write!(writer, "P6\n{} {}\n255\n", img[0].size().0, img[0].size().1)?;
@@ -78,7 +75,7 @@ mod test {
     fn covert_to_pgm() -> Result<()> {
         let image = Image::<f32>::new((32, 32))?;
         let mut bytes = vec![];
-        to_pgm_as_8bit(&image.as_rect(), &mut bytes)?;
+        to_pgm_as_8bit(&image, &mut bytes)?;
         assert!(bytes.starts_with(b"P5\n32 32\n255\n"));
         Ok(())
     }


### PR DESCRIPTION
This allows to create images that have additional padding wrt. their standard dimensions. This padding can be used as additional space for i.e. the pipeline implementation, or modular decoding.

Also removes as_rect() by adding row() and row_mut() methods directly to Image, which simplifies the code somewhat.

Performance-neutral.