### PR TITLE
Speedup modular decoding.

### DIFF
--- a/jxl/src/frame/modular/borrowed_buffers.rs
+++ b/jxl/src/frame/modular/borrowed_buffers.rs
@@ -5,7 +5,11 @@
 
 use std::{cell::RefMut, ops::DerefMut};
 
-use crate::{error::Result, image::Image};
+use crate::{
+    error::Result,
+    frame::modular::{IMAGE_OFFSET, IMAGE_PADDING},
+    image::Image,
+};
 
 use super::{ModularBufferInfo, ModularChannel};
 
@@ -23,7 +27,7 @@ pub fn with_buffers<T>(
         let mut data = b.data.borrow_mut();
         if data.is_none() {
             *data = Some(ModularChannel {
-                data: Image::new(b.size)?,
+                data: Image::new_with_padding(b.size, IMAGE_OFFSET, IMAGE_PADDING)?,
                 auxiliary_data: None,
                 shift: buf.info.shift,
                 bit_depth: buf.info.bit_depth,

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -35,6 +35,10 @@ pub use predict::Predictor;
 use transforms::{TransformStepChunk, make_grids};
 pub use tree::Tree;
 
+// Two rows on top, two pixels to the left, two pixels to the right.
+const IMAGE_PADDING: (usize, usize) = (4, 2);
+const IMAGE_OFFSET: (usize, usize) = (2, 2);
+
 #[derive(Clone, PartialEq, Eq, Copy)]
 struct ChannelInfo {
     // The index of the output channel in the render pipeline, or -1 for non-output channels.
@@ -135,7 +139,7 @@ impl ModularChannel {
         bit_depth: BitDepth,
     ) -> Result<Self> {
         Ok(ModularChannel {
-            data: Image::new(size)?,
+            data: Image::new_with_padding(size, IMAGE_OFFSET, IMAGE_PADDING)?,
             auxiliary_data: None,
             shift,
             bit_depth,

--- a/jxl/src/image/raw.rs
+++ b/jxl/src/image/raw.rs
@@ -100,6 +100,14 @@ impl OwnedRawImage {
         (size.0 - self.padding.0, size.1 - self.padding.1)
     }
 
+    pub fn byte_offset(&self) -> (usize, usize) {
+        self.offset
+    }
+
+    pub fn byte_padding(&self) -> (usize, usize) {
+        self.padding
+    }
+
     pub fn try_clone(&self) -> Result<OwnedRawImage> {
         Ok(Self {
             // SAFETY: we own the data that self.data references, so it is all accessible.


### PR DESCRIPTION
This is in preparation of having specialized code paths for useful special cases.

Slight speedup in VarDCT images (~3%), significant speedup on modular images (~30%).