### PR TITLE
Actually free buffers that will not be used again.

### DIFF
--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -116,6 +116,8 @@ pub struct DecoderState {
     pub(super) reference_frames: Arc<[Option<ReferenceFrame>; Self::MAX_STORED_FRAMES]>,
     pub(super) lf_frames: [Option<[Image<f32>; 3]>; 4],
     pub xyb_output_linear: bool,
+    // TODO(veluca): do we really need this? ISTM it could be achieved by passing None for all the
+    // buffers, and it's not clear to me what use the decoder can make of it.
     pub enable_output: bool,
     pub render_spotcolors: bool,
     pub use_simple_pipeline: bool,

--- a/jxl/src/render/internal.rs
+++ b/jxl/src/render/internal.rs
@@ -8,7 +8,6 @@ use std::fmt::Display;
 
 use crate::error::Result;
 use crate::image::{DataTypeTag, ImageDataType};
-use crate::util::ShiftRightCeil;
 
 use super::save::SaveStage;
 use super::stages::ExtendToImageDimensionsStage;
@@ -134,10 +133,8 @@ impl<Buffer> RenderPipelineShared<Buffer> {
     pub fn group_size_for_channel(
         &self,
         channel: usize,
-        group_id: usize,
         requested_data_type: DataTypeTag,
     ) -> (usize, usize) {
-        let goffset = self.group_offset(group_id);
         let ChannelInfo { downsample, ty } = self.channel_info[0][channel];
         if ty.unwrap() != requested_data_type {
             panic!(
@@ -145,12 +142,9 @@ impl<Buffer> RenderPipelineShared<Buffer> {
                 requested_data_type
             );
         }
-        assert_eq!(goffset.0 % (1 << downsample.0), 0);
-        assert_eq!(goffset.1 % (1 << downsample.1), 0);
-        let group_size = self.group_size(group_id);
         (
-            group_size.0.shrc(downsample.0),
-            group_size.1.shrc(downsample.1),
+            1 << (self.log_group_size - downsample.0 as usize),
+            1 << (self.log_group_size - downsample.1 as usize),
         )
     }
 

--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -101,14 +101,10 @@ pub(crate) trait RenderPipeline: Sized {
 
     fn new_from_shared(shared: RenderPipelineShared<Self::Buffer>) -> Result<Self>;
 
-    /// Obtains a buffer suitable for storing the input at  channel `channel` of group `group_id`.
+    /// Obtains a buffer suitable for storing the input in channel `channel`.
     /// This *might* be a buffer that was used to store that channel for that group in a previous
     /// pass, a new buffer, or a re-used buffer from i.e. previously decoded frames.
-    fn get_buffer_for_group<T: ImageDataType>(
-        &mut self,
-        channel: usize,
-        group_id: usize,
-    ) -> Result<Image<T>>;
+    fn get_buffer<T: ImageDataType>(&mut self, channel: usize) -> Result<Image<T>>;
 
     /// Gives back the buffer for a channel and group to the render pipeline, marking that
     /// `num_passes` additional passes (wrt. the previous call to this method for the same channel


### PR DESCRIPTION
Also switch to using buffers of consistent sizes.

Roughly 14% speedup.