### PR TITLE
Render groups eagerly (remove explicit `do_render` calls).

### DIFF
--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -177,6 +177,7 @@ pub struct Frame {
     reference_frame_data: Option<Vec<Image<f32>>>,
     lf_frame_data: Option<[Image<f32>; 3]>,
     use_simple_pipeline: bool,
+    lf_global_was_rendered: bool,
 }
 
 impl Frame {

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -533,7 +533,7 @@ impl FullModularImage {
         section_id: usize,
         grid: usize,
         frame_header: &FrameHeader,
-        pass_to_pipeline: &mut dyn FnMut(usize, usize, usize, Image<i32>),
+        pass_to_pipeline: &mut dyn FnMut(usize, usize, usize, Image<i32>) -> Result<()>,
     ) -> Result<()> {
         let mut maybe_output = |bi: &mut ModularBufferInfo, grid: usize| -> Result<()> {
             if bi.info.output_channel_idx >= 0 {
@@ -543,11 +543,11 @@ impl FullModularImage {
                 // TODO(veluca): figure out what to do with passes here.
                 if chan == 0 && self.modular_color_channels == 1 {
                     for i in 0..2 {
-                        pass_to_pipeline(i, grid, 1, buf.data.try_clone()?);
+                        pass_to_pipeline(i, grid, 1, buf.data.try_clone()?)?;
                     }
-                    pass_to_pipeline(2, grid, 1, buf.data);
+                    pass_to_pipeline(2, grid, 1, buf.data)?;
                 } else {
-                    pass_to_pipeline(chan, grid, 1, buf.data);
+                    pass_to_pipeline(chan, grid, 1, buf.data)?;
                 }
             }
             Ok(())

--- a/jxl/src/image/output_buffer.rs
+++ b/jxl/src/image/output_buffer.rs
@@ -74,9 +74,8 @@ impl<'a> JxlOutputBuffer<'a> {
         )
     }
 
-    pub(crate) fn reborrow(lender: &'a mut JxlOutputBuffer<'_>) -> Self {
-        // Safety note: this is effectively equivalent to a reborrow. Moreover, the safety
-        // invariants are preserved by virtue of copying all the fields.
+    pub(crate) fn reborrow(lender: &'a mut JxlOutputBuffer<'_>) -> JxlOutputBuffer<'a> {
+        // Safety note: this is effectively equivalent to a reborrow.
         Self {
             _ph: PhantomData,
             ..*lender
@@ -105,7 +104,9 @@ impl<'a> JxlOutputBuffer<'a> {
         self.inner.byte_size()
     }
 
-    pub fn rect(&mut self, rect: Rect) -> Self {
+    pub fn rect(&mut self, rect: Rect) -> JxlOutputBuffer<'_> {
+        // Safety note: the return value borrows from `self`, so we are lending our memory to the
+        // returned JxlOutputBuffer.
         Self {
             inner: self.inner.rect(rect),
             _ph: PhantomData,

--- a/jxl/src/image/rect.rs
+++ b/jxl/src/image/rect.rs
@@ -24,10 +24,36 @@ impl Rect {
         }
     }
 
-    pub const fn to_byte_rect(&self, data_type: DataTypeTag) -> Rect {
+    pub fn to_byte_rect(&self, data_type: DataTypeTag) -> Rect {
+        self.to_byte_rect_sz(data_type.size())
+    }
+
+    pub fn to_byte_rect_sz(&self, sz: usize) -> Rect {
         Rect {
-            origin: (self.origin.0 * data_type.size(), self.origin.1),
-            size: (self.size.0 * data_type.size(), self.size.1),
+            origin: (self.origin.0 * sz, self.origin.1),
+            size: (self.size.0 * sz, self.size.1),
+        }
+    }
+
+    pub fn downsample(&self, downsample: (u8, u8)) -> Rect {
+        Rect {
+            origin: (self.origin.0 >> downsample.0, self.origin.1 >> downsample.1),
+            size: (self.size.0 >> downsample.0, self.size.1 >> downsample.1),
+        }
+    }
+
+    pub fn end(&self) -> (usize, usize) {
+        (self.origin.0 + self.size.0, self.origin.1 + self.size.1)
+    }
+
+    pub fn clip(&self, size: (usize, usize)) -> Rect {
+        let end = self.end();
+        Rect {
+            origin: self.origin,
+            size: (
+                end.0.min(size.0).saturating_sub(self.origin.0),
+                end.1.min(size.1).saturating_sub(self.origin.1),
+            ),
         }
     }
 }

--- a/jxl/src/render/buffer_splitter.rs
+++ b/jxl/src/render/buffer_splitter.rs
@@ -1,0 +1,97 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use crate::{api::JxlOutputBuffer, headers::Orientation, image::Rect, util::ShiftRightCeil};
+
+// Information for splitting the output buffers.
+pub(super) struct SaveStageBufferInfo {
+    pub(super) downsample: (u8, u8),
+    pub(super) orientation: Orientation,
+    pub(super) byte_size: usize,
+    pub(super) after_extend: bool,
+}
+
+/// Data structure responsible for handing out access to portions of the output buffers.
+pub struct BufferSplitter<'a, 'b>(&'a mut [Option<JxlOutputBuffer<'b>>]);
+
+impl<'a, 'b> BufferSplitter<'a, 'b> {
+    pub fn new(bufs: &'a mut [Option<JxlOutputBuffer<'b>>]) -> Self {
+        Self(bufs)
+    }
+
+    pub(super) fn get_local_buffers(
+        &mut self,
+        save_buffer_info: &[Option<SaveStageBufferInfo>],
+        rect: Rect,
+        outside_current_frame: bool,
+        frame_size: (usize, usize),
+        full_image_size: (usize, usize),
+        frame_origin: (isize, isize),
+    ) -> Vec<Option<JxlOutputBuffer<'_>>> {
+        let mut local_buffers = vec![];
+        let buffers = &mut *self.0;
+        local_buffers.reserve(buffers.len());
+        for _ in 0..buffers.len() {
+            local_buffers.push(None::<JxlOutputBuffer>);
+        }
+        for (i, (info, buf)) in save_buffer_info.iter().zip(buffers.iter_mut()).enumerate() {
+            let Some(bi) = info else {
+                // We never write to this buffer.
+                continue;
+            };
+            let Some(buf) = buf.as_mut() else {
+                // The buffer to write into was not provided.
+                continue;
+            };
+            if outside_current_frame && !bi.after_extend {
+                // Before-extend stages do not write to rects outside the current frame.
+                continue;
+            }
+            let mut channel_rect = rect.downsample(bi.downsample);
+            if !outside_current_frame {
+                let frame_size = (
+                    frame_size.0.shrc(bi.downsample.0),
+                    frame_size.1.shrc(bi.downsample.1),
+                );
+                channel_rect = channel_rect.clip(frame_size);
+                if bi.after_extend {
+                    // clip this rect to its visible area in the full image (in full image coordinates).
+                    let origin = (
+                        rect.origin.0 as isize + frame_origin.0,
+                        rect.origin.1 as isize + frame_origin.1,
+                    );
+                    let end = (
+                        origin.0 + rect.size.0 as isize,
+                        origin.1 + rect.size.1 as isize,
+                    );
+                    let origin = (origin.0.max(0) as usize, origin.1.max(0) as usize);
+                    let end = (
+                        end.0.min(full_image_size.0 as isize).max(0) as usize,
+                        end.1.min(full_image_size.1 as isize).max(0) as usize,
+                    );
+                    channel_rect = Rect {
+                        origin,
+                        size: (
+                            end.0.saturating_sub(origin.0),
+                            end.1.saturating_sub(origin.1),
+                        ),
+                    };
+                }
+            }
+            if channel_rect.size.0 == 0 || channel_rect.size.1 == 0 {
+                // Buffer would be empty anyway.
+                continue;
+            }
+            let channel_rect = bi.orientation.display_rect(channel_rect, full_image_size);
+            let channel_rect = channel_rect.to_byte_rect_sz(bi.byte_size);
+            local_buffers[i] = Some(buf.rect(channel_rect));
+        }
+        local_buffers
+    }
+
+    pub fn get_full_buffers(&mut self) -> &mut [Option<JxlOutputBuffer<'b>>] {
+        &mut *self.0
+    }
+}


### PR DESCRIPTION
This is in preparation for rendering the "interior" of groups eagerly in the low-memory pipeline (without ever storing them), which should significantly improve cache locality and reduce memory usage.

Mostly speed neutral.