### PR TITLE
Tighten the size of some buffers.

### DIFF
--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -45,9 +45,6 @@ fn decode_modular_channel_small(
     let mut references = Image::<i32>::new((num_ref_props, size.0))?;
     let num_properties = NUM_NONREF_PROPERTIES + num_ref_props;
 
-    assert_eq!(buffers[chan].data.padding(), IMAGE_PADDING);
-    assert_eq!(buffers[chan].data.offset(), IMAGE_OFFSET);
-
     const { assert!(IMAGE_OFFSET.1 == 2) };
 
     for y in 0..size.1 {
@@ -184,7 +181,8 @@ pub(super) fn decode_modular_channel(
         return decode_modular_channel_small(buffers, chan, stream_id, header, tree, reader, br);
     }
 
-    assert_eq!(buffers[chan].data.padding(), IMAGE_PADDING);
+    assert_eq!(buffers[chan].data.padding().1, IMAGE_PADDING.1);
+    assert!(buffers[chan].data.padding().0 >= IMAGE_PADDING.0);
     assert_eq!(buffers[chan].data.offset(), IMAGE_OFFSET);
 
     // We now know the channel has size at least IMAGE_PADDING.

--- a/jxl/src/render/low_memory_pipeline/row_buffers.rs
+++ b/jxl/src/render/low_memory_pipeline/row_buffers.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// Temporary storage for data rows. Note that the first pixel of the group is expected to be
-/// located *two cachelines worth of data* inside the row.
+/// located *one cacheline worth of data* inside the row.
 pub struct RowBuffer {
     buffer: Box<[CacheLine]>,
     // Distance (in number of *cache lines*) between the start of two rows.
@@ -36,9 +36,9 @@ impl RowBuffer {
         row_len: usize,
     ) -> Result<Self> {
         let num_rows = (1 << y_shift) + 2 * next_y_border;
-        // Input offset is at *one* cacheline, and we need up to *three* cachelines on the other
+        // Input offset is at *one* cacheline, and we need up to *two* cachelines on the other
         // side as the data might exceed xsize slightly.
-        let row_stride = (row_len * data_type.size()).div_ceil(CACHE_LINE_BYTE_SIZE) + 4;
+        let row_stride = (row_len * data_type.size()).div_ceil(CACHE_LINE_BYTE_SIZE) + 3;
         let mut buffer = Vec::<CacheLine>::new();
         buffer.try_reserve_exact(row_stride * num_rows)?;
         buffer.resize(row_stride * num_rows, CacheLine::default());

--- a/jxl/src/render/simple_pipeline/extend.rs
+++ b/jxl/src/render/simple_pipeline/extend.rs
@@ -6,7 +6,7 @@
 use crate::{
     image::{Image, ImageDataType},
     render::stages::ExtendToImageDimensionsStage,
-    util::{round_up_size_to_two_cache_lines, tracing_wrappers::*},
+    util::{round_up_size_to_cache_line, tracing_wrappers::*},
 };
 
 impl ExtendToImageDimensionsStage {
@@ -57,7 +57,7 @@ impl ExtendToImageDimensionsStage {
             }
         }
         // Fill in rows above and below the original data.
-        let mut buffer = vec![f32::default(); round_up_size_to_two_cache_lines::<f32>(chunk_size)];
+        let mut buffer = vec![f32::default(); round_up_size_to_cache_line::<f32>(chunk_size)];
         for y in (0..y0).chain(y1..output_size.1) {
             for x in (0..output_size.0).step_by(chunk_size) {
                 let xsize = output_size.0.min(x + chunk_size) - x;

--- a/jxl/src/render/simple_pipeline/run_stage.rs
+++ b/jxl/src/render/simple_pipeline/run_stage.rs
@@ -13,7 +13,7 @@ use crate::{
         RenderPipelineInOutStage, RenderPipelineInPlaceStage, RunInOutStage, RunInPlaceStage,
         internal::PipelineBuffer,
     },
-    util::{round_up_size_to_two_cache_lines, tracing_wrappers::*},
+    util::{round_up_size_to_cache_line, tracing_wrappers::*},
 };
 
 impl PipelineBuffer for Image<f64> {
@@ -39,7 +39,7 @@ impl<T: RenderPipelineInPlaceStage> RunInPlaceStage<Image<f64>> for T {
         }
         let mut buffer =
             vec![
-                vec![T::Type::default(); round_up_size_to_two_cache_lines::<T::Type>(chunk_size)];
+                vec![T::Type::default(); round_up_size_to_cache_line::<T::Type>(chunk_size)];
                 numc
             ];
         for y in 0..size.1 {
@@ -101,8 +101,8 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<Image<f64>> for T {
                 vec![
                     T::InputT::default();
                     // Double rounding make sure that we always have enough buffer for reading a whole SIMD lane.
-                    round_up_size_to_two_cache_lines::<T::OutputT>(
-                        round_up_size_to_two_cache_lines::<T::OutputT>(chunk_size)
+                    round_up_size_to_cache_line::<T::OutputT>(
+                        round_up_size_to_cache_line::<T::OutputT>(chunk_size)
                             + T::BORDER.0 as usize * 2
                     )
                 ];
@@ -114,7 +114,7 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<Image<f64>> for T {
             vec![
                 vec![
                     T::OutputT::default();
-                    round_up_size_to_two_cache_lines::<T::OutputT>(chunk_size)
+                    round_up_size_to_cache_line::<T::OutputT>(chunk_size)
                         << T::SHIFT.0
                 ];
                 1 << T::SHIFT.1

--- a/jxl/src/render/stages/xyb.rs
+++ b/jxl/src/render/stages/xyb.rs
@@ -266,7 +266,7 @@ mod test {
     use crate::headers::encodings::Empty;
     use crate::image::Image;
     use crate::render::test::make_and_run_simple_pipeline;
-    use crate::util::round_up_size_to_two_cache_lines;
+    use crate::util::round_up_size_to_cache_line;
     use crate::util::test::assert_all_almost_abs_eq;
     use jxl_simd::{ScalarDescriptor, SimdDescriptor, test_all_instruction_sets};
 
@@ -310,9 +310,9 @@ mod test {
         arbtest::arbtest(|u| {
             let xsize = u.arbitrary_len::<usize>()?;
             let intensity_target = u.arbitrary::<u8>()? as f32 * 2.0 + 1.0;
-            let mut row_x = vec![0.0; round_up_size_to_two_cache_lines::<f32>(xsize)];
-            let mut row_y = vec![0.0; round_up_size_to_two_cache_lines::<f32>(xsize)];
-            let mut row_b = vec![0.0; round_up_size_to_two_cache_lines::<f32>(xsize)];
+            let mut row_x = vec![0.0; round_up_size_to_cache_line::<f32>(xsize)];
+            let mut row_y = vec![0.0; round_up_size_to_cache_line::<f32>(xsize)];
+            let mut row_b = vec![0.0; round_up_size_to_cache_line::<f32>(xsize)];
 
             for i in 0..xsize {
                 row_x[i] = u.arbitrary::<i16>()? as f32 * (0.07 / i16::MAX as f32);

--- a/jxl/src/util/cacheline.rs
+++ b/jxl/src/util/cacheline.rs
@@ -19,8 +19,8 @@ pub const fn num_per_cache_line<T>() -> usize {
     CACHE_LINE_BYTE_SIZE / std::mem::size_of::<T>()
 }
 
-pub fn round_up_size_to_two_cache_lines<T>(size: usize) -> usize {
-    let n = const { num_per_cache_line::<T>() * 2 };
+pub fn round_up_size_to_cache_line<T>(size: usize) -> usize {
+    let n = const { num_per_cache_line::<T>() };
     size.div_ceil(n) * n
 }
 


### PR DESCRIPTION
Also ensure that image padding takes into account the padding to the size of a cache line that allocating a OwnedRawImage creates.

Minor (1~2%) speedup, preparation for pipeline improvements.