### PR TITLE
Added criterion bench for decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
+ "criterion",
  "exr",
  "half",
  "jxl",

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -17,6 +17,7 @@ color-eyre = "0.6.5"
 
 [dev-dependencies]
 jxl_macros = { path = "../jxl_macros", features = ["test"] }
+criterion = { version = "0.7.0", features = ["html_reports"] }
 
 [features]
 tracing-subscriber = ["dep:tracing-subscriber", "jxl/tracing"]
@@ -31,3 +32,7 @@ neon = ["jxl/neon"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "decode"
+harness = false

--- a/jxl_cli/benches/decode.rs
+++ b/jxl_cli/benches/decode.rs
@@ -1,0 +1,68 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use criterion::{BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main};
+use jxl::api::JxlDecoderOptions;
+use jxl_cli::dec::{decode_bytes, decode_header};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn decode_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode");
+    group.sampling_mode(SamplingMode::Flat);
+
+    let paths: Vec<PathBuf> = std::env::var("JXL_FILES").map_or_else(
+        |_| {
+            let root_test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("jxl")
+                .join("resources")
+                .join("test");
+            [
+                &root_test_dir,
+                &root_test_dir.join("conformance_test_images"),
+            ]
+            .iter()
+            .flat_map(|path| {
+                fs::read_dir(path)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| p.is_file() && p.extension().is_some_and(|ext| ext == "jxl"))
+                    .collect::<Vec<PathBuf>>()
+            })
+            .collect()
+        },
+        |csv| csv.split(',').map(PathBuf::from).collect(),
+    );
+
+    for path in paths {
+        let bytes = fs::read(&path).unwrap();
+        let mut header_bytes = bytes.as_slice();
+        let header_decoder =
+            decode_header(&mut header_bytes, JxlDecoderOptions::default()).unwrap();
+        let pixel_count = header_decoder.basic_info().size.0 * header_decoder.basic_info().size.1;
+        group.throughput(criterion::Throughput::Elements(pixel_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(path.to_string_lossy()),
+            &path,
+            |b, _path| {
+                b.iter(|| {
+                    decode_bytes(&bytes, JxlDecoderOptions::default()).unwrap();
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = decode;
+    config = Criterion::default().sample_size(50);
+    targets = decode_benches
+);
+criterion_main!(decode);

--- a/jxl_cli/src/dec/mod.rs
+++ b/jxl_cli/src/dec/mod.rs
@@ -1,0 +1,142 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use std::time::{Duration, Instant};
+
+use color_eyre::eyre::{Result, eyre};
+use jxl::{
+    api::{
+        JxlAnimation, JxlBitDepth, JxlColorProfile, JxlColorType, JxlDecoder, JxlDecoderOptions,
+        JxlOutputBuffer, states::WithImageInfo,
+    },
+    image::{Image, ImageDataType, Rect},
+};
+
+pub struct ImageFrame<T: ImageDataType> {
+    pub channels: Vec<Image<T>>,
+    pub duration: f64,
+    pub color_type: JxlColorType,
+}
+
+pub struct DecodeOutput<T: ImageDataType> {
+    pub size: (usize, usize),
+    pub frames: Vec<ImageFrame<T>>,
+    pub original_bit_depth: JxlBitDepth,
+    pub output_profile: JxlColorProfile,
+    pub embedded_profile: JxlColorProfile,
+    pub jxl_animation: Option<JxlAnimation>,
+}
+
+pub fn decode_header(
+    input_buffer: &mut &[u8],
+    decoder_options: JxlDecoderOptions,
+) -> Result<JxlDecoder<WithImageInfo>> {
+    let mut initialized_decoder = JxlDecoder::<jxl::api::states::Initialized>::new(decoder_options);
+
+    // Process until we have image info
+    loop {
+        match initialized_decoder.process(input_buffer)? {
+            jxl::api::ProcessingResult::Complete { result } => break Ok(result),
+            jxl::api::ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                if input_buffer.is_empty() {
+                    break Err(eyre!("Source file truncated"));
+                }
+                initialized_decoder = fallback;
+            }
+        }
+    }
+}
+
+pub fn decode_bytes(
+    mut input_buffer: &[u8],
+    decoder_options: JxlDecoderOptions,
+) -> Result<(DecodeOutput<f32>, Duration)> {
+    let start = Instant::now();
+
+    let mut decoder_with_image_info = decode_header(&mut input_buffer, decoder_options)?;
+
+    let info = decoder_with_image_info.basic_info();
+    let embedded_profile = decoder_with_image_info.embedded_color_profile().clone();
+    let output_profile = decoder_with_image_info.output_color_profile().clone();
+
+    let mut image_data = DecodeOutput {
+        size: info.size,
+        frames: Vec::new(),
+        original_bit_depth: info.bit_depth.clone(),
+        output_profile,
+        embedded_profile,
+        jxl_animation: info.animation.clone(),
+    };
+
+    let extra_channels = info.extra_channels.len();
+    let pixel_format = decoder_with_image_info.current_pixel_format().clone();
+    let color_type = pixel_format.color_type;
+    // TODO(zond): This is the way the API works right now, let's improve it when the API is cleverer.
+    let samples_per_pixel = if color_type == JxlColorType::Grayscale {
+        1
+    } else {
+        3
+    };
+
+    loop {
+        let mut decoder_with_frame_info = loop {
+            match decoder_with_image_info.process(&mut input_buffer)? {
+                jxl::api::ProcessingResult::Complete { result } => break Ok(result),
+                jxl::api::ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                    if input_buffer.is_empty() {
+                        break Err(eyre!("Source file truncated"));
+                    }
+                    decoder_with_image_info = fallback;
+                }
+            }
+        }?;
+
+        let frame_header = decoder_with_frame_info.frame_header();
+
+        let mut outputs = vec![Image::<f32>::new((
+            image_data.size.0 * samples_per_pixel,
+            image_data.size.1,
+        ))?];
+
+        for _ in 0..extra_channels {
+            outputs.push(Image::<f32>::new(image_data.size)?);
+        }
+
+        let mut output_bufs: Vec<JxlOutputBuffer<'_>> = outputs
+            .iter_mut()
+            .map(|x| {
+                let rect = Rect {
+                    size: x.size(),
+                    origin: (0, 0),
+                };
+                JxlOutputBuffer::from_image_rect_mut(x.get_rect_mut(rect).into_raw())
+            })
+            .collect();
+
+        decoder_with_image_info = loop {
+            match decoder_with_frame_info.process(&mut input_buffer, &mut output_bufs)? {
+                jxl::api::ProcessingResult::Complete { result } => break Ok(result),
+                jxl::api::ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                    if input_buffer.is_empty() {
+                        break Err(eyre!("Source file truncated"));
+                    }
+                    decoder_with_frame_info = fallback;
+                }
+            }
+        }?;
+
+        image_data.frames.push(ImageFrame {
+            duration: frame_header.duration.unwrap_or(0.0),
+            channels: outputs,
+            color_type,
+        });
+
+        if !decoder_with_image_info.has_more_frames() {
+            break;
+        }
+    }
+
+    Ok((image_data, start.elapsed()))
+}

--- a/jxl_cli/src/enc/exr.rs
+++ b/jxl_cli/src/enc/exr.rs
@@ -7,7 +7,7 @@ pub use jxl_exr::to_exr;
 
 #[cfg(not(feature = "exr"))]
 mod jxl_exr {
-    use crate::DecodeOutput;
+    use crate::dec::DecodeOutput;
     use color_eyre::eyre::{Result, eyre};
     use std::io::{Seek, Write};
 
@@ -31,7 +31,7 @@ mod jxl_exr {
     use exr::meta::attribute::Chromaticities;
     use exr::prelude::*;
 
-    use crate::DecodeOutput;
+    use crate::dec::DecodeOutput;
 
     pub fn to_exr<Writer: Write + Seek>(
         image_data: &DecodeOutput<f32>,

--- a/jxl_cli/src/enc/numpy.rs
+++ b/jxl_cli/src/enc/numpy.rs
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use crate::DecodeOutput;
+use crate::dec::DecodeOutput;
 use jxl::error::{Error, Result};
 use std::io::Write;
 

--- a/jxl_cli/src/enc/png.rs
+++ b/jxl_cli/src/enc/png.rs
@@ -7,7 +7,7 @@ use jxl::api::{
     JxlColorEncoding, JxlColorProfile, JxlPrimaries, JxlTransferFunction, JxlWhitePoint,
 };
 
-use crate::DecodeOutput;
+use crate::dec::DecodeOutput;
 use color_eyre::eyre::{Result, WrapErr, eyre};
 use jxl::error::Error;
 use jxl::headers::color_encoding::RenderingIntent;

--- a/jxl_cli/src/lib.rs
+++ b/jxl_cli/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+pub mod dec;
+pub mod enc;


### PR DESCRIPTION
Defaults to benchmarking the files in the jxl/resourced directory, but can be controlled via JXL_FILES env variable.

Also moved the decode_bytes function in jxl_cli out of main.rs to import it into the benchmark.