### PR TITLE
Add WebAssembly decoder with browser demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,9 +478,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -610,6 +622,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jxl_wasm"
+version = "0.1.0"
+dependencies = [
+ "byteorder",
+ "console_error_panic_hook",
+ "getrandom",
+ "jxl",
+ "png",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +695,16 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1241,6 +1276,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1318,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ debug = true
 debug = true
 
 [workspace]
-members = ["jxl", "jxl_cli", "jxl_macros", "jxl_simd", "jxl_transforms"]
+members = ["jxl", "jxl_cli", "jxl_macros", "jxl_simd", "jxl_transforms", "jxl_wasm"]
 resolver = "2"
 
 [workspace.lints.clippy]

--- a/jxl_wasm/.gitignore
+++ b/jxl_wasm/.gitignore
@@ -1,0 +1,3 @@
+/pkg
+/target
+demo/pkg

--- a/jxl_wasm/Cargo.toml
+++ b/jxl_wasm/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "jxl_wasm"
+version = "0.1.0"
+edition = "2024"
+license = "BSD-3-Clause"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+jxl = { path = "../jxl", version = "0.2", default-features = false }
+wasm-bindgen = "0.2"
+console_error_panic_hook = { version = "0.1", optional = true }
+png = "0.18.0"
+byteorder = "1.4.3"
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[features]
+default = ["console_error_panic_hook"]
+console_error_panic_hook = ["dep:console_error_panic_hook"]
+
+[lints]
+workspace = true

--- a/jxl_wasm/README.md
+++ b/jxl_wasm/README.md
@@ -1,0 +1,174 @@
+# JXL WASM Decoder
+
+WebAssembly decoder for JPEG XL images. Decodes JXL to PNG/APNG in the browser.
+
+## Build
+
+```bash
+cargo install wasm-pack
+wasm-pack build --target web --release
+```
+
+Or use the build script:
+```bash
+./build.sh
+```
+
+Output in `pkg/`:
+- `jxl_wasm_bg.wasm` - WASM binary (~1.5MB, ~500KB gzipped)
+- `jxl_wasm.js` - JavaScript bindings
+- `jxl_wasm.d.ts` - TypeScript definitions
+
+## Usage
+
+### HTML
+
+```html
+<script type="module">
+  import init, { decode_jxl_to_png } from './pkg/jxl_wasm.js';
+
+  await init();
+
+  const jxlData = new Uint8Array(await file.arrayBuffer());
+  const pngData = decode_jxl_to_png(jxlData);
+  const blob = new Blob([pngData], { type: 'image/png' });
+  img.src = URL.createObjectURL(blob);
+</script>
+```
+
+### TypeScript
+
+```typescript
+import init, { decode_jxl_to_png, get_jxl_info, init_panic_hook } from './pkg/jxl_wasm';
+
+await init();
+init_panic_hook(); // optional: better error messages
+
+const pngData = decode_jxl_to_png(jxlData);
+const info = get_jxl_info(jxlData);
+console.log(`${info.width}x${info.height}, ${info.num_frames} frames`);
+```
+
+### React
+
+```tsx
+import { useEffect, useState } from 'react';
+import init, { decode_jxl_to_png } from './pkg/jxl_wasm';
+
+function JXLImage({ src }: { src: string }) {
+  const [imgSrc, setImgSrc] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      await init();
+      const res = await fetch(src);
+      const jxlData = new Uint8Array(await res.arrayBuffer());
+      const pngData = decode_jxl_to_png(jxlData);
+      const blob = new Blob([pngData], { type: 'image/png' });
+      setImgSrc(URL.createObjectURL(blob));
+    })();
+  }, [src]);
+
+  return imgSrc ? <img src={imgSrc} /> : <div>Loading...</div>;
+}
+```
+
+## Polyfill (Auto Mode)
+
+Automatically handle all JXL images on your page:
+
+```html
+<script type="module" src="polyfill.js"></script>
+
+<!-- Use JXL images normally -->
+<img src="image.jxl" alt="My image">
+```
+
+Features:
+- Detects native JXL support (skips polyfill if supported)
+- Scans existing `<img src="*.jxl">` tags
+- Watches for dynamically added images
+- Patches `new Image()` constructor
+- Caches decoded images
+- Shows loading state
+
+Options:
+```javascript
+import { JXLPolyfill } from './polyfill.js';
+
+const polyfill = new JXLPolyfill({
+  patchImageConstructor: true,  // Intercept new Image()
+  showLoadingState: true,        // Blur while decoding
+  cacheDecoded: true,            // Cache PNG blobs
+  verbose: false                 // Debug logging
+});
+
+polyfill.start();
+```
+
+## API
+
+### `decode_jxl_to_png(jxl_data: Uint8Array): Uint8Array`
+
+Decode JXL to PNG. Returns APNG for animated images.
+
+**Throws:** Error message if decoding fails.
+
+### `get_jxl_info(jxl_data: Uint8Array): ImageInfo`
+
+Get image metadata without full decode.
+
+Returns:
+- `width: number`
+- `height: number`
+- `num_frames: number`
+- `has_alpha: boolean`
+
+### `init_panic_hook(): void`
+
+Enable better error messages in console. Call once at startup.
+
+## Demo
+
+```bash
+./build.sh
+cd demo
+python3 -m http.server 8000
+```
+
+Open http://localhost:8000
+
+Features:
+- Multi-file drag & drop
+- Per-image stats (dimensions, sizes, decode time)
+- Download as PNG
+- Remove/clear images
+
+Test images: https://github.com/libjxl/conformance
+
+## Performance
+
+Decode times (approximate):
+- <1MP: 10-50ms
+- 1-5MP: 50-200ms
+- \>5MP: 200-1000ms
+
+Based on jxl-rs with SIMD optimizations (compiled out for WASM).
+
+## Browser Support
+
+Requires WebAssembly:
+- Chrome 57+
+- Firefox 52+
+- Safari 11+
+- Edge 79+
+
+## Limitations
+
+- Single-threaded (no parallel decoding)
+- No WASM SIMD support yet
+- Browser memory constraints apply
+
+## License
+
+BSD-3-Clause

--- a/jxl_wasm/build.sh
+++ b/jxl_wasm/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -e
+
+echo "🔨 Building JXL WASM decoder..."
+
+# Build the WASM module
+wasm-pack build --target web --release
+
+echo "✅ WASM module built successfully!"
+echo ""
+echo "📦 Copying to demo directory..."
+
+# Copy to demo directory
+mkdir -p demo/pkg
+cp -r pkg/* demo/pkg/
+
+echo "✅ Demo ready!"
+echo ""
+echo "🚀 To run the demo:"
+echo "   cd demo"
+echo "   python3 -m http.server 8000"
+echo ""
+echo "Then open http://localhost:8000 in your browser"

--- a/jxl_wasm/demo/README.md
+++ b/jxl_wasm/demo/README.md
@@ -1,0 +1,65 @@
+# Demo
+
+Browser demos for the JXL WASM decoder.
+
+## Run
+
+```bash
+python3 -m http.server 8000
+```
+
+- **Main demo**: http://localhost:8000 - Drag & drop JXL files
+- **Polyfill demo**: http://localhost:8000/polyfill-demo.html - Automatic JXL support
+
+## Requirements
+
+WASM module must be built first:
+```bash
+cd ..
+./build.sh
+```
+
+This copies `pkg/` to `demo/pkg/`.
+
+## Polyfill Usage
+
+Automatically handle JXL images on any page:
+
+```html
+<script type="module" src="polyfill.js"></script>
+
+<!-- JXL images work automatically -->
+<img src="image.jxl" alt="My image">
+```
+
+### Options
+
+```javascript
+import { JXLPolyfill } from './polyfill.js';
+
+const polyfill = new JXLPolyfill({
+  patchImageConstructor: true,  // Intercept new Image() (default: true)
+  showLoadingState: true,        // Blur while decoding (default: true)
+  cacheDecoded: true,            // Cache PNG blobs (default: true)
+  verbose: false                 // Debug logging (default: false)
+});
+
+polyfill.start();
+```
+
+Add `?jxl-debug` to URL for verbose logging.
+
+### Features
+
+- Detects native JXL support (skips polyfill if browser supports JXL)
+- Scans existing `<img src="*.jxl">` tags
+- Watches for dynamically added images (MutationObserver)
+- Patches `new Image()` constructor
+- Caches decoded images
+- Shows loading state during decode
+
+## Test Images
+
+- https://github.com/libjxl/conformance
+- https://jpegxl.info/images/dice.jxl
+- https://jpegxl.info/images/anim-icos.jxl

--- a/jxl_wasm/demo/index.html
+++ b/jxl_wasm/demo/index.html
@@ -1,0 +1,596 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JXL WASM Decoder Demo</title>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: Roboto, Arial, sans-serif;
+            background: #f5f5f5;
+            min-height: 100vh;
+            padding: 20px;
+            color: #212121;
+        }
+
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 2px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            padding: 24px;
+        }
+
+        h1 {
+            color: #1976d2;
+            margin-bottom: 8px;
+            font-size: 2em;
+            font-weight: 400;
+        }
+
+        .subtitle {
+            color: #757575;
+            margin-bottom: 32px;
+            font-size: 1em;
+        }
+
+        .drop-zone {
+            border: 2px dashed #bdbdbd;
+            border-radius: 2px;
+            padding: 60px 20px;
+            text-align: center;
+            background: #fafafa;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            margin-bottom: 24px;
+        }
+
+        .drop-zone:hover,
+        .drop-zone.drag-over {
+            background: #e3f2fd;
+            border-color: #1976d2;
+        }
+
+        .drop-zone-icon {
+            font-size: 3em;
+            margin-bottom: 16px;
+            color: #757575;
+        }
+
+        .drop-zone-text {
+            font-size: 1.1em;
+            color: #424242;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+
+        .drop-zone-subtext {
+            color: #9e9e9e;
+            font-size: 0.9em;
+        }
+
+        #file-input {
+            display: none;
+        }
+
+        .button {
+            background: #1976d2;
+            color: white;
+            border: none;
+            padding: 10px 24px;
+            border-radius: 2px;
+            font-size: 0.95em;
+            cursor: pointer;
+            transition: background 0.2s, box-shadow 0.2s;
+            margin: 8px 4px;
+            text-transform: uppercase;
+            font-weight: 500;
+            letter-spacing: 0.5px;
+        }
+
+        .button:hover {
+            background: #1565c0;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+        }
+
+        .button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            background: #9e9e9e;
+        }
+
+        .gallery {
+            margin-top: 24px;
+        }
+
+        .gallery-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 16px;
+        }
+
+        .gallery-header h3 {
+            color: #424242;
+            font-weight: 500;
+            font-size: 1.1em;
+            margin: 0;
+        }
+
+        .image-card {
+            background: white;
+            border-radius: 2px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 16px;
+            overflow: hidden;
+        }
+
+        .image-card-header {
+            background: #fafafa;
+            padding: 12px 16px;
+            border-bottom: 1px solid #e0e0e0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .image-card-title {
+            font-weight: 500;
+            color: #424242;
+            font-size: 0.95em;
+        }
+
+        .image-card-body {
+            padding: 16px;
+        }
+
+        .info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .info-item {
+            background: #fafafa;
+            padding: 12px;
+            border-radius: 2px;
+        }
+
+        .info-label {
+            font-size: 0.75em;
+            color: #757575;
+            margin-bottom: 4px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .info-value {
+            font-size: 1.2em;
+            font-weight: 400;
+            color: #212121;
+        }
+
+        .image-preview {
+            text-align: center;
+            margin-top: 12px;
+            min-height: 100px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .image-preview img {
+            max-width: 100%;
+            border-radius: 2px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+        }
+
+        .card-spinner {
+            border: 3px solid #e0e0e0;
+            border-top: 3px solid #1976d2;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 0.8s linear infinite;
+        }
+
+        .card-actions {
+            padding: 12px 16px;
+            background: #fafafa;
+            border-top: 1px solid #e0e0e0;
+            text-align: right;
+        }
+
+        .button-small {
+            background: #1976d2;
+            color: white;
+            border: none;
+            padding: 6px 16px;
+            border-radius: 2px;
+            font-size: 0.85em;
+            cursor: pointer;
+            transition: background 0.2s;
+            text-transform: uppercase;
+            font-weight: 500;
+            letter-spacing: 0.5px;
+            margin-left: 8px;
+        }
+
+        .button-small:hover {
+            background: #1565c0;
+        }
+
+        .button-small.danger {
+            background: #d32f2f;
+        }
+
+        .button-small.danger:hover {
+            background: #c62828;
+        }
+
+        .stats {
+            display: flex;
+            justify-content: space-around;
+            margin-top: 16px;
+            padding: 16px;
+            background: #fafafa;
+            border-radius: 2px;
+        }
+
+        .stat-item {
+            text-align: center;
+        }
+
+        .stat-value {
+            font-size: 2em;
+            font-weight: 400;
+            color: #1976d2;
+        }
+
+        .stat-label {
+            font-size: 0.85em;
+            color: #757575;
+            margin-top: 4px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 32px;
+            display: none;
+        }
+
+        .loading.show {
+            display: block;
+        }
+
+        .spinner {
+            border: 3px solid #e0e0e0;
+            border-top: 3px solid #1976d2;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 0.8s linear infinite;
+            margin: 0 auto 16px;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        .error {
+            background: #ffebee;
+            border-left: 4px solid #d32f2f;
+            padding: 16px;
+            margin: 16px 0;
+            border-radius: 2px;
+            color: #c62828;
+            display: none;
+        }
+
+        .error.show {
+            display: block;
+        }
+
+        .controls {
+            text-align: center;
+            margin: 16px 0;
+        }
+
+        footer {
+            margin-top: 32px;
+            text-align: center;
+            color: #757575;
+            font-size: 0.9em;
+            padding: 16px 0;
+        }
+
+        footer a {
+            color: #1976d2;
+            text-decoration: none;
+        }
+
+        footer a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>JXL WASM Decoder</h1>
+        <p class="subtitle">Decode JPEG XL images directly in your browser</p>
+
+        <div class="drop-zone" id="drop-zone">
+            <div class="drop-zone-icon">📁</div>
+            <div class="drop-zone-text">Drop your JXL files here</div>
+            <div class="drop-zone-subtext">or click to browse (supports multiple files)</div>
+        </div>
+
+        <input type="file" id="file-input" accept=".jxl,image/jxl" multiple>
+
+        <div class="loading" id="loading">
+            <div class="spinner"></div>
+            <p>Decoding JXL image...</p>
+        </div>
+
+        <div class="error" id="error"></div>
+
+        <div class="gallery" id="gallery" style="display: none;">
+            <div class="gallery-header">
+                <h3>Decoded Images (<span id="image-count">0</span>)</h3>
+                <button class="button-small danger" id="clear-all-btn">Clear All</button>
+            </div>
+            <div id="gallery-content"></div>
+        </div>
+    </div>
+
+    <footer>
+        <p>Powered by <a href="https://github.com/libjxl/jxl-rs" target="_blank">jxl-rs</a></p>
+        <p>JPEG XL is a royalty-free raster image format</p>
+    </footer>
+
+    <script type="module">
+        import init, { decode_jxl_to_png, init_panic_hook } from './pkg/jxl_wasm.js';
+
+        const dropZone = document.getElementById('drop-zone');
+        const fileInput = document.getElementById('file-input');
+        const loading = document.getElementById('loading');
+        const error = document.getElementById('error');
+        const gallery = document.getElementById('gallery');
+        const galleryContent = document.getElementById('gallery-content');
+        const imageCount = document.getElementById('image-count');
+        const clearAllBtn = document.getElementById('clear-all-btn');
+
+        let imageCounter = 0;
+        const decodedImages = new Map(); // cardId -> {blob, filename}
+
+        // Initialize WASM module
+        async function initWasm() {
+            try {
+                await init();
+                init_panic_hook();
+                console.log('WASM module initialized');
+            } catch (err) {
+                showError('Failed to initialize WASM module: ' + err.message);
+            }
+        }
+
+        function showError(message) {
+            error.textContent = message;
+            error.classList.add('show');
+            setTimeout(() => hideError(), 5000);
+        }
+
+        function hideError() {
+            error.classList.remove('show');
+        }
+
+        function formatBytes(bytes) {
+            if (bytes === 0) return '0 Bytes';
+            const k = 1024;
+            const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+            const i = Math.floor(Math.log(bytes) / Math.log(k));
+            return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
+        }
+
+        function updateImageCount() {
+            imageCount.textContent = decodedImages.size;
+            gallery.style.display = decodedImages.size > 0 ? 'block' : 'none';
+        }
+
+        function createPlaceholderCard(cardId, filename, originalSize) {
+            const card = document.createElement('div');
+            card.className = 'image-card';
+            card.id = `card-${cardId}`;
+
+            card.innerHTML = `
+                <div class="image-card-header">
+                    <div class="image-card-title">${filename}</div>
+                </div>
+                <div class="image-card-body">
+                    <div class="info-grid">
+                        <div class="info-item">
+                            <div class="info-label">JXL Size</div>
+                            <div class="info-value">${originalSize}</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Status</div>
+                            <div class="info-value">Decoding...</div>
+                        </div>
+                    </div>
+                    <div class="image-preview">
+                        <div class="card-spinner"></div>
+                    </div>
+                </div>
+            `;
+
+            galleryContent.insertBefore(card, galleryContent.firstChild);
+            gallery.style.display = 'block';
+        }
+
+        function updateImageCard(cardId, dimensions, pngSize, decodeTime, imageUrl, blob, filename, originalSize) {
+            const card = document.getElementById(`card-${cardId}`);
+            if (!card) return;
+
+            card.innerHTML = `
+                <div class="image-card-header">
+                    <div class="image-card-title">${filename}</div>
+                </div>
+                <div class="image-card-body">
+                    <div class="info-grid">
+                        <div class="info-item">
+                            <div class="info-label">Dimensions</div>
+                            <div class="info-value">${dimensions}</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">JXL Size</div>
+                            <div class="info-value">${originalSize}</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">PNG Size</div>
+                            <div class="info-value">${pngSize}</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Decode Time</div>
+                            <div class="info-value">${decodeTime} ms</div>
+                        </div>
+                    </div>
+                    <div class="image-preview">
+                        <img src="${imageUrl}" alt="${filename}">
+                    </div>
+                </div>
+                <div class="card-actions">
+                    <button class="button-small" onclick="downloadImage(${cardId})">Download PNG</button>
+                    <button class="button-small danger" onclick="removeImage(${cardId})">Remove</button>
+                </div>
+            `;
+
+            decodedImages.set(cardId, { blob, filename: filename.replace(/\.[^/.]+$/, '') });
+            updateImageCount();
+        }
+
+        async function processFile(file) {
+            hideError();
+
+            const cardId = ++imageCounter;
+            createPlaceholderCard(cardId, file.name, formatBytes(file.size));
+
+            try {
+                const arrayBuffer = await file.arrayBuffer();
+                const uint8Array = new Uint8Array(arrayBuffer);
+
+                const startTime = performance.now();
+                const pngData = decode_jxl_to_png(uint8Array);
+                const endTime = performance.now();
+                const decodeTime = (endTime - startTime).toFixed(2);
+
+                const pngBlob = new Blob([pngData], { type: 'image/png' });
+                const url = URL.createObjectURL(pngBlob);
+
+                const img = new Image();
+                img.onload = () => {
+                    updateImageCard(
+                        cardId,
+                        `${img.width} × ${img.height}`,
+                        formatBytes(pngData.length),
+                        decodeTime,
+                        url,
+                        pngBlob,
+                        file.name,
+                        formatBytes(file.size)
+                    );
+                };
+
+                img.onerror = () => {
+                    showError(`Failed to load decoded image: ${file.name}`);
+                    const card = document.getElementById(`card-${cardId}`);
+                    if (card) card.remove();
+                };
+
+                img.src = url;
+
+            } catch (err) {
+                showError(`Decoding failed for ${file.name}: ${err.message}`);
+                const card = document.getElementById(`card-${cardId}`);
+                if (card) card.remove();
+                console.error(err);
+            }
+        }
+
+        async function processFiles(files) {
+            for (const file of files) {
+                if (file.type === 'image/jxl' || file.name.endsWith('.jxl')) {
+                    await processFile(file);
+                }
+            }
+        }
+
+        window.downloadImage = (cardId) => {
+            const imageData = decodedImages.get(cardId);
+            if (imageData) {
+                const url = URL.createObjectURL(imageData.blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = imageData.filename + '.png';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+            }
+        };
+
+        window.removeImage = (cardId) => {
+            const card = document.getElementById(`card-${cardId}`);
+            if (card) {
+                card.remove();
+                decodedImages.delete(cardId);
+                updateImageCount();
+            }
+        };
+
+        clearAllBtn.addEventListener('click', () => {
+            galleryContent.innerHTML = '';
+            decodedImages.clear();
+            updateImageCount();
+            fileInput.value = '';
+        });
+
+        dropZone.addEventListener('click', () => {
+            fileInput.click();
+        });
+
+        dropZone.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            dropZone.classList.add('drag-over');
+        });
+
+        dropZone.addEventListener('dragleave', () => {
+            dropZone.classList.remove('drag-over');
+        });
+
+        dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dropZone.classList.remove('drag-over');
+            const files = Array.from(e.dataTransfer.files);
+            processFiles(files);
+        });
+
+        fileInput.addEventListener('change', (e) => {
+            const files = Array.from(e.target.files);
+            processFiles(files);
+        });
+
+        initWasm();
+    </script>
+</body>
+</html>

--- a/jxl_wasm/demo/polyfill-demo.html
+++ b/jxl_wasm/demo/polyfill-demo.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JXL Polyfill Demo</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+
+        h1 {
+            color: #1976d2;
+        }
+
+        .section {
+            background: white;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 4px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
+        .section h2 {
+            margin-top: 0;
+            color: #424242;
+        }
+
+        .image-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 16px;
+            margin-top: 16px;
+        }
+
+        .image-card {
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            padding: 8px;
+            background: #fafafa;
+        }
+
+        .image-card img {
+            width: 100%;
+            height: auto;
+            border-radius: 2px;
+        }
+
+        .image-card p {
+            margin: 8px 0 0;
+            font-size: 12px;
+            color: #757575;
+        }
+
+        button {
+            background: #1976d2;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px;
+        }
+
+        button:hover {
+            background: #1565c0;
+        }
+
+        code {
+            background: #f5f5f5;
+            padding: 2px 6px;
+            border-radius: 2px;
+            font-family: monospace;
+        }
+
+        pre {
+            background: #263238;
+            color: #aed581;
+            padding: 16px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+
+        .status {
+            padding: 8px 12px;
+            background: #e3f2fd;
+            border-left: 4px solid #1976d2;
+            border-radius: 2px;
+            margin: 10px 0;
+        }
+
+        /* CSS Background demo styles */
+        .bg-demo-box {
+            width: 200px;
+            height: 150px;
+            background-size: cover;
+            background-position: center;
+            border-radius: 4px;
+            display: inline-block;
+            margin: 8px;
+            border: 2px solid #e0e0e0;
+        }
+
+        /* SVG demo styles */
+        .svg-demo {
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            background: #fafafa;
+            padding: 8px;
+        }
+
+        .feature-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 12px;
+            margin-top: 16px;
+        }
+
+        .feature-item {
+            display: flex;
+            align-items: center;
+            padding: 12px;
+            background: #e8f5e9;
+            border-radius: 4px;
+            border-left: 4px solid #4caf50;
+        }
+
+        .feature-item.new {
+            background: #fff3e0;
+            border-left-color: #ff9800;
+        }
+
+        .feature-item span {
+            margin-left: 8px;
+        }
+    </style>
+</head>
+<body>
+    <h1>JXL Polyfill Demo</h1>
+
+    <div class="status">
+        <strong>Status:</strong> <span id="status">Initializing...</span>
+    </div>
+
+    <div class="section">
+        <h2>What is this?</h2>
+        <p>
+            This polyfill automatically detects and converts JXL images to PNG in browsers
+            that don't have native JXL support. It works transparently across multiple contexts:
+        </p>
+        <div class="feature-list">
+            <div class="feature-item">
+                <span><code>&lt;img src="*.jxl"&gt;</code> - Standard image tags</span>
+            </div>
+            <div class="feature-item">
+                <span><code>new Image()</code> - JavaScript Image constructor</span>
+            </div>
+            <div class="feature-item new">
+                <span><code>background-image: url(*.jxl)</code> - CSS backgrounds</span>
+            </div>
+            <div class="feature-item new">
+                <span><code>&lt;source srcset="*.jxl"&gt;</code> - Picture element sources</span>
+            </div>
+            <div class="feature-item new">
+                <span><code>&lt;image href="*.jxl"&gt;</code> - SVG image elements</span>
+            </div>
+            <div class="feature-item new">
+                <span><code>&lt;feImage href="*.jxl"&gt;</code> - SVG filter images</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Usage</h2>
+        <pre>&lt;!-- Just include the polyfill --&gt;
+&lt;script type="module" src="polyfill.js"&gt;&lt;/script&gt;
+
+&lt;!-- Use JXL images normally in any context --&gt;
+&lt;img src="photo.jxl" alt="My image"&gt;
+
+&lt;!-- CSS backgrounds work too --&gt;
+&lt;div style="background-image: url('bg.jxl')"&gt;&lt;/div&gt;
+
+&lt;!-- Picture element with JXL source --&gt;
+&lt;picture&gt;
+  &lt;source srcset="image.jxl" type="image/jxl"&gt;
+  &lt;img src="fallback.png"&gt;
+&lt;/picture&gt;
+
+&lt;!-- SVG images --&gt;
+&lt;svg&gt;&lt;image href="graphic.jxl" /&gt;&lt;/svg&gt;</pre>
+    </div>
+
+    <div class="section">
+        <h2>Test 1: Static &lt;img&gt; Elements</h2>
+        <p>These images are in the HTML on page load:</p>
+        <div class="image-grid" id="static-images">
+            <!-- Images will be added dynamically for testing -->
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Test 2: CSS Background Images</h2>
+        <p>Elements with <code>background-image: url(*.jxl)</code>:</p>
+        <div id="bg-demo-container">
+            <!-- Background demo boxes will be added here -->
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Test 3: &lt;picture&gt; with &lt;source srcset&gt;</h2>
+        <p>Using the <code>&lt;picture&gt;</code> element with JXL sources:</p>
+        <div class="image-grid" id="picture-demo">
+            <!-- Picture elements will be added here -->
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Test 4: SVG &lt;image&gt; Elements</h2>
+        <p>SVG elements using JXL images via <code>href</code> attribute:</p>
+        <div class="svg-demo" id="svg-demo">
+            <!-- SVG will be added here -->
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Test 5: Dynamic Operations</h2>
+        <button id="add-image-btn">Add &lt;img&gt; Dynamically</button>
+        <button id="add-image-js-btn">Add via new Image()</button>
+        <button id="add-bg-btn">Add CSS Background</button>
+        <button id="add-picture-btn">Add &lt;picture&gt; Element</button>
+        <div class="image-grid" id="dynamic-images"></div>
+    </div>
+
+    <div class="section">
+        <h2>Test 6: Change src Attribute</h2>
+        <button id="change-src-btn">Change Image Source</button>
+        <div class="image-grid">
+            <div class="image-card">
+                <img id="changeable-img" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Changeable">
+                <p>Click button to load JXL</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Controls</h2>
+        <button id="clear-cache-btn">Clear Cache</button>
+        <button id="toggle-verbose-btn">Toggle Verbose Logging</button>
+        <p><small>Add <code>?jxl-debug</code> to URL for automatic verbose mode</small></p>
+    </div>
+
+    <div class="section">
+        <h2>Stats</h2>
+        <div id="stats"></div>
+    </div>
+
+    <script type="module">
+        // Wait for polyfill to initialize
+        function waitForPolyfill() {
+            return new Promise((resolve) => {
+                const check = () => {
+                    if (window.jxlPolyfill !== undefined) {
+                        resolve(window.jxlPolyfill);
+                    } else {
+                        setTimeout(check, 50);
+                    }
+                };
+                check();
+            });
+        }
+
+        // Update status after polyfill loads
+        setTimeout(() => {
+            const status = window.jxlPolyfill
+                ? 'Polyfill loaded and active'
+                : 'Native JXL support detected';
+            document.getElementById('status').textContent = status;
+        }, 200);
+
+        // Test images from jpegxl.info
+        const TEST_IMAGES = [
+            'https://jpegxl.info/images/dice.jxl',
+            'https://jpegxl.info/images/zoltan-tasi-CLJeQCr2F_A-unsplash.jxl',
+            'https://jpegxl.info/images/Webkit-logo-P3.jxl',
+            'https://jpegxl.info/images/anim-icos.jxl',
+        ];
+
+        // ==================== Test 1: Static Images ====================
+        const staticImagesDiv = document.getElementById('static-images');
+        if (TEST_IMAGES.length === 0) {
+            staticImagesDiv.innerHTML = `
+                <p style="color: #757575; font-style: italic;">
+                    No test images configured. Add JXL URLs to TEST_IMAGES array in the HTML.
+                </p>
+            `;
+        } else {
+            TEST_IMAGES.slice(0, 2).forEach((url, i) => {
+                staticImagesDiv.innerHTML += `
+                    <div class="image-card">
+                        <img src="${url}" alt="Test ${i + 1}">
+                        <p>Static &lt;img&gt; ${i + 1}</p>
+                    </div>
+                `;
+            });
+        }
+
+        // ==================== Test 2: CSS Backgrounds ====================
+        const bgContainer = document.getElementById('bg-demo-container');
+        if (TEST_IMAGES.length > 0) {
+            TEST_IMAGES.slice(0, 2).forEach((url, i) => {
+                const div = document.createElement('div');
+                div.className = 'bg-demo-box';
+                div.style.backgroundImage = `url("${url}")`;
+                div.title = `Background ${i + 1}: ${url}`;
+                bgContainer.appendChild(div);
+            });
+        } else {
+            bgContainer.innerHTML = '<p style="color: #757575;">No test images configured.</p>';
+        }
+
+        // ==================== Test 3: Picture Elements ====================
+        const pictureDemo = document.getElementById('picture-demo');
+        if (TEST_IMAGES.length > 0) {
+            TEST_IMAGES.slice(0, 2).forEach((url, i) => {
+                pictureDemo.innerHTML += `
+                    <div class="image-card">
+                        <picture>
+                            <source srcset="${url}" type="image/jxl">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Picture ${i + 1}">
+                        </picture>
+                        <p>&lt;picture&gt; with &lt;source&gt; ${i + 1}</p>
+                    </div>
+                `;
+            });
+        }
+
+        // ==================== Test 4: SVG Images ====================
+        const svgDemo = document.getElementById('svg-demo');
+        if (TEST_IMAGES.length > 0) {
+            svgDemo.innerHTML = `
+                <svg width="220" height="170" xmlns="http://www.w3.org/2000/svg">
+                    <rect width="220" height="170" fill="#f0f0f0" rx="4"/>
+                    <image href="${TEST_IMAGES[0]}" x="10" y="10" width="200" height="150" />
+                </svg>
+                <p style="margin-top: 8px; font-size: 12px; color: #757575;">
+                    SVG &lt;image&gt; element with JXL href
+                </p>
+            `;
+        }
+
+        // ==================== Dynamic Tests ====================
+        let dynamicCounter = 0;
+
+        // Add image dynamically (DOM)
+        document.getElementById('add-image-btn').addEventListener('click', () => {
+            if (TEST_IMAGES.length === 0) {
+                alert('Add JXL URLs to TEST_IMAGES array first');
+                return;
+            }
+
+            const container = document.getElementById('dynamic-images');
+            const url = TEST_IMAGES[dynamicCounter % TEST_IMAGES.length];
+
+            const card = document.createElement('div');
+            card.className = 'image-card';
+            card.innerHTML = `
+                <img src="${url}" alt="Dynamic ${++dynamicCounter}">
+                <p>Added via DOM (${new Date().toLocaleTimeString()})</p>
+            `;
+            container.appendChild(card);
+        });
+
+        // Add image via new Image()
+        document.getElementById('add-image-js-btn').addEventListener('click', () => {
+            if (TEST_IMAGES.length === 0) {
+                alert('Add JXL URLs to TEST_IMAGES array first');
+                return;
+            }
+
+            const container = document.getElementById('dynamic-images');
+            const url = TEST_IMAGES[dynamicCounter % TEST_IMAGES.length];
+
+            const card = document.createElement('div');
+            card.className = 'image-card';
+
+            const img = new Image();
+            img.src = url;
+            img.alt = `JS ${++dynamicCounter}`;
+
+            const p = document.createElement('p');
+            p.textContent = `Added via new Image() (${new Date().toLocaleTimeString()})`;
+
+            card.appendChild(img);
+            card.appendChild(p);
+            container.appendChild(card);
+        });
+
+        // Add CSS background dynamically
+        document.getElementById('add-bg-btn').addEventListener('click', () => {
+            if (TEST_IMAGES.length === 0) {
+                alert('Add JXL URLs to TEST_IMAGES array first');
+                return;
+            }
+
+            const container = document.getElementById('dynamic-images');
+            const url = TEST_IMAGES[dynamicCounter % TEST_IMAGES.length];
+
+            const card = document.createElement('div');
+            card.className = 'image-card';
+
+            const box = document.createElement('div');
+            box.className = 'bg-demo-box';
+            box.style.backgroundImage = `url("${url}")`;
+            box.style.width = '100%';
+            box.style.height = '150px';
+            box.style.margin = '0';
+
+            const p = document.createElement('p');
+            p.textContent = `CSS background (${new Date().toLocaleTimeString()})`;
+
+            card.appendChild(box);
+            card.appendChild(p);
+            container.appendChild(card);
+            dynamicCounter++;
+        });
+
+        // Add picture element dynamically
+        document.getElementById('add-picture-btn').addEventListener('click', () => {
+            if (TEST_IMAGES.length === 0) {
+                alert('Add JXL URLs to TEST_IMAGES array first');
+                return;
+            }
+
+            const container = document.getElementById('dynamic-images');
+            const url = TEST_IMAGES[dynamicCounter % TEST_IMAGES.length];
+
+            const card = document.createElement('div');
+            card.className = 'image-card';
+            card.innerHTML = `
+                <picture>
+                    <source srcset="${url}" type="image/jxl">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Dynamic picture">
+                </picture>
+                <p>&lt;picture&gt; element (${new Date().toLocaleTimeString()})</p>
+            `;
+            container.appendChild(card);
+            dynamicCounter++;
+        });
+
+        // Change src attribute
+        let srcToggle = false;
+        document.getElementById('change-src-btn').addEventListener('click', () => {
+            if (TEST_IMAGES.length === 0) {
+                alert('Add JXL URLs to TEST_IMAGES array first');
+                return;
+            }
+
+            const img = document.getElementById('changeable-img');
+            srcToggle = !srcToggle;
+
+            if (srcToggle) {
+                img.src = TEST_IMAGES[0];
+            } else {
+                img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+            }
+        });
+
+        // Clear cache
+        document.getElementById('clear-cache-btn').addEventListener('click', () => {
+            if (!window.jxlPolyfill) {
+                alert('Polyfill not active (native JXL support detected)');
+                return;
+            }
+            window.jxlPolyfill.clearCache();
+            alert('Cache cleared!');
+            updateStats();
+        });
+
+        // Toggle verbose
+        document.getElementById('toggle-verbose-btn').addEventListener('click', () => {
+            if (!window.jxlPolyfill) {
+                alert('Polyfill not active (native JXL support detected)');
+                return;
+            }
+            window.jxlPolyfill.options.verbose = !window.jxlPolyfill.options.verbose;
+            alert(`Verbose logging: ${window.jxlPolyfill.options.verbose ? 'ON' : 'OFF'}`);
+        });
+
+        // Update stats
+        function updateStats() {
+            const stats = document.getElementById('stats');
+            if (!window.jxlPolyfill) {
+                stats.innerHTML = `<p><em>Polyfill not active (native JXL support detected)</em></p>`;
+                return;
+            }
+            const s = window.jxlPolyfill.getStats();
+            stats.innerHTML = `
+                <p><strong>Cache size:</strong> ${s.cacheSize} images</p>
+                <p><strong>Currently processing:</strong> ${s.processingCount} images</p>
+                <p><strong>Initialized:</strong> ${s.initialized ? 'Yes' : 'No'}</p>
+            `;
+        }
+
+        // Update stats every second
+        setInterval(updateStats, 1000);
+        updateStats();
+    </script>
+
+    <!-- Include the polyfill -->
+    <script type="module" src="polyfill.js"></script>
+</body>
+</html>

