### PR TITLE
Added a perfhistory command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +482,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +526,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +556,108 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indenter"
@@ -529,7 +692,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -557,7 +720,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "paste",
- "rand",
+ "rand 0.9.2",
  "rand_xorshift",
  "test-log",
  "thiserror",
@@ -590,6 +753,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jxl_perfhistory"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "color-eyre",
+ "git2",
+ "rand 0.9.2",
+ "statrs",
+ "tempdir",
+]
+
+[[package]]
 name = "jxl_simd"
 version = "0.1.1"
 dependencies = [
@@ -604,8 +779,8 @@ dependencies = [
  "criterion",
  "jxl_simd",
  "paste",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "test-log",
 ]
 
@@ -651,6 +826,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +890,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
 ]
 
 [[package]]
@@ -682,12 +919,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -702,12 +975,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -738,6 +1032,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +1060,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -800,6 +1118,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -859,12 +1186,46 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -874,7 +1235,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -883,7 +1268,17 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -892,8 +1287,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -913,6 +1314,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -945,6 +1355,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1380,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -1030,6 +1458,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1481,24 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "strsim"
@@ -1056,6 +1515,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -1107,6 +1587,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1191,10 +1681,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1209,6 +1723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1737,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1283,6 +1809,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1842,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1313,6 +1871,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1913,60 @@ name = "zerocopy-derive"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ debug = true
 debug = true
 
 [workspace]
-members = ["jxl", "jxl_cli", "jxl_macros", "jxl_simd", "jxl_transforms"]
+members = ["jxl", "jxl_cli", "jxl_macros", "jxl_perfhistory", "jxl_simd", "jxl_transforms"]
 resolver = "2"
 
 [workspace.lints.clippy]

--- a/jxl_perfhistory/Cargo.toml
+++ b/jxl_perfhistory/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "jxl_perfhistory"
+version = "0.1.0"
+edition = "2024"
+license = "BSD-3-Clause"
+
+[dependencies]
+clap = { version = "4.5.18", features = ["derive"] }
+git2 = "0.19"
+color-eyre = "0.6.5"
+statrs = "0.18.0"
+tempdir = "0.3.7"
+rand = "0.9.2"
+
+[lints]
+workspace = true

