### PR TITLE
Make `SymbolReader` optimistic

### DIFF
--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -111,9 +111,10 @@ impl CodestreamParser {
                         Err(e) => return Err(e),
                     }
                 }
+                let icc_result = self.icc_parser.take().unwrap().finalize(&mut br);
                 self.non_section_buf.consume(bits / 8);
                 self.non_section_bit_offset = (bits % 8) as u8;
-                JxlColorProfile::Icc(self.icc_parser.take().unwrap().finalize()?)
+                JxlColorProfile::Icc(icc_result?)
             } else {
                 JxlColorProfile::Simple(JxlColorEncoding::from_internal(
                     &file_header.image_metadata.color_encoding,

--- a/jxl/src/entropy_coding/context_map.rs
+++ b/jxl/src/entropy_coding/context_map.rs
@@ -58,7 +58,7 @@ pub fn decode_context_map(num_contexts: usize, br: &mut BitReader) -> Result<Vec
 
         let mut ctx_map: Vec<u8> = (0..num_contexts)
             .map(|_| {
-                let mv = reader.read_unsigned(&histograms, br, 0usize)?;
+                let mv = reader.read_unsigned(&histograms, br, 0usize);
                 if mv > u8::MAX as u32 {
                     Err(Error::InvalidContextMap(mv))
                 } else {
@@ -66,7 +66,7 @@ pub fn decode_context_map(num_contexts: usize, br: &mut BitReader) -> Result<Vec
                 }
             })
             .collect::<Result<_, _>>()?;
-        reader.check_final_state(&histograms)?;
+        reader.check_final_state(&histograms, br)?;
         if use_mtf {
             inverse_move_to_front(&mut ctx_map[..]);
         }

--- a/jxl/src/features/patches.rs
+++ b/jxl/src/features/patches.rs
@@ -368,7 +368,7 @@ impl PatchesDictionary {
             &patches_histograms,
             br,
             PatchContext::NumRefPatch as usize,
-        )? as usize;
+        ) as usize;
         let num_pixels = xsize * ysize;
         let max_ref_patches = 1024 + num_pixels / 4;
         let max_patches = max_ref_patches * 4;
@@ -390,7 +390,7 @@ impl PatchesDictionary {
                 &patches_histograms,
                 br,
                 PatchContext::ReferenceFrame as usize,
-            )? as usize;
+            ) as usize;
             if reference >= DecoderState::MAX_STORED_FRAMES {
                 return Err(Error::PatchesRefTooLarge(
                     reference,
@@ -402,23 +402,23 @@ impl PatchesDictionary {
                 &patches_histograms,
                 br,
                 PatchContext::PatchReferencePosition as usize,
-            )? as usize;
+            ) as usize;
             let y0 = patches_reader.read_unsigned(
                 &patches_histograms,
                 br,
                 PatchContext::PatchReferencePosition as usize,
-            )? as usize;
+            ) as usize;
             let ref_pos_xsize = patches_reader.read_unsigned(
                 &patches_histograms,
                 br,
                 PatchContext::PatchSize as usize,
-            )? as usize
+            ) as usize
                 + 1;
             let ref_pos_ysize = patches_reader.read_unsigned(
                 &patches_histograms,
                 br,
                 PatchContext::PatchSize as usize,
-            )? as usize
+            ) as usize
                 + 1;
             let reference_frame = &reference_frames[reference];
             // TODO(firsching): make sure this check is correct in the presence of downsampled extra channels (also in libjxl).