--- a/jxl_wasm/demo/polyfill.js
+++ b/jxl_wasm/demo/polyfill.js
@@ -1,0 +1,558 @@
+/**
+ * JXL Polyfill - Automatic JXL support for browsers
+ *
+ * Usage:
+ *   <script type="module" src="polyfill.js"></script>
+ *
+ * Features:
+ * - Automatically converts <img src="*.jxl"> tags
+ * - Supports CSS background-image with JXL URLs
+ * - Supports <source srcset="*.jxl"> in <picture> elements
+ * - Supports SVG <image> and <feImage> elements with JXL URLs
+ * - Watches for dynamically added elements
+ * - Patches Image() constructor (optional)
+ * - Shows loading state during conversion
+ * - Caches decoded images for performance
+ */
+
+import init, { decode_jxl_to_png, init_panic_hook } from './pkg/jxl_wasm.js';
+
+class JXLPolyfill {
+    constructor(options = {}) {
+        this.options = {
+            patchImageConstructor: options.patchImageConstructor ?? true,
+            showLoadingState: options.showLoadingState ?? true,
+            cacheDecoded: options.cacheDecoded ?? true,
+            verbose: options.verbose ?? false,
+            // New options for extended support
+            handleCSSBackgrounds: options.handleCSSBackgrounds ?? true,
+            handleSourceElements: options.handleSourceElements ?? true,
+            handleSVGElements: options.handleSVGElements ?? true,
+            ...options
+        };
+
+        this.initialized = false;
+        this.initPromise = null;
+        this.cache = new Map(); // URL -> Blob URL
+        this.processing = new Set(); // URLs currently being processed
+        this.observer = null;
+    }
+
+    async init() {
+        if (this.initialized) return;
+        if (this.initPromise) return this.initPromise;
+
+        this.initPromise = (async () => {
+            await init();
+            init_panic_hook();
+            this.initialized = true;
+            this.log('JXL Polyfill initialized');
+        })();
+
+        return this.initPromise;
+    }
+
+    log(...args) {
+        if (this.options.verbose) {
+            console.log('[JXL Polyfill]', ...args);
+        }
+    }
+
+    isJXL(url) {
+        if (!url) return false;
+        const urlStr = url.toString().toLowerCase();
+        return urlStr.endsWith('.jxl') || urlStr.includes('.jxl?') || urlStr.includes('.jxl#');
+    }
+
+    /**
+     * Extract JXL URL from CSS background-image value
+     * @param {string} bgValue - CSS background-image value like 'url("image.jxl")'
+     * @returns {string|null} - The URL or null if not a JXL
+     */
+    extractJXLFromBackground(bgValue) {
+        if (!bgValue || bgValue === 'none') return null;
+
+        // Match url(...) patterns
+        const match = bgValue.match(/url\(["']?([^"')]+\.jxl[^"')]*?)["']?\)/i);
+        if (match && match[1]) {
+            return match[1];
+        }
+        return null;
+    }
+
+    async convertJXL(url) {
+        // Resolve relative URLs to absolute
+        const absoluteUrl = new URL(url, window.location.href).href;
+
+        // Check cache
+        if (this.options.cacheDecoded && this.cache.has(absoluteUrl)) {
+            this.log('Using cached:', absoluteUrl);
+            return this.cache.get(absoluteUrl);
+        }
+
+        // Prevent duplicate processing
+        if (this.processing.has(absoluteUrl)) {
+            this.log('Already processing:', absoluteUrl);
+            // Wait for existing conversion
+            return new Promise((resolve) => {
+                const check = setInterval(() => {
+                    if (!this.processing.has(absoluteUrl)) {
+                        clearInterval(check);
+                        resolve(this.cache.get(absoluteUrl));
+                    }
+                }, 100);
+            });
+        }
+
+        this.processing.add(absoluteUrl);
+
+        try {
+            this.log('Converting:', absoluteUrl);
+
+            const response = await fetch(absoluteUrl);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            const jxlData = new Uint8Array(await response.arrayBuffer());
+            const pngData = decode_jxl_to_png(jxlData);
+            const blob = new Blob([pngData], { type: 'image/png' });
+            const blobUrl = URL.createObjectURL(blob);
+
+            if (this.options.cacheDecoded) {
+                this.cache.set(absoluteUrl, blobUrl);
+            }
+
+            this.log('Converted:', absoluteUrl, '->', blobUrl);
+            return blobUrl;
+
+        } catch (error) {
+            console.error('[JXL Polyfill] Conversion failed:', absoluteUrl, error);
+            throw error;
+        } finally {
+            this.processing.delete(absoluteUrl);
+        }
+    }
+
+    // ==================== IMG Element Support ====================
+
+    async processImage(img) {
+        const src = img.getAttribute('src') || img.src;
+        if (!src || !this.isJXL(src)) return;
+
+        // Skip if already processed
+        if (img.dataset.jxlProcessed) return;
+        img.dataset.jxlProcessed = 'processing';
+
+        const originalSrc = src;
+
+        try {
+            // Show loading state
+            if (this.options.showLoadingState) {
+                img.style.opacity = '0.5';
+                img.style.filter = 'blur(2px)';
+            }
+
+            await this.init();
+            const pngUrl = await this.convertJXL(src);
+
+            // Update image
+            img.src = pngUrl;
+            img.dataset.jxlProcessed = 'true';
+            img.dataset.jxlOriginal = originalSrc;
+
+            // Remove loading state
+            if (this.options.showLoadingState) {
+                img.style.opacity = '';
+                img.style.filter = '';
+            }
+
+        } catch (error) {
+            img.dataset.jxlProcessed = 'error';
+            img.alt = `Failed to load JXL: ${error.message}`;
+            console.error('[JXL Polyfill] Failed to process image:', img, error);
+        }
+    }
+
+    // ==================== CSS Background Support ====================
+
+    async processBackgroundImage(element) {
+        if (!this.options.handleCSSBackgrounds) return;
+
+        const computedStyle = getComputedStyle(element);
+        const bgImage = computedStyle.backgroundImage;
+        const jxlUrl = this.extractJXLFromBackground(bgImage);
+
+        if (!jxlUrl) return;
+
+        // Skip if already processed
+        if (element.dataset.jxlBgProcessed) return;
+        element.dataset.jxlBgProcessed = 'processing';
+
+        try {
+            await this.init();
+            const pngUrl = await this.convertJXL(jxlUrl);
+
+            // Update background-image
+            element.style.backgroundImage = `url("${pngUrl}")`;
+            element.dataset.jxlBgProcessed = 'true';
+            element.dataset.jxlBgOriginal = jxlUrl;
+
+            this.log('Updated background-image:', element, jxlUrl, '->', pngUrl);
+
+        } catch (error) {
+            element.dataset.jxlBgProcessed = 'error';
+            console.error('[JXL Polyfill] Failed to process background:', element, error);
+        }
+    }
+
+    // ==================== <source> Element Support ====================
+
+    async processSourceElement(source) {
+        if (!this.options.handleSourceElements) return;
+
+        const srcset = source.getAttribute('srcset');
+        if (!srcset || !this.isJXL(srcset)) return;
+
+        // Skip if already processed
+        if (source.dataset.jxlProcessed) return;
+        source.dataset.jxlProcessed = 'processing';
+
+        try {
+            await this.init();
+
+            // Parse srcset (can have multiple entries like "image.jxl 1x, image2.jxl 2x")
+            const entries = srcset.split(',').map(s => s.trim());
+            const newEntries = [];
+
+            for (const entry of entries) {
+                const parts = entry.split(/\s+/);
+                const url = parts[0];
+                const descriptor = parts.slice(1).join(' ');
+
+                if (this.isJXL(url)) {
+                    const pngUrl = await this.convertJXL(url);
+                    newEntries.push(descriptor ? `${pngUrl} ${descriptor}` : pngUrl);
+                } else {
+                    newEntries.push(entry);
+                }
+            }
+
+            // Update srcset
+            source.srcset = newEntries.join(', ');
+            source.type = 'image/png';
+            source.dataset.jxlProcessed = 'true';
+            source.dataset.jxlOriginal = srcset;
+
+            this.log('Updated <source> srcset:', source);
+
+        } catch (error) {
+            source.dataset.jxlProcessed = 'error';
+            console.error('[JXL Polyfill] Failed to process <source>:', source, error);
+        }
+    }
+
+    // ==================== SVG Element Support ====================
+
+    async processSVGImage(svgElement) {
+        if (!this.options.handleSVGElements) return;
+
+        // SVG uses href or xlink:href
+        const href = svgElement.getAttribute('href') ||
+                     svgElement.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+
+        if (!href || !this.isJXL(href)) return;
+
+        // Skip if already processed
+        if (svgElement.dataset.jxlProcessed) return;
+        svgElement.dataset.jxlProcessed = 'processing';
+
+        try {
+            await this.init();
+            const pngUrl = await this.convertJXL(href);
+
+            // Update href (prefer standard href over xlink:href)
+            if (svgElement.hasAttribute('href')) {
+                svgElement.setAttribute('href', pngUrl);
+            } else {
+                svgElement.setAttributeNS('http://www.w3.org/1999/xlink', 'href', pngUrl);
+            }
+
+            svgElement.dataset.jxlProcessed = 'true';
+            svgElement.dataset.jxlOriginal = href;
+
+            this.log('Updated SVG element:', svgElement.tagName, href, '->', pngUrl);
+
+        } catch (error) {
+            svgElement.dataset.jxlProcessed = 'error';
+            console.error('[JXL Polyfill] Failed to process SVG element:', svgElement, error);
+        }
+    }
+
+    // ==================== Scanning ====================
+
+    scanAndConvert() {
+        this.log('Scanning for JXL images...');
+
+        // Scan <img> elements
+        const images = document.querySelectorAll('img');
+        this.log('Found', images.length, 'img elements');
+        images.forEach(img => {
+            if (this.isJXL(img.src || img.getAttribute('src'))) {
+                this.processImage(img);
+            }
+        });
+
+        // Scan <source> elements in <picture>
+        if (this.options.handleSourceElements) {
+            const sources = document.querySelectorAll('picture source');
+            this.log('Found', sources.length, 'source elements');
+            sources.forEach(source => {
+                if (this.isJXL(source.srcset || source.getAttribute('srcset'))) {
+                    this.processSourceElement(source);
+                }
+            });
+        }
+
+        // Scan SVG <image> and <feImage> elements
+        if (this.options.handleSVGElements) {
+            const svgImages = document.querySelectorAll('image, feImage');
+            this.log('Found', svgImages.length, 'SVG image elements');
+            svgImages.forEach(el => {
+                const href = el.getAttribute('href') ||
+                             el.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+                if (this.isJXL(href)) {
+                    this.processSVGImage(el);
+                }
+            });
+        }
+
+        // Scan elements with CSS background-image
+        if (this.options.handleCSSBackgrounds) {
+            // Get all elements and check their computed styles
+            const allElements = document.querySelectorAll('*');
+            let bgCount = 0;
+            allElements.forEach(el => {
+                const bgImage = getComputedStyle(el).backgroundImage;
+                if (this.extractJXLFromBackground(bgImage)) {
+                    bgCount++;
+                    this.processBackgroundImage(el);
+                }
+            });
+            this.log('Found', bgCount, 'elements with JXL backgrounds');
+        }
+    }
+
+    // ==================== DOM Observer ====================
+
+    observeDOM() {
+        if (this.observer) return;
+
+        this.observer = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                // Check added nodes
+                for (const node of mutation.addedNodes) {
+                    if (node.nodeType !== 1) continue; // Element nodes only
+
+                    // Check the node itself
+                    this.checkElement(node);
+
+                    // Check children
+                    if (node.querySelectorAll) {
+                        node.querySelectorAll('img, source, image, feImage, [style*="background"]')
+                            .forEach(el => this.checkElement(el));
+                    }
+                }
+
+                // Check attribute changes
+                if (mutation.type === 'attributes' && mutation.target.nodeType === 1) {
+                    const target = mutation.target;
+                    const attr = mutation.attributeName;
+
+                    if (attr === 'src' && target.tagName === 'IMG') {
+                        delete target.dataset.jxlProcessed;
+                        this.processImage(target);
+                    } else if (attr === 'srcset' && target.tagName === 'SOURCE') {
+                        delete target.dataset.jxlProcessed;
+                        this.processSourceElement(target);
+                    } else if ((attr === 'href' || attr === 'xlink:href') &&
+                               (target.tagName === 'image' || target.tagName === 'feImage')) {
+                        delete target.dataset.jxlProcessed;
+                        this.processSVGImage(target);
+                    } else if (attr === 'style') {
+                        delete target.dataset.jxlBgProcessed;
+                        this.processBackgroundImage(target);
+                    }
+                }
+            }
+        });
+
+        this.observer.observe(document.documentElement, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['src', 'srcset', 'href', 'xlink:href', 'style']
+        });
+
+        this.log('DOM observer started');
+    }
+
+    checkElement(el) {
+        const tagName = el.tagName?.toUpperCase();
+
+        if (tagName === 'IMG') {
+            this.processImage(el);
+        } else if (tagName === 'SOURCE') {
+            this.processSourceElement(el);
+        } else if (tagName === 'IMAGE' || tagName === 'FEIMAGE') {
+            this.processSVGImage(el);
+        }
+
+        // Check for background-image
+        if (this.options.handleCSSBackgrounds) {
+            const bgImage = getComputedStyle(el).backgroundImage;
+            if (this.extractJXLFromBackground(bgImage)) {
+                this.processBackgroundImage(el);
+            }
+        }
+    }
+
+    // ==================== Image Constructor Patch ====================
+
+    patchImage() {
+        if (!this.options.patchImageConstructor) return;
+
+        const OriginalImage = window.Image;
+        const polyfill = this;
+
+        window.Image = class extends OriginalImage {
+            constructor(width, height) {
+                super(width, height);
+
+                const originalSetSrc = Object.getOwnPropertyDescriptor(
+                    HTMLImageElement.prototype, 'src'
+                ).set;
+
+                let currentSrc = '';
+
+                Object.defineProperty(this, 'src', {
+                    get() {
+                        return currentSrc;
+                    },
+                    set(value) {
+                        currentSrc = value;
+
+                        if (polyfill.isJXL(value)) {
+                            polyfill.log('Image() constructor intercepted:', value);
+
+                            // Set to data URL initially to prevent 404
+                            originalSetSrc.call(this, 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+
+                            polyfill.init().then(() => {
+                                polyfill.convertJXL(value).then(pngUrl => {
+                                    originalSetSrc.call(this, pngUrl);
+                                }).catch(error => {
+                                    console.error('[JXL Polyfill] Image() conversion failed:', error);
+                                });
+                            });
+                        } else {
+                            originalSetSrc.call(this, value);
+                        }
+                    }
+                });
+            }
+        };
+
+        // Preserve constructor name
+        Object.defineProperty(window.Image, 'name', { value: 'Image' });
+
+        this.log('Image() constructor patched');
+    }
+
+    // ==================== Lifecycle ====================
+
+    start() {
+        // Wait for DOM ready
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.start());
+            return;
+        }
+
+        this.log('Starting polyfill');
+
+        // Patch Image constructor first
+        this.patchImage();
+
+        // Scan existing elements
+        this.scanAndConvert();
+
+        // Watch for new elements
+        this.observeDOM();
+    }
+
+    stop() {
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+            this.log('DOM observer stopped');
+        }
+    }
+
+    clearCache() {
+        // Revoke all blob URLs
+        for (const blobUrl of this.cache.values()) {
+            URL.revokeObjectURL(blobUrl);
+        }
+        this.cache.clear();
+        this.log('Cache cleared');
+    }
+
+    /**
+     * Get statistics about the polyfill state
+     */
+    getStats() {
+        return {
+            initialized: this.initialized,
+            cacheSize: this.cache.size,
+            processingCount: this.processing.size,
+            cachedUrls: [...this.cache.keys()]
+        };
+    }
+}
+
+// Check for native JXL support before starting polyfill
+async function checkNativeJXLSupport() {
+    // Create a 1x1 JXL image (smallest valid JXL)
+    const jxlData = 'data:image/jxl;base64,/woIELASCAgQAFzgBzgBPAk=';
+
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => resolve(true);
+        img.onerror = () => resolve(false);
+        img.src = jxlData;
+
+        // Timeout after 100ms
+        setTimeout(() => resolve(false), 100);
+    });
+}
+
+// Auto-start only if native support is not available
+checkNativeJXLSupport().then(hasNativeSupport => {
+    if (hasNativeSupport) {
+        console.log('[JXL Polyfill] Native JXL support detected, polyfill not needed');
+        return;
+    }
+
+    console.log('[JXL Polyfill] No native support, loading polyfill');
+    const polyfill = new JXLPolyfill({
+        verbose: new URLSearchParams(window.location.search).has('jxl-debug')
+    });
+
+    polyfill.start();
+
+    // Export for manual control
+    window.jxlPolyfill = polyfill;
+});
+
+// Export for manual control
+export { JXLPolyfill };

--- a/jxl_wasm/src/lib.rs
+++ b/jxl_wasm/src/lib.rs
@@ -1,0 +1,453 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use jxl::api::JxlOutputBuffer;
+use jxl::api::{JxlBitDepth, ProcessingResult};
+use jxl::api::{
+    JxlColorEncoding, JxlColorProfile, JxlColorType, JxlDecoderOptions, JxlPrimaries,
+    JxlTransferFunction, JxlWhitePoint,
+};
+use jxl::image::{Image, Rect};
+use std::mem;
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "console_error_panic_hook")]
+pub use console_error_panic_hook::set_once as set_panic_hook;
+
+#[wasm_bindgen]
+pub fn init_panic_hook() {
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}
+
+/// Information about a decoded JXL image
+#[wasm_bindgen]
+pub struct ImageInfo {
+    width: u32,
+    height: u32,
+    num_frames: u32,
+    has_alpha: bool,
+}
+
+#[wasm_bindgen]
+impl ImageInfo {
+    #[wasm_bindgen(getter)]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn num_frames(&self) -> u32 {
+        self.num_frames
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn has_alpha(&self) -> bool {
+        self.has_alpha
+    }
+}
+
+fn gcd(a: u64, b: u64) -> u64 {
+    if b == 0 { a } else { gcd(b, a % b) }
+}
+
+fn calculate_apng_delay(duration_ms: f64) -> Result<(u16, u16), JsValue> {
+    if duration_ms < 0.0 {
+        return Err(JsValue::from_str(&format!(
+            "Negative frame duration: {}",
+            duration_ms
+        )));
+    }
+    if duration_ms == 0.0 {
+        return Ok((0, 1));
+    }
+
+    let mut num = duration_ms.round() as u64;
+    let mut den = 1000u64;
+
+    let common = gcd(num, den);
+    num /= common;
+    den /= common;
+
+    if num > u16::MAX as u64 || den > u16::MAX as u64 {
+        Err(JsValue::from_str(&format!(
+            "APNG frame delay overflow after GCD: {}/{}",
+            num, den
+        )))
+    } else {
+        Ok((num as u16, den as u16))
+    }
+}
+
+fn png_color(num_channels: usize) -> Result<png::ColorType, JsValue> {
+    match num_channels {
+        1 => Ok(png::ColorType::Grayscale),
+        2 => Ok(png::ColorType::GrayscaleAlpha),
+        3 => Ok(png::ColorType::Rgb),
+        4 => Ok(png::ColorType::Rgba),
+        _ => Err(JsValue::from_str(&format!(
+            "Invalid number of channels for PNG output: {}",
+            num_channels
+        ))),
+    }
+}
+
+fn make_cicp(encoding: &JxlColorEncoding) -> Option<png::CodingIndependentCodePoints> {
+    let JxlColorEncoding::RgbColorSpace {
+        white_point,
+        primaries,
+        transfer_function,
+        ..
+    } = encoding
+    else {
+        return None;
+    };
+
+    Some(png::CodingIndependentCodePoints {
+        color_primaries: match white_point {
+            JxlWhitePoint::DCI => {
+                if *primaries == JxlPrimaries::P3 {
+                    11
+                } else {
+                    return None;
+                }
+            }
+            JxlWhitePoint::D65 => match primaries {
+                JxlPrimaries::SRGB => 1,
+                JxlPrimaries::BT2100 => 9,
+                JxlPrimaries::P3 => 12,
+                JxlPrimaries::Chromaticities { .. } => return None,
+            },
+            _ => return None,
+        },
+        transfer_function: match transfer_function {
+            JxlTransferFunction::BT709 => 1,
+            JxlTransferFunction::Linear => 8,
+            JxlTransferFunction::SRGB => 13,
+            JxlTransferFunction::PQ => 16,
+            JxlTransferFunction::DCI => 17,
+            JxlTransferFunction::HLG => 18,
+            JxlTransferFunction::Gamma(_) => return None,
+        },
+        matrix_coefficients: 0,
+        is_video_full_range_image: true,
+    })
+}
+
+// Extract RGB channels from interleaved RGB buffer
+fn planes_from_interleaved(interleaved: &Image<f32>) -> Result<Vec<Image<f32>>, JsValue> {
+    let size = interleaved.size();
+    let size = (size.0 / 3, size.1);
+    let mut r_image = Image::<f32>::new(size)
+        .map_err(|e| JsValue::from_str(&format!("Failed to create image: {}", e)))?;
+    let mut g_image = Image::<f32>::new(size)
+        .map_err(|e| JsValue::from_str(&format!("Failed to create image: {}", e)))?;
+    let mut b_image = Image::<f32>::new(size)
+        .map_err(|e| JsValue::from_str(&format!("Failed to create image: {}", e)))?;
+
+    for y in 0..size.1 {
+        let r_row = r_image.row_mut(y);
+        let g_row = g_image.row_mut(y);
+        let b_row = b_image.row_mut(y);
+        let src_row = interleaved.row(y);
+        for x in 0..size.0 {
+            r_row[x] = src_row[3 * x];
+            g_row[x] = src_row[3 * x + 1];
+            b_row[x] = src_row[3 * x + 2];
+        }
+    }
+    Ok(vec![r_image, g_image, b_image])
+}
+
+struct ImageFrame {
+    channels: Vec<Image<f32>>,
+    duration: f64,
+    color_type: JxlColorType,
+}
+
+struct DecodeOutput {
+    size: (usize, usize),
+    frames: Vec<ImageFrame>,
+    original_bit_depth: JxlBitDepth,
+    output_profile: JxlColorProfile,
+    num_loops: u32,
+}
+
+fn decode_jxl_internal(jxl_data: &[u8]) -> Result<DecodeOutput, JsValue> {
+    let mut input = jxl_data;
+
+    let decoder_options = JxlDecoderOptions::default();
+    let initialized_decoder =
+        jxl::api::JxlDecoder::<jxl::api::states::Initialized>::new(decoder_options);
+
+    let mut decoder_with_image_info = match initialized_decoder
+        .process(&mut input)
+        .map_err(|e| JsValue::from_str(&format!("Failed to decode header: {}", e)))?
+    {
+        ProcessingResult::Complete { result } => result,
+        ProcessingResult::NeedsMoreInput { .. } => {
+            return Err(JsValue::from_str("Source file truncated"));
+        }
+    };
+
+    let info = decoder_with_image_info.basic_info();
+    let image_size = info.size;
+    let output_profile = decoder_with_image_info.output_color_profile().clone();
+    let num_loops = info.animation.as_ref().map(|a| a.num_loops).unwrap_or(0);
+    let extra_channels = info.extra_channels.len();
+    let original_bit_depth = info.bit_depth.clone();
+
+    let mut image_data = DecodeOutput {
+        size: image_size,
+        frames: Vec::new(),
+        original_bit_depth,
+        output_profile,
+        num_loops,
+    };
+
+    let pixel_format = decoder_with_image_info.current_pixel_format().clone();
+    let color_type = pixel_format.color_type;
+    let samples_per_pixel = if color_type == JxlColorType::Grayscale {
+        1
+    } else {
+        3
+    };
+
+    loop {
+        let decoder_with_frame_info = match decoder_with_image_info
+            .process(&mut input)
+            .map_err(|e| JsValue::from_str(&format!("Failed to decode frame info: {}", e)))?
+        {
+            ProcessingResult::Complete { result } => result,
+            ProcessingResult::NeedsMoreInput { .. } => {
+                return Err(JsValue::from_str("Source file truncated"));
+            }
+        };
+
+        let frame_header = decoder_with_frame_info.frame_header();
+        let frame_size = image_size;
+
+        let mut outputs = vec![
+            Image::<f32>::new((frame_size.0 * samples_per_pixel, frame_size.1))
+                .map_err(|e| JsValue::from_str(&format!("Failed to create output image: {}", e)))?,
+        ];
+
+        for _ in 0..extra_channels {
+            outputs.push(Image::<f32>::new(frame_size).map_err(|e| {
+                JsValue::from_str(&format!("Failed to create extra channel: {}", e))
+            })?);
+        }
+
+        let mut output_bufs: Vec<JxlOutputBuffer<'_>> = outputs
+            .iter_mut()
+            .map(|x| {
+                let rect = Rect {
+                    size: x.size(),
+                    origin: (0, 0),
+                };
+                JxlOutputBuffer::from_image_rect_mut(x.get_rect_mut(rect).into_raw())
+            })
+            .collect();
+
+        decoder_with_image_info = match decoder_with_frame_info
+            .process(&mut input, &mut output_bufs)
+            .map_err(|e| JsValue::from_str(&format!("Failed to decode frame data: {}", e)))?
+        {
+            ProcessingResult::Complete { result } => result,
+            ProcessingResult::NeedsMoreInput { .. } => {
+                return Err(JsValue::from_str("Source file truncated"));
+            }
+        };
+
+        image_data.frames.push(ImageFrame {
+            duration: frame_header.duration.unwrap_or(0.0),
+            channels: outputs,
+            color_type,
+        });
+
+        if !decoder_with_image_info.has_more_frames() {
+            break;
+        }
+    }
+
+    Ok(image_data)
+}
+
+fn encode_to_png(mut image_data: DecodeOutput) -> Result<Vec<u8>, JsValue> {
+    if image_data.frames.is_empty()
+        || image_data.frames[0].channels.is_empty()
+        || image_data.size.0 == 0
+        || image_data.size.1 == 0
+    {
+        return Err(JsValue::from_str("Invalid JXL image: no frames"));
+    }
+
+    let (width, height) = image_data.size;
+
+    // Convert interleaved RGB to planar
+    for frame in image_data.frames.iter_mut() {
+        if frame.color_type != JxlColorType::Grayscale {
+            let mut new_channels = planes_from_interleaved(&frame.channels[0])?;
+            new_channels.extend(mem::take(&mut frame.channels).into_iter().skip(1));
+            frame.channels = new_channels;
+        }
+    }
+
+    // Get num_channels AFTER conversion from interleaved to planar
+    let num_channels = image_data.frames[0].channels.len();
+
+    let mut info = png::Info::with_size(width as u32, height as u32);
+    match &image_data.output_profile {
+        JxlColorProfile::Simple(JxlColorEncoding::RgbColorSpace {
+            white_point: JxlWhitePoint::D65,
+            primaries: JxlPrimaries::SRGB,
+            transfer_function: JxlTransferFunction::SRGB,
+            rendering_intent,
+        }) => {
+            use jxl::headers::color_encoding::RenderingIntent;
+            info.srgb = Some(match rendering_intent {
+                RenderingIntent::Absolute => png::SrgbRenderingIntent::AbsoluteColorimetric,
+                RenderingIntent::Relative => png::SrgbRenderingIntent::RelativeColorimetric,
+                RenderingIntent::Perceptual => png::SrgbRenderingIntent::Perceptual,
+                RenderingIntent::Saturation => png::SrgbRenderingIntent::Saturation,
+            });
+            info.source_gamma = Some(png::ScaledFloat::from_scaled(45455));
+            info.source_chromaticities = Some(png::SourceChromaticities {
+                white: (
+                    png::ScaledFloat::from_scaled(31270),
+                    png::ScaledFloat::from_scaled(32900),
+                ),
+                red: (
+                    png::ScaledFloat::from_scaled(64000),
+                    png::ScaledFloat::from_scaled(33000),
+                ),
+                green: (
+                    png::ScaledFloat::from_scaled(30000),
+                    png::ScaledFloat::from_scaled(60000),
+                ),
+                blue: (
+                    png::ScaledFloat::from_scaled(15000),
+                    png::ScaledFloat::from_scaled(6000),
+                ),
+            });
+        }
+        JxlColorProfile::Simple(encoding) => {
+            info.coding_independent_code_points = make_cicp(encoding);
+            let icc_bytes = encoding
+                .maybe_create_profile()
+                .map_err(|e| JsValue::from_str(&format!("Failed to create ICC profile: {}", e)))?
+                .unwrap();
+            info.icc_profile = Some(std::borrow::Cow::from(icc_bytes));
+        }
+        JxlColorProfile::Icc(icc_bytes) => {
+            info.icc_profile = Some(std::borrow::Cow::Borrowed(icc_bytes));
+        }
+    }
+
+    let mut buf = Vec::new();
+    let mut encoder = png::Encoder::with_info(&mut buf, info)
+        .map_err(|e| JsValue::from_str(&format!("Failed to create PNG encoder: {}", e)))?;
+
+    encoder.set_color(png_color(num_channels)?);
+
+    // Use 8-bit for web compatibility
+    let bit_depth = image_data.original_bit_depth.bits_per_sample().min(8);
+    encoder.set_depth(if bit_depth <= 8 {
+        png::BitDepth::Eight
+    } else {
+        png::BitDepth::Sixteen
+    });
+
+    if image_data.frames.len() > 1 {
+        encoder
+            .set_animated(image_data.frames.len() as u32, image_data.num_loops)
+            .map_err(|e| JsValue::from_str(&format!("Failed to set animation: {}", e)))?;
+    }
+
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| JsValue::from_str(&format!("Failed to write PNG header: {}", e)))?;
+
+    let num_pixels = height * width * num_channels;
+    let mut data: Vec<u8> = vec![0; num_pixels];
+
+    for (index, frame) in image_data.frames.iter().enumerate() {
+        for y in 0..height {
+            for x in 0..width {
+                for c in 0..num_channels {
+                    data[(y * width + x) * num_channels + c] =
+                        ((frame.channels[c].row(y)[x] * 255.0).clamp(0.0, 255.0) + 0.5) as u8;
+                }
+            }
+        }
+        writer
+            .write_image_data(&data)
+            .map_err(|e| JsValue::from_str(&format!("Failed to write image data: {}", e)))?;
+
+        if index + 1 < image_data.frames.len() && image_data.frames.len() > 1 {
+            let (delay_num, delay_den) = calculate_apng_delay(frame.duration)?;
+            writer
+                .set_frame_delay(delay_num, delay_den)
+                .map_err(|e| JsValue::from_str(&format!("Failed to set frame delay: {}", e)))?;
+        }
+    }
+
+    drop(writer);
+    Ok(buf)
+}
+
+/// Decode a JXL image and return PNG bytes
+///
+/// # Arguments
+/// * `jxl_data` - The JXL image data as a byte array
+///
+/// # Returns
+/// PNG image data that can be used directly in a browser
+#[wasm_bindgen]
+pub fn decode_jxl_to_png(jxl_data: &[u8]) -> Result<Vec<u8>, JsValue> {
+    let decoded = decode_jxl_internal(jxl_data)?;
+    encode_to_png(decoded)
+}
+
+/// Get information about a JXL image without fully decoding it
+#[wasm_bindgen]
+pub fn get_jxl_info(jxl_data: &[u8]) -> Result<ImageInfo, JsValue> {
+    let mut input = jxl_data;
+
+    let decoder_options = JxlDecoderOptions::default();
+    let initialized_decoder =
+        jxl::api::JxlDecoder::<jxl::api::states::Initialized>::new(decoder_options);
+
+    let decoder_with_image_info = match initialized_decoder
+        .process(&mut input)
+        .map_err(|e| JsValue::from_str(&format!("Failed to decode header: {}", e)))?
+    {
+        ProcessingResult::Complete { result } => result,
+        ProcessingResult::NeedsMoreInput { .. } => {
+            return Err(JsValue::from_str("Source file truncated"));
+        }
+    };
+
+    let info = decoder_with_image_info.basic_info();
+    let num_frames = if info.animation.is_some() {
+        // For animated images, we'd need to decode all frames to know the count
+        // For now, just indicate it's animated
+        2 // Minimum for animation
+    } else {
+        1
+    };
+
+    Ok(ImageInfo {
+        width: info.size.0 as u32,
+        height: info.size.1 as u32,
+        num_frames,
+        has_alpha: !info.extra_channels.is_empty(),
+    })
+}


### PR DESCRIPTION
## Summary

Adds a WebAssembly decoder that allows JXL images to be decoded entirely in the browser without native support. Outputs PNG/APNG for universal browser compatibility.

## What's New

### WASM Decoder (`jxl_wasm/`)
- **API**: Simple `decode_jxl_to_png(bytes) -> png_bytes` interface
- **Output**: PNG for still images, APNG for animations
- **Color profiles**: Preserves ICC, sRGB, and custom color spaces
- **Size**: 1.4MB WASM binary (~540KB gzipped)
- **TypeScript**: Auto-generated type definitions included

### Browser Polyfill (`jxl_wasm/demo/polyfill.js`)

A drop-in polyfill that automatically converts JXL images in browsers without native support.

**Supported image contexts:**
| Context | Element/Property | Example |
|---------|-----------------|---------|
| Standard images | `<img src>` | `<img src="photo.jxl">` |
| JavaScript | `new Image()` | `img.src = "photo.jxl"` |
| CSS backgrounds | `background-image` | `div { background-image: url(bg.jxl) }` |
| Picture sources | `<source srcset>` | `<source srcset="image.jxl" type="image/jxl">` |
| SVG images | `<image href>` | `<image href="graphic.jxl" />` |
| SVG filters | `<feImage href>` | `<feImage href="texture.jxl" />` |

**Features:**
- Automatic native support detection (skips polyfill if browser supports JXL)
- MutationObserver for dynamically added elements
- Caching of decoded images
- Configurable options for each feature

### Browser Demo

## Building & Testing

```bash
cd jxl_wasm
./build.sh

# Run demo
cd demo
python3 -m http.server 8000
# Open http://localhost:8000
```

## Usage Examples

### Basic Polyfill (Recommended)
```html
<!-- Just include the polyfill - it handles everything automatically -->
<script type="module" src="polyfill.js"></script>

<!-- Use JXL images normally -->
<img src="photo.jxl" alt="My photo">

<!-- CSS backgrounds work too -->
<div style="background-image: url('background.jxl')"></div>

<!-- Picture element with JXL source -->
<picture>
  <source srcset="image.jxl" type="image/jxl">
  <img src="fallback.png" alt="Fallback">
</picture>

<!-- SVG images -->
<svg><image href="graphic.jxl" width="200" height="150" /></svg>
```

### Manual API Usage
```html
<script type="module">
  import init, { decode_jxl_to_png } from './pkg/jxl_wasm.js';
  
  await init();
  const jxlData = new Uint8Array(await file.arrayBuffer());
  const pngData = decode_jxl_to_png(jxlData);
  const blob = new Blob([pngData], { type: 'image/png' });
  img.src = URL.createObjectURL(blob);
</script>
```

### Polyfill Configuration
```javascript
import { JXLPolyfill } from './polyfill.js';

const polyfill = new JXLPolyfill({
  patchImageConstructor: true,   // Intercept new Image()
  showLoadingState: true,        // Visual feedback during decode
  cacheDecoded: true,            // Cache converted images
  handleCSSBackgrounds: true,    // Convert background-image
  handleSourceElements: true,    // Convert <source srcset>
  handleSVGElements: true,       // Convert SVG <image>/<feImage>
  verbose: false                 // Debug logging
});

polyfill.start();
```

### React/TypeScript
See `jxl_wasm/README.md` for complete examples including React, Next.js, and TypeScript usage.

## Browser Compatibility

Works in all modern browsers with WebAssembly support:
- Chrome 57+
- Firefox 52+
- Safari 11+
- Edge 79+


https://github.com/user-attachments/assets/cec7f16f-4fcb-4056-b28e-4c888f23c435