### PR TITLE
implement flush_pixels for progressive decoding

### DIFF
--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -118,6 +118,17 @@ impl CodestreamParser {
             .set_use_simple_pipeline(u);
     }
 
+    /// Flushes any pending rendered data to the output buffers.
+    /// This is used for progressive decoding to output partially decoded pixels.
+    pub(super) fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer<'_>]) -> Result<()> {
+        if let Some(frame) = &mut self.frame {
+            if let Some(pixel_format) = &self.pixel_format {
+                frame.flush_to_buffers(buffers, pixel_format)?;
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn process<In: JxlBitstreamInput>(
         &mut self,
         box_parser: &mut BoxParser,

--- a/jxl/src/api/inner/process.rs
+++ b/jxl/src/api/inner/process.rs
@@ -114,7 +114,7 @@ impl JxlDecoderInner {
     }
 
     /// Draws all the pixels we have data for.
-    pub fn flush_pixels(&mut self, _buffers: &mut [JxlOutputBuffer]) -> Result<()> {
-        todo!()
+    pub fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer]) -> Result<()> {
+        self.codestream_parser.flush_pixels(buffers)
     }
 }

--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -126,6 +126,10 @@ pub(crate) trait RenderPipeline: Sized {
     /// implementation to ensure rendering only happens once.
     fn render_outside_frame(&mut self, buffer_splitter: &mut BufferSplitter) -> Result<()>;
 
+    /// Flushes any pending rendered data to the output buffers.
+    /// This is used for progressive decoding to output partially decoded pixels.
+    fn flush(&mut self, buffer_splitter: &mut BufferSplitter) -> Result<()>;
+
     fn box_inout_stage<S: RenderPipelineInOutStage>(
         stage: S,
     ) -> Box<dyn RunInOutStage<Self::Buffer>>;

--- a/jxl/src/render/simple_pipeline/mod.rs
+++ b/jxl/src/render/simple_pipeline/mod.rs
@@ -206,6 +206,10 @@ impl RenderPipeline for SimpleRenderPipeline {
         Box::new(stage)
     }
 
+    fn flush(&mut self, buffer_splitter: &mut BufferSplitter) -> Result<()> {
+        self.do_render(buffer_splitter)
+    }
+
     fn box_inplace_stage<S: RenderPipelineInPlaceStage>(
         stage: S,
     ) -> Box<dyn super::RunInPlaceStage<Self::Buffer>> {


### PR DESCRIPTION
Adds `flush_pixels()` to output partially decoded pixels during progressive decoding.

- Added `flush` method to RenderPipeline trait
- Implemented for both SimpleRenderPipeline and LowMemoryRenderPipeline
- Added `flush_to_buffers` on Frame
- Wired through CodestreamParser to JxlDecoderInner
- 6 tests covering edge cases, both pipelines, modular/vardct, idempotency