### PR TITLE
Made bit reader refill conditional

### DIFF
--- a/jxl/src/bit_reader.rs
+++ b/jxl/src/bit_reader.rs
@@ -47,7 +47,9 @@ impl<'a> BitReader<'a> {
     #[inline]
     pub fn peek(&mut self, num: usize) -> u64 {
         debug_assert!(num <= MAX_BITS_PER_CALL);
-        self.refill();
+        if self.bits_in_buf < num {
+            self.refill();
+        }
         self.bit_buf & ((1u64 << num) - 1)
     }
 


### PR DESCRIPTION
Before: Decoded 9088204800 pixels in 515.156071204 seconds: 17641653.293067962 pixels/s
After:  Decoded 9088204800 pixels in 506.305871868 seconds: 17950028.441245105 pixels/s

~1.7% faster