### PR TITLE
Implement fast-lossless path

### DIFF
--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -198,6 +198,9 @@ pub(super) fn decode_modular_channel(
         TreeSpecialCase::WpOnly(t) => {
             decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
         }
+        TreeSpecialCase::SingleGradientOnly(t) => {
+            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
+        }
         TreeSpecialCase::General(t) => {
             decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
         }


### PR DESCRIPTION
Fast-lossless = single gradient predictor specialization + RLE histogram specialization. Maybe it could become faster with more special paths, but I just couldn't figure out how to do it properly (I tried to write manual decoding loop but it slightly got worse).

Also merged `RleSymbolReader` into `SymbolReader` as another LZ77 state (kind of).

Decoding libjxl lossless e1 got 1.4-1.5x faster on my machine. ~1.3x with the predictor specialization, and 10% more with RLE decoder.