--- a/jxl_perfhistory/src/main.rs
+++ b/jxl_perfhistory/src/main.rs
@@ -1,0 +1,382 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use clap::Parser;
+use color_eyre::eyre::{Result, eyre};
+use git2::{Oid, Repository};
+use rand::Rng;
+use statrs::distribution::{ContinuousCDF, StudentsT};
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::Command;
+use tempdir::TempDir;
+
+#[derive(Parser, Debug)]
+#[command(name = "jxl_perfhistory")]
+#[command(about = "Benchmark jxl_cli across git revisions", long_about = None)]
+struct Args {
+    /// Number of revisions to go back from HEAD
+    #[arg(short = 'r', long = "revisions", default_value = "10")]
+    revisions: usize,
+
+    /// Path to the JXL file to decode
+    #[arg(short = 'f', long = "file")]
+    jxl_file: String,
+
+    /// Required confidence interval for measured decoding speed
+    #[arg(short = 'c', long = "confidence", default_value = "0.95")]
+    confidence: f64,
+
+    /// Maximum relative error for measured decoding speed
+    #[arg(short = 'e', long = "error", default_value = "0.05")]
+    rel_error: f64,
+
+    /// Minimum number of measurements per revision
+    #[arg(short = 'm', long = "min-measurements", default_value = "10")]
+    min_measurements: usize,
+
+    /// Persistent directory to put the built binaries in - a temporary directory will be used if not provided
+    #[arg(short = 'b', long = "binary-directory")]
+    binary_directory: Option<String>,
+}
+
+#[derive(Debug)]
+struct Revision {
+    oid: Oid,
+    summary: String,
+    binary_path: Option<String>,
+    measurements: Vec<f64>,
+    mean: Option<f64>,
+    rel_error: Option<f64>,
+    ordinal: usize,
+}
+
+macro_rules! print_flush {
+    ($($arg:tt)*) => {{
+        print!($($arg)*);
+        io::stdout().flush().unwrap();
+    }};
+}
+
+impl Revision {
+    /// Compute credible interval for a constant value measured with noise
+    ///
+    /// With uninformative priors, the Bayesian credible interval equals the
+    /// frequentist t-interval. Each measurement = true_value + noise, with
+    /// unknown true value and noise variance.
+    pub fn compute(&mut self, confidence: f64) -> Result<()> {
+        if !(0f64..=1f64).contains(&confidence) {
+            return Err(eyre!("Can't compute with confidence {}", confidence));
+        }
+        let n = self.measurements.len() as f64;
+        if n <= 2f64 {
+            return Err(eyre!("Can't compute with {} measurements", n));
+        }
+        let mean = self.measurements.iter().sum::<f64>() / n;
+
+        let variance = self
+            .measurements
+            .iter()
+            .map(|x| (x - mean).powi(2))
+            .sum::<f64>()
+            / (n - 1.0);
+        let std_error = (variance / n).sqrt();
+
+        let t_dist = StudentsT::new(0.0, 1.0, n - 1.0).unwrap();
+        let t_critical = t_dist.inverse_cdf(1.0 - (1.0 - confidence) / 2.0);
+        let margin = t_critical * std_error;
+
+        self.mean = Some(mean);
+        self.rel_error = Some(margin / mean.abs());
+        Ok(())
+    }
+    pub fn benchmark(&mut self, jxl_file: &String) -> Result<()> {
+        let output = Command::new(self.binary_path.as_ref().unwrap())
+            .arg(jxl_file)
+            .args(["--speedtest", "--num-reps", "1"])
+            .output()?;
+        if !output.status.success() {
+            return Err(eyre!(
+                "Build failed for {:.8}!\n{}",
+                self.oid,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let pixels_per_sec: f64 = stdout
+            .lines()
+            .find(|line| line.contains("pixels/s") && line.contains("Decoded"))
+            .and_then(|line| line.split_whitespace().rev().nth(1))
+            .ok_or_else(|| eyre!("Can't find decoding speed in `{}`", stdout))?
+            .parse()
+            .map_err(|e| eyre!("Can't parse decoding speed: {}", e))?;
+        self.measurements.push(pixels_per_sec);
+        Ok(())
+    }
+    pub fn build(&mut self, binary_dir: &Path) -> Result<()> {
+        let binary_path = binary_dir.join(self.oid.to_string());
+        self.binary_path = Some(binary_path.to_string_lossy().to_string());
+
+        if binary_path.exists() {
+            return Ok(());
+        }
+
+        let build = Command::new("cargo")
+            .args([
+                "build",
+                "--release",
+                "--package",
+                "jxl_cli",
+                "--bin",
+                "jxl_cli",
+            ])
+            .output()?;
+
+        if !build.status.success() {
+            return Err(eyre!(
+                "Build failed for {:.8}!\n{}",
+                self.oid,
+                String::from_utf8_lossy(&build.stderr)
+            ));
+        }
+
+        fs::copy(Path::new("target/release/jxl_cli"), &binary_path)?;
+
+        Ok(())
+    }
+    fn clipped_summary(&self, len: usize) -> String {
+        if self.summary.len() > len {
+            format!("{}...", &self.summary[..(len - 3)])
+        } else {
+            self.summary.clone()
+        }
+    }
+}
+
+fn collect_revisions(repo: &Repository, count: usize) -> Result<Vec<Revision>> {
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_head()?;
+
+    let mut ordinal = 0;
+    revwalk
+        .take(count)
+        .map(|oid| {
+            let oid = oid?;
+            ordinal += 1;
+            Ok(Revision {
+                oid,
+                summary: repo
+                    .find_commit(oid)?
+                    .summary()
+                    .unwrap_or("(no message)")
+                    .to_string(),
+                binary_path: None,
+                measurements: vec![],
+                mean: None,
+                rel_error: None,
+                ordinal: ordinal,
+            })
+        })
+        .collect()
+}
+
+fn checkout_revision(repo: &Repository, oid: Oid) -> Result<()> {
+    let commit = repo.find_commit(oid)?;
+
+    let mut opts = git2::build::CheckoutBuilder::new();
+    opts.safe(); // Don't overwrite modified files or remove untracked files
+
+    repo.checkout_tree(commit.as_object(), Some(&mut opts))?;
+    repo.set_head_detached(oid)?;
+
+    Ok(())
+}
+
+fn verify_repo(repo: &Repository) -> Result<String> {
+    let mut status_opts = git2::StatusOptions::new();
+    status_opts.include_untracked(false);
+    let statuses = repo.statuses(Some(&mut status_opts))?;
+    if !statuses.is_empty() {
+        return Err(eyre!(
+            "Working directory has uncommitted changes. Please commit or stash them first."
+        ));
+    }
+
+    // Save original HEAD state (branch or detached)
+    let head = repo.head()?;
+    if head.is_branch() {
+        head.name()
+            .ok_or(eyre!(
+                "Working directory doesn't have a name, won't be able to restore it properly."
+            ))
+            .map(|s| s.into())
+    } else {
+        Err(eyre!(
+            "Working directory isn't a checked out branch, won't be able to restore it properly."
+        ))
+    }
+}
+
+fn restore_repo(repo: &Repository, original_ref_name: String) -> Result<()> {
+    repo.set_head(&original_ref_name)?;
+    let mut opts = git2::build::CheckoutBuilder::new();
+    opts.force();
+    repo.checkout_head(Some(&mut opts))?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut rng = rand::rng();
+    let tmp_dir = TempDir::new("perfhistory")?;
+    let binary_dir = match &args.binary_directory {
+        Some(s) => Path::new(s),
+        None => tmp_dir.path(),
+    };
+    let repo = Repository::open(".")?;
+    let original_ref_name = verify_repo(&repo)?;
+
+    let result: Result<()> = (|| {
+        let mut unfinished_revisions = collect_revisions(&repo, args.revisions)?;
+        for rev in &mut unfinished_revisions {
+            checkout_revision(&repo, rev.oid)?;
+            print_flush!("Building {}: {}...", rev.oid, rev.summary);
+            rev.build(&binary_dir)?;
+            println!("done!");
+        }
+        restore_repo(&repo, original_ref_name)?;
+        let mut finished_revisions = vec![];
+        while !unfinished_revisions.is_empty() {
+            let idx = rng.random_range(0..unfinished_revisions.len());
+            let res = {
+                let rev = &mut unfinished_revisions[idx];
+                print_flush!("Benchmarking {:.8}: {:<50}...", rev.oid, rev.clipped_summary(50));
+                rev.benchmark(&args.jxl_file)?;
+                if rev.measurements.len() > 2 {
+                    let old_relative_error = rev.rel_error;
+                    rev.compute(args.confidence)?;
+                    if rev.measurements.len() >= args.min_measurements
+                        && rev.rel_error.unwrap() <= args.rel_error
+                    {
+                        println!(
+                            "done! {} samples, new mean/relative error ({:.2}/{:.4} (from {:?})) is *GOOD ENOUGH*, removing from unfinished set",
+                            rev.measurements.len(),
+                            rev.mean.unwrap(),
+                            rev.rel_error.unwrap(),
+                            old_relative_error,
+                        );
+                        true
+                    } else {
+                        println!(
+                            "done! {} samples, new mean/relative error: {:.2}/{:.4} (from {:?})",
+                            rev.measurements.len(),
+                            rev.mean.unwrap(),
+                            rev.rel_error.unwrap(),
+                            old_relative_error,
+                        );
+                        false
+                    }
+                } else {
+                    println!("done!");
+                    false
+                }
+            };
+            if res {
+                finished_revisions.push(unfinished_revisions.swap_remove(idx));
+            }
+        }
+        finished_revisions.sort_by(|a, b| a.ordinal.partial_cmp(&b.ordinal).unwrap());
+        print_results(&mut finished_revisions, &args);
+        Ok(())
+    })();
+
+    tmp_dir.close()?;
+
+    result?;
+
+    Ok(())
+}
+
+fn print_results(results: &[Revision], args: &Args) {
+    println!("\n{}", "=".repeat(80));
+    println!("BENCHMARK RESULTS using {}", args.jxl_file);
+    println!("{}", "=".repeat(80));
+
+    // Calculate statistics
+    let mut min = f64::MAX;
+    let mut max = f64::MIN;
+    let mut sum = 0f64;
+    for rev in results.iter() {
+        let m = rev.mean.unwrap();
+        min = min.min(m);
+        max = max.max(m);
+        sum += m;
+    }
+    let avg = sum / results.len() as f64;
+
+    println!("\nStatistics:");
+    println!("  Samples:            {:>15}", results.len());
+    println!("  Confidence:         {:>15.1}%", 100f64 * args.confidence);
+    println!("  Max relative error: {:>15.1}%", 100f64 * args.rel_error);
+    println!("  Min:                {:>15.2} pixels/s", min);
+    println!("  Max:                {:>15.2} pixels/s", max);
+    println!("  Average:            {:>15.2} pixels/s", avg);
+    println!(
+        "  Improvement:        {:>15.2}% (max vs min)",
+        ((max - min) / min) * 100.0
+    );
+
+    // Show performance graph
+    println!("\n{}", "=".repeat(80));
+    println!("Performance Graph (normalized to max):");
+    println!("{}", "-".repeat(80));
+
+    for (i, result) in results.iter().enumerate() {
+        let speed = result.mean.unwrap();
+        let normalized = ((speed - min) / (max - min) * 40.0) as usize;
+        let bar = "█".repeat(normalized.max(1));
+
+        let marker = if speed == max {
+            "▲ MAX"
+        } else if speed == min {
+            "▼ MIN"
+        } else {
+            ""
+        };
+
+        println!(
+            "[{:2}] {:.8} {:<50} {:40} {:.2} {}",
+            i + 1,
+            result.oid,
+            result.clipped_summary(50),
+            bar,
+            speed,
+            marker
+        );
+    }
+
+    println!("{}", "-".repeat(80));
+    println!("Scale: Min={:.0} pixels/s, Max={:.0} pixels/s", min, max);
+
+    println!("\nDetailed Results:");
+    println!("{}", "-".repeat(80));
+    println!(
+        "{:<4} {:<10} {:<50} {:>20}",
+        "#", "Commit", "Message", "Performance"
+    );
+    println!("{}", "-".repeat(80));
+
+    for (i, result) in results.iter().enumerate() {
+        println!(
+            "[{:2}] {:.8} {:<50} {:>20.2} pixels/s",
+            i + 1,
+            result.oid,
+            result.clipped_summary(50),
+            result.mean.unwrap()
+        );
+    }
+}


### PR DESCRIPTION
Used to compare speeds between git revisions.

================================================================================ BENCHMARK RESULTS using /home/zond/Downloads/nikon.jxl ================================================================================

Statistics:
  Samples:                         30
  Confidence:                    97.0%
  Max relative error:             3.0%
  Min:                    19779901.82 pixels/s
  Max:                    26344096.09 pixels/s
  Average:                22623293.22 pixels/s
  Improvement:                  33.19% (max vs min)

================================================================================ Performance Graph (normalized to max):
--------------------------------------------------------------------------------
[ 1] 146d99dd Added a perfhistory command                        █████████████████████████████████████    25948905.82
[ 2] 1437db17 SIMDify RCT                                        ██████████████████████████████████       25487263.82
[ 3] 87408a74 Tighten the size of some buffers.                  ████████████████████████████████████████ 26344096.09 ▲ MAX
[ 4] e2cbe7ed Make `SymbolReader` optimistic                     █████████████████████████████████████    25973837.36
[ 5] 582ec6f8 Implement fast-lossless path                       ████████████████████████████████████     25752257.18
[ 6] e08e966b Add `RleSymbolReader`                              █████████████████████████████████████    25999072.06
[ 7] 186d9e96 Update and clean up dependencies                   █████████████████████████████████████    25941291.22
[ 8] 70d37946 Add infrastructure for decoder special paths fo... █████████████████████████████████████    25975572.59
[ 9] b93d000b Speedup modular decoding.                          ███████████████████████████████          25019102.05
[10] 777cbbf6 Incremental TOC reader                             █████████████████████████                24029179.03
[11] fc2019d8 Made bit reader refill conditional (#476)          ██████████████████████████               24167049.30
[12] 2effc05c Actually free buffers that will not be used again. ████████████████████████                 23822833.87
[13] 149cd2b1 Made AnsHistogram::read branchless (#473)          ███████████████████                      22947418.82
[14] 0d2ce7f8 Cleaned up speedtest (#474)                        ███████████                              21685945.66
[15] 95eedfb3 SIMDify vertical unsqueeze                         ███                                      20352465.90
[16] 18d7705c Fix border handling for inner groups in the low... ███████                                  20945693.92
[17] 899280ae Avoiding br.peek when unnecessary (#471)           ███████                                  20984056.40
[18] c3a04163 Render groups eagerly (remove explicit `do_rend... ███                                      20389021.27
[19] 337d9ebe Let `Image`s have a "default rect".                █████████                                21278950.75
[20] 3d4b52ad SIMDify horizontal unsqueeze                       ██████                                   20769525.09
[21] a721f04c Fix benchmarks not running except for the topmo... ███                                      20364412.87
[22] 8993da1c Perform static dispatch when target feature is ... ███████                                  21016045.98
[23] 5ac07956 Update GitHub Actions workflow                     ██████                                   20890399.74
[24] 169bea3e Feature gate SIMD implementations                  █████████                                21335273.28
[25] 059236c1 Add SIMD implementation for NEON                   █████                                    20691281.86
[26] bd6c4989 Tweak vardct decoding to improve speed.            ███████                                  21042387.45
[27] 245e72da Improve loading of sigma in epf.                   █                                        19819255.82
[28] f94a53a2 Fix downsampling_bracket function. (#461)          █                                        19998933.27
[29] 261ba745 Fix images with empty squeeze residual channels... █                                        19779901.82 ▼ MIN
[30] 91866afc Get rid of SIGMA_PADDING.                          █                                        19947366.45
--------------------------------------------------------------------------------
Scale: Min=19779902 pixels/s, Max=26344096 pixels/s

Detailed Results:
-------------------------------------------------------------------------------- --------------------------------------------------------------------------------
[ 1] 146d99dd Added a perfhistory command                                 25948905.82 pixels/s
[ 2] 1437db17 SIMDify RCT                                                 25487263.82 pixels/s
[ 3] 87408a74 Tighten the size of some buffers.                           26344096.09 pixels/s
[ 4] e2cbe7ed Make `SymbolReader` optimistic                              25973837.36 pixels/s
[ 5] 582ec6f8 Implement fast-lossless path                                25752257.18 pixels/s
[ 6] e08e966b Add `RleSymbolReader`                                       25999072.06 pixels/s
[ 7] 186d9e96 Update and clean up dependencies                            25941291.22 pixels/s
[ 8] 70d37946 Add infrastructure for decoder special paths fo...          25975572.59 pixels/s
[ 9] b93d000b Speedup modular decoding.                                   25019102.05 pixels/s
[10] 777cbbf6 Incremental TOC reader                                      24029179.03 pixels/s
[11] fc2019d8 Made bit reader refill conditional (#476)                   24167049.30 pixels/s
[12] 2effc05c Actually free buffers that will not be used again.          23822833.87 pixels/s
[13] 149cd2b1 Made AnsHistogram::read branchless (#473)                   22947418.82 pixels/s
[14] 0d2ce7f8 Cleaned up speedtest (#474)                                 21685945.66 pixels/s
[15] 95eedfb3 SIMDify vertical unsqueeze                                  20352465.90 pixels/s
[16] 18d7705c Fix border handling for inner groups in the low...          20945693.92 pixels/s
[17] 899280ae Avoiding br.peek when unnecessary (#471)                    20984056.40 pixels/s
[18] c3a04163 Render groups eagerly (remove explicit `do_rend...          20389021.27 pixels/s
[19] 337d9ebe Let `Image`s have a "default rect".                         21278950.75 pixels/s
[20] 3d4b52ad SIMDify horizontal unsqueeze                                20769525.09 pixels/s
[21] a721f04c Fix benchmarks not running except for the topmo...          20364412.87 pixels/s
[22] 8993da1c Perform static dispatch when target feature is ...          21016045.98 pixels/s
[23] 5ac07956 Update GitHub Actions workflow                              20890399.74 pixels/s
[24] 169bea3e Feature gate SIMD implementations                           21335273.28 pixels/s
[25] 059236c1 Add SIMD implementation for NEON                            20691281.86 pixels/s
[26] bd6c4989 Tweak vardct decoding to improve speed.                     21042387.45 pixels/s
[27] 245e72da Improve loading of sigma in epf.                            19819255.82 pixels/s
[28] f94a53a2 Fix downsampling_bracket function. (#461)                   19998933.27 pixels/s
[29] 261ba745 Fix images with empty squeeze residual channels...          19779901.82 pixels/s
[30] 91866afc Get rid of SIGMA_PADDING.                                   19947366.45 pixels/s