### PR TITLE
Perform static dispatch when target feature is enabled at compile time

### DIFF
--- a/jxl_simd/src/x86_64/mod.rs
+++ b/jxl_simd/src/x86_64/mod.rs
@@ -42,13 +42,17 @@ macro_rules! simd_function {
 #[macro_export]
 macro_rules! simd_function_body_sse42 {
     ($name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty )?; ($($val:expr),* $(,)?)) => {
-        if let Some(d) = $crate::Sse42Descriptor::new() {
+        if cfg!(target_feature = "sse4.2") {
+            // SAFETY: we just checked for sse4.2.
+            let d = unsafe { $crate::Sse42Descriptor::new_unchecked() };
+            return $name(d, $($val),*);
+        } else if let Some(d) = $crate::Sse42Descriptor::new() {
             #[target_feature(enable = "sse4.2")]
-            fn inner(d: $crate::Sse42Descriptor, $($arg: $ty),*) $(-> $ret)? {
+            fn sse42(d: $crate::Sse42Descriptor, $($arg: $ty),*) $(-> $ret)? {
                 $name(d, $($val),*)
             }
             // SAFETY: we just checked for sse4.2.
-            return unsafe { inner(d, $($arg),*) };
+            return unsafe { sse42(d, $($arg),*) };
         }
     };
 }
@@ -58,13 +62,17 @@ macro_rules! simd_function_body_sse42 {
 #[macro_export]
 macro_rules! simd_function_body_avx {
     ($name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty )?; ($($val:expr),* $(,)?)) => {
-        if let Some(d) = $crate::AvxDescriptor::new() {
+        if cfg!(all(target_feature = "avx2", target_feature = "fma")) {
+            // SAFETY: we just checked for avx2 and fma.
+            let d = unsafe { $crate::AvxDescriptor::new_unchecked() };
+            return $name(d, $($val),*);
+        } else if let Some(d) = $crate::AvxDescriptor::new() {
             #[target_feature(enable = "avx2,fma")]
-            fn inner(d: $crate::AvxDescriptor, $($arg: $ty),*) $(-> $ret)? {
+            fn avx(d: $crate::AvxDescriptor, $($arg: $ty),*) $(-> $ret)? {
                 $name(d, $($val),*)
             }
             // SAFETY: we just checked for avx2 and fma.
-            return unsafe { inner(d, $($arg),*) };
+            return unsafe { avx(d, $($arg),*) };
         }
     };
 }
@@ -74,13 +82,17 @@ macro_rules! simd_function_body_avx {
 #[macro_export]
 macro_rules! simd_function_body_avx512 {
     ($name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty )?; ($($val:expr),* $(,)?)) => {
-        if let Some(d) = $crate::Avx512Descriptor::new() {
+        if cfg!(target_feature = "avx512f") {
+            // SAFETY: we just checked for avx512f.
+            let d = unsafe { $crate::Avx512Descriptor::new_unchecked() };
+            return $name(d, $($val),*);
+        } else if let Some(d) = $crate::Avx512Descriptor::new() {
             #[target_feature(enable = "avx512f")]
-            fn inner(d: $crate::Avx512Descriptor, $($arg: $ty),*) $(-> $ret)? {
+            fn avx512(d: $crate::Avx512Descriptor, $($arg: $ty),*) $(-> $ret)? {
                 $name(d, $($val),*)
             }
             // SAFETY: we just checked for avx512f.
-            return unsafe { inner(d, $($arg),*) };
+            return unsafe { avx512(d, $($arg),*) };
         }
     };
 }


### PR DESCRIPTION
With `RUSTFLAGS='-C target-feature=+avx2,+fma'`, dispatcher will look like this:
```
0000000000235530 <jxl_transforms::transform::transform_to_pixels>:
  235530:       55                      push   %rbp
  235531:       41 57                   push   %r15
  235533:       41 56                   push   %r14
  235535:       41 55                   push   %r13
  235537:       41 54                   push   %r12
  235539:       53                      push   %rbx
  23553a:       48 81 ec e8 08 00 00    sub    $0x8e8,%rsp
  235541:       4d 89 c5                mov    %r8,%r13
  235544:       48 89 cb                mov    %rcx,%rbx
  235547:       49 89 d4                mov    %rdx,%r12
  23554a:       49 89 f7                mov    %rsi,%r15
  23554d:       89 fd                   mov    %edi,%ebp
  23554f:       ff 15 83 13 1c 00       call   *0x1c1383(%rip)        # 3f68d8 <_DYNAMIC+0xdd0>
  235555:       84 c0                   test   %al,%al
  235557:       74 26                   je     23557f <jxl_transforms::transform::transform_to_pixels+0x4f>
  235559:       40 0f b6 fd             movzbl %bpl,%edi
  23555d:       4c 89 fe                mov    %r15,%rsi
  235560:       4c 89 e2                mov    %r12,%rdx
  235563:       48 89 d9                mov    %rbx,%rcx
  235566:       4d 89 e8                mov    %r13,%r8
  235569:       48 81 c4 e8 08 00 00    add    $0x8e8,%rsp
  235570:       5b                      pop    %rbx
  235571:       41 5c                   pop    %r12
  235573:       41 5d                   pop    %r13
  235575:       41 5e                   pop    %r14
  235577:       41 5f                   pop    %r15
  235579:       5d                      pop    %rbp
  23557a:       e9 b1 41 02 00          jmp    259730 <jxl_transforms::transform::transform_to_pixels::avx512>
  23557f:       48 89 5c 24 20          mov    %rbx,0x20(%rsp)
  235584:       40 0f b6 c5             movzbl %bpl,%eax
  235588:       48 8d 0d 61 01 e3 ff    lea    -0x1cfe9f(%rip),%rcx        # 656f0 <anon.cb985788e218398fb4310040182fbe0e.149.llvm.3990871657644904276+0x90>
  23558f:       48 63 04 81             movslq (%rcx,%rax,4),%rax
  235593:       48 01 c8                add    %rcx,%rax
  235596:       ff e0                   jmp    *%rax

[...]
```

`RUSTFLAGS='-C target-feature=+avx512f'` will make the dispatcher contain only the AVX512 version of the code:
```
00000000002359d0 <jxl_transforms::transform::transform_to_pixels>:
  2359d0:       55                      push   %rbp
  2359d1:       41 57                   push   %r15
  2359d3:       41 56                   push   %r14
  2359d5:       41 55                   push   %r13
  2359d7:       41 54                   push   %r12
  2359d9:       53                      push   %rbx
  2359da:       48 81 ec 98 0e 00 00    sub    $0xe98,%rsp
  2359e1:       49 89 cf                mov    %rcx,%r15
  2359e4:       49 89 f6                mov    %rsi,%r14
  2359e7:       40 0f b6 c7             movzbl %dil,%eax
  2359eb:       48 8d 0d 8e 2c e3 ff    lea    -0x1cd372(%rip),%rcx        # 68680 <anon.e9d77170807e575b54fe704499751839.161.llvm.8038620448421557673+0x388e>
  2359f2:       48 63 04 81             movslq (%rcx,%rax,4),%rax
  2359f6:       48 01 c8                add    %rcx,%rax
  2359f9:       4c 89 bc 24 30 02 00 00         mov    %r15,0x230(%rsp)
  235a01:       ff e0                   jmp    *%rax

[...]
```