@@ -451,7 +451,7 @@ impl PatchesDictionary {
                 &patches_histograms,
                 br,
                 PatchContext::PatchCount as usize,
-            )? as usize
+            ) as usize
                 + 1;
             if id_count > max_patches + 1 {
                 return Err(Error::PatchesTooMany(
@@ -499,19 +499,19 @@ impl PatchesDictionary {
                         &patches_histograms,
                         br,
                         PatchContext::PatchPosition as usize,
-                    )? as usize;
+                    ) as usize;
                     pos.y = patches_reader.read_unsigned(
                         &patches_histograms,
                         br,
                         PatchContext::PatchPosition as usize,
-                    )? as usize;
+                    ) as usize;
                 } else {
                     // Read offsets and calculate new position
                     let delta_x = patches_reader.read_signed(
                         &patches_histograms,
                         br,
                         PatchContext::PatchOffset as usize,
-                    )?;
+                    );
                     if delta_x < 0 && (-delta_x as usize) > positions.last().unwrap().x {
                         return Err(Error::PatchesInvalidDelta(
                             "x".to_string(),
@@ -525,7 +525,7 @@ impl PatchesDictionary {
                         &patches_histograms,
                         br,
                         PatchContext::PatchOffset as usize,
-                    )?;
+                    );
                     if delta_y < 0 && (-delta_y as usize) > positions.last().unwrap().y {
                         return Err(Error::PatchesInvalidDelta(
                             "y".to_string(),
@@ -560,7 +560,7 @@ impl PatchesDictionary {
                         &patches_histograms,
                         br,
                         PatchContext::PatchBlendMode as usize,
-                    )? as u8;
+                    ) as u8;
                     let blend_mode = match PatchBlendMode::from_u8(maybe_blend_mode) {
                         None => {
                             return Err(Error::PatchesInvalidBlendMode(
@@ -576,7 +576,7 @@ impl PatchesDictionary {
                             &patches_histograms,
                             br,
                             PatchContext::PatchAlphaChannel as usize,
-                        )? as usize;
+                        ) as usize;
                         if alpha_channel >= num_extra_channels {
                             return Err(Error::PatchesInvalidAlphaChannel(
                                 alpha_channel,
@@ -590,7 +590,7 @@ impl PatchesDictionary {
                             &patches_histograms,
                             br,
                             PatchContext::PatchClamp as usize,
-                        )? != 0;
+                        ) != 0;
                     }
                     blendings.push(PatchBlending {
                         mode: blend_mode,

--- a/jxl/src/features/spline.rs
+++ b/jxl/src/features/spline.rs
@@ -185,7 +185,7 @@ impl QuantizedSpline {
         total_num_control_points: &mut u32,
     ) -> Result<QuantizedSpline> {
         let num_control_points =
-            splines_reader.read_unsigned(splines_histograms, br, NUM_CONTROL_POINTS_CONTEXT)?;
+            splines_reader.read_unsigned(splines_histograms, br, NUM_CONTROL_POINTS_CONTEXT);
         *total_num_control_points += num_control_points;
         if *total_num_control_points > max_control_points {
             return Err(Error::SplinesTooManyControlPoints(
@@ -196,9 +196,9 @@ impl QuantizedSpline {
         let mut control_points = Vec::new_with_capacity(num_control_points as usize)?;
         for _ in 0..num_control_points {
             let x =
-                splines_reader.read_signed(splines_histograms, br, CONTROL_POINTS_CONTEXT)? as i64;
+                splines_reader.read_signed(splines_histograms, br, CONTROL_POINTS_CONTEXT) as i64;
             let y =
-                splines_reader.read_signed(splines_histograms, br, CONTROL_POINTS_CONTEXT)? as i64;
+                splines_reader.read_signed(splines_histograms, br, CONTROL_POINTS_CONTEXT) as i64;
             control_points.push((x, y));
             // Add check that double deltas are not outrageous (not in spec).
             let max_delta_delta = x.abs().max(y.abs());
@@ -212,7 +212,7 @@ impl QuantizedSpline {
 
         let mut decode_dct = |dct: &mut [i32; 32]| -> Result<()> {
             for value in dct.iter_mut() {
-                *value = splines_reader.read_signed(splines_histograms, br, DCT_CONTEXT)?;
+                *value = splines_reader.read_signed(splines_histograms, br, DCT_CONTEXT);
             }
             Ok(())
         };
@@ -716,7 +716,7 @@ impl Splines {
         let splines_histograms = Histograms::decode(NUM_SPLINE_CONTEXTS, br, true)?;
         let mut splines_reader = SymbolReader::new(&splines_histograms, br, None)?;
         let num_splines =
-            1 + splines_reader.read_unsigned(&splines_histograms, br, NUM_SPLINES_CONTEXT)?;
+            1 + splines_reader.read_unsigned(&splines_histograms, br, NUM_SPLINES_CONTEXT);
         let max_control_points =
             MAX_NUM_CONTROL_POINTS.min(num_pixels / MAX_NUM_CONTROL_POINTS_PER_PIXEL_RATIO);
         if num_splines > max_control_points {
@@ -728,9 +728,9 @@ impl Splines {
         let mut last_y = 0;
         for i in 0..num_splines {
             let unsigned_x =
-                splines_reader.read_unsigned(&splines_histograms, br, STARTING_POSITION_CONTEXT)?;
+                splines_reader.read_unsigned(&splines_histograms, br, STARTING_POSITION_CONTEXT);
             let unsigned_y =
-                splines_reader.read_unsigned(&splines_histograms, br, STARTING_POSITION_CONTEXT)?;
+                splines_reader.read_unsigned(&splines_histograms, br, STARTING_POSITION_CONTEXT);
 
             let (x, y) = if i != 0 {
                 (
@@ -759,7 +759,7 @@ impl Splines {
         }
 
         let quantization_adjustment =
-            splines_reader.read_signed(&splines_histograms, br, QUANTIZATION_ADJUSTMENT_CONTEXT)?;
+            splines_reader.read_signed(&splines_histograms, br, QUANTIZATION_ADJUSTMENT_CONTEXT);
 
         let mut splines = Vec::new();
         let mut num_control_points = 0u32;
@@ -772,7 +772,7 @@ impl Splines {
                 &mut num_control_points,
             )?);
         }
-        splines_reader.check_final_state(&splines_histograms)?;
+        splines_reader.check_final_state(&splines_histograms, br)?;
         Ok(Splines {
             quantization_adjustment,
             splines,

--- a/jxl/src/frame/coeff_order.rs
+++ b/jxl/src/frame/coeff_order.rs
@@ -117,7 +117,7 @@ pub fn decode_coeff_orders(used_orders: u32, br: &mut BitReader) -> Result<Vec<P
             permutations[index].compose(&permutation);
         }
     }
-    reader.check_final_state(&histograms)?;
+    reader.check_final_state(&histograms, br)?;
     Ok(permutations)
 }
 

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -455,8 +455,7 @@ pub fn decode_vardct_group(
                     .nonzero_context(predicted_nzeros, block_context)
                     + context_offset;
                 let mut nonzeros =
-                    reader.read_unsigned(&hf_global.passes[pass].histograms, br, nonzero_context)?
-                        as usize;
+                    reader.read_unsigned(&pass_info.histograms, br, nonzero_context) as usize;
                 trace!(
                     "block ({},{},{c}) predicted_nzeros: {predicted_nzeros} \
                        nzero_ctx: {nonzero_context} (offset: {context_offset}) \
@@ -484,7 +483,7 @@ pub fn decode_vardct_group(
                     let ctx =
                         histo_offset + zero_density_context(nonzeros, k, log_num_blocks, prev);
                     let coeff =
-                        reader.read_signed(&pass_info.histograms, br, ctx)? << shift_for_pass;
+                        reader.read_signed(&pass_info.histograms, br, ctx) << shift_for_pass;
                     prev = if coeff != 0 { 1 } else { 0 };
                     nonzeros -= prev;
                     let coeff_index = permutation[k] as usize;
@@ -528,6 +527,6 @@ pub fn decode_vardct_group(
             coeffs_offset += num_coeffs;
         }
     }
-    reader.check_final_state(&hf_global.passes[pass].histograms)?;
+    reader.check_final_state(&hf_global.passes[pass].histograms, br)?;
     Ok(())
 }

--- a/jxl/src/frame/modular/decode/bitstream.rs
+++ b/jxl/src/frame/modular/decode/bitstream.rs
@@ -83,7 +83,7 @@ pub fn decode_modular_subbitstream(
         decode_modular_channel(&mut buffers, i, stream_id, &header, tree, &mut reader, br)?;
     }
 
-    reader.check_final_state(&tree.histograms)?;
+    reader.check_final_state(&tree.histograms, br)?;
 
     drop(buffers);
 

--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -72,8 +72,7 @@ fn decode_modular_channel_small(
                 &references,
                 &mut property_buffer,
             );
-            let dec =
-                reader.read_signed(&tree.histograms, br, prediction_result.context as usize)?;
+            let dec = reader.read_signed(&tree.histograms, br, prediction_result.context as usize);
             let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
             row[x] = val;
             wp_state.update_errors(val, (x, y), size.0);
@@ -95,7 +94,7 @@ pub(super) trait ModularChannelDecoder {
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
-    ) -> Result<i32>;
+    ) -> i32;
 }
 
 #[inline(never)]
@@ -130,14 +129,14 @@ fn decode_modular_channel_impl<D: ModularChannelDecoder>(
         let mut prediction_data = PredictionData::default();
         for x in 0..2 {
             prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
-            let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br)?;
+            let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br);
             row[x] = val;
             last = val;
         }
         if y < 2 {
             for x in 2..size.0 - 2 {
                 let prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
-                let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br)?;
+                let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br);
                 row[x] = val;
             }
         } else {
@@ -151,14 +150,14 @@ fn decode_modular_channel_impl<D: ModularChannelDecoder>(
                     D::NEEDS_TOPTOP,
                 );
                 let val =
-                    decoder.decode_one(prediction_data, (x, y), size.0, reader, br, histograms)?;
+                    decoder.decode_one(prediction_data, (x, y), size.0, reader, br, histograms);
                 *r = val;
                 last = val;
             }
         }
         for x in size.0 - 2..size.0 {
             prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
-            let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br)?;
+            let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br);
             row[x] = val;
         }
     }
@@ -166,7 +165,7 @@ fn decode_modular_channel_impl<D: ModularChannelDecoder>(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[instrument(level = "debug", skip(buffers, reader, tree, br))]
+#[instrument(level = "debug", skip(buffers, reader, tree))]
 pub(super) fn decode_modular_channel(
     buffers: &mut [&mut ModularChannel],
     chan: usize,

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -73,7 +73,7 @@ impl ModularChannelDecoder for NoWpTree {
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
-    ) -> Result<i32> {
+    ) -> i32 {
         let prediction_result = predict(
             &self.nodes,
             prediction_data,
@@ -84,12 +84,8 @@ impl ModularChannelDecoder for NoWpTree {
             &self.references,
             &mut self.property_buffer,
         );
-        let dec = reader.read_signed(histograms, br, prediction_result.context as usize)?;
-        Ok(make_pixel(
-            dec,
-            prediction_result.multiplier,
-            prediction_result.guess,
-        ))
+        let dec = reader.read_signed(histograms, br, prediction_result.context as usize);
+        make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
     }
 }
 
@@ -131,7 +127,7 @@ impl ModularChannelDecoder for GeneralTree {
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
-    ) -> Result<i32> {
+    ) -> i32 {
         let prediction_result = predict(
             &self.no_wp_tree.nodes,
             prediction_data,
@@ -142,10 +138,10 @@ impl ModularChannelDecoder for GeneralTree {
             &self.no_wp_tree.references,
             &mut self.no_wp_tree.property_buffer,
         );
-        let dec = reader.read_signed(histograms, br, prediction_result.context as usize)?;
+        let dec = reader.read_signed(histograms, br, prediction_result.context as usize);
         let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
         self.wp_state.update_errors(val, pos, xsize);
-        Ok(val)
+        val
     }
 }
 
@@ -239,16 +235,16 @@ impl ModularChannelDecoder for WpOnlyLookup {
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
-    ) -> Result<i32> {
+    ) -> i32 {
         let (wp_pred, property) = self
             .wp_state
             .predict_and_property(pos, xsize, &prediction_data);
         let ctx =
             self.lut[(property - LUT_MIN_SPLITVAL).clamp(0, LUT_TABLE_SIZE as i32 - 1) as usize];
-        let dec = reader.read_signed_clustered(histograms, br, ctx as usize)?;
+        let dec = reader.read_signed_clustered(histograms, br, ctx as usize);
         let val = dec + wp_pred as i32;
         self.wp_state.update_errors(val, pos, xsize);
-        Ok(val)
+        val
     }
 }
 
@@ -271,10 +267,10 @@ impl ModularChannelDecoder for SingleGradientOnly {
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
-    ) -> Result<i32> {
+    ) -> i32 {
         let pred = Predictor::Gradient.predict_one(prediction_data, 0);
-        let dec = reader.read_signed(histograms, br, self.ctx)?;
-        Ok(make_pixel(dec, 1, pred))
+        let dec = reader.read_signed(histograms, br, self.ctx);
+        make_pixel(dec, 1, pred)
     }
 }
 

--- a/jxl/src/frame/modular/tree.rs
+++ b/jxl/src/frame/modular/tree.rs
@@ -193,7 +193,7 @@ impl Tree {
                 tree.try_reserve(tree.len() * 2 + 1)?;
             }
             to_decode -= 1;
-            let property = tree_reader.read_unsigned(&tree_histograms, br, PROPERTY_CONTEXT)?;
+            let property = tree_reader.read_unsigned(&tree_histograms, br, PROPERTY_CONTEXT);
             trace!(property);
             if let Some(property) = property.checked_sub(1) {
                 // inner node.
@@ -201,7 +201,7 @@ impl Tree {
                     return Err(Error::InvalidProperty(property));
                 }
                 max_property = max_property.max(property);
-                let splitval = tree_reader.read_signed(&tree_histograms, br, SPLIT_VAL_CONTEXT)?;
+                let splitval = tree_reader.read_signed(&tree_histograms, br, SPLIT_VAL_CONTEXT);
                 let left_child = (tree.len() + to_decode + 1) as u32;
                 let node = TreeNode::Split {
                     property: property as u8,
@@ -217,15 +217,15 @@ impl Tree {
                     &tree_histograms,
                     br,
                     PREDICTOR_CONTEXT,
-                )?)?;
-                let offset = tree_reader.read_signed(&tree_histograms, br, OFFSET_CONTEXT)?;
+                ))?;
+                let offset = tree_reader.read_signed(&tree_histograms, br, OFFSET_CONTEXT);
                 let mul_log =
-                    tree_reader.read_unsigned(&tree_histograms, br, MULTIPLIER_LOG_CONTEXT)?;
+                    tree_reader.read_unsigned(&tree_histograms, br, MULTIPLIER_LOG_CONTEXT);
                 if mul_log >= 31 {
                     return Err(Error::TreeMultiplierTooLarge(mul_log, 31));
                 }
                 let mul_bits =
-                    tree_reader.read_unsigned(&tree_histograms, br, MULTIPLIER_BITS_CONTEXT)?;
+                    tree_reader.read_unsigned(&tree_histograms, br, MULTIPLIER_BITS_CONTEXT);
                 let multiplier = (mul_bits as u64 + 1) << mul_log;
                 if multiplier > (u32::MAX as u64) {
                     return Err(Error::TreeMultiplierBitsTooLarge(mul_bits, mul_log));
@@ -241,7 +241,7 @@ impl Tree {
                 tree.push(node);
             }
         }
-        tree_reader.check_final_state(&tree_histograms)?;
+        tree_reader.check_final_state(&tree_histograms, br)?;
 
         let num_properties = max_property as usize + 1;
         let mut property_ranges = Vec::new_with_capacity(num_properties * tree.len())?;

--- a/jxl/src/headers/permutation.rs
+++ b/jxl/src/headers/permutation.rs
@@ -29,7 +29,7 @@ impl Permutation {
         br: &mut BitReader,
         entropy_reader: &mut SymbolReader,
     ) -> Result<Self> {
-        let end = entropy_reader.read_unsigned(histograms, br, get_context(size))?;
+        let end = entropy_reader.read_unsigned(histograms, br, get_context(size));
         Self::decode_inner(size, skip, end, |ctx| {
             entropy_reader.read_unsigned(histograms, br, ctx)
         })
@@ -39,7 +39,7 @@ impl Permutation {
         size: u32,
         skip: u32,
         end: u32,
-        mut read: impl FnMut(usize) -> Result<u32>,
+        mut read: impl FnMut(usize) -> u32,
     ) -> Result<Self> {
         if end > size - skip {
             return Err(Error::InvalidPermutationSize { size, skip, end });
@@ -49,7 +49,7 @@ impl Permutation {
 
         let mut prev_val = 0u32;
         for idx in skip..(skip + end) {
-            let val = read(get_context(prev_val))?;
+            let val = read(get_context(prev_val));
             if val >= size - idx {
                 return Err(Error::InvalidPermutationLehmerCode {
                     size,


### PR DESCRIPTION
`SymbolReader` keeps read error in its internal state, and reports it when `.check_final_state()` is called.

About 1% to 10% speedups, depending on the image.