### PR TITLE
Improve code size.

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -28,7 +28,7 @@ pub mod states {
 
 /// High level API using the typestate pattern to forbid invalid usage.
 pub struct JxlDecoder<State: JxlState> {
-    inner: JxlDecoderInner,
+    inner: Box<JxlDecoderInner>,
     _state: PhantomData<State>,
 }
 
@@ -36,7 +36,7 @@ pub struct JxlDecoder<State: JxlState> {
 pub type FrameCallback = dyn FnMut(&Frame, usize) -> Result<()>;
 
 impl<S: JxlState> JxlDecoder<S> {
-    fn wrap_inner(inner: JxlDecoderInner) -> Self {
+    fn wrap_inner(inner: Box<JxlDecoderInner>) -> Self {
         Self {
             inner,
             _state: PhantomData,
@@ -80,7 +80,7 @@ impl<S: JxlState> JxlDecoder<S> {
 
 impl JxlDecoder<Initialized> {
     pub fn new(options: JxlDecoderOptions) -> Self {
-        Self::wrap_inner(JxlDecoderInner::new(options))
+        Self::wrap_inner(Box::new(JxlDecoderInner::new(options)))
     }
 
     pub fn process(

--- a/jxl/src/api/inner/box_parser.rs
+++ b/jxl/src/api/inner/box_parser.rs
@@ -45,11 +45,7 @@ impl BoxParser {
     // Returns the number of codestream bytes that will be available to be read after this call,
     // including any bytes in self.box_buffer.
     // Might return `u64::MAX`, indicating that the rest of the file is codestream.
-    pub(super) fn get_more_codestream(
-        &mut self,
-        input: &mut impl JxlBitstreamInput,
-    ) -> Result<u64> {
-        // TODO(veluca): consider moving most of this function into a function that is not generic.
+    pub(super) fn get_more_codestream(&mut self, input: &mut dyn JxlBitstreamInput) -> Result<u64> {
         loop {
             match self.state.clone() {
                 ParseState::SignatureNeeded => {

--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -129,10 +129,10 @@ impl CodestreamParser {
             .set_use_simple_pipeline(u);
     }
 
-    pub(super) fn process<In: JxlBitstreamInput>(
+    pub(super) fn process(
         &mut self,
         box_parser: &mut BoxParser,
-        input: &mut In,
+        input: &mut dyn JxlBitstreamInput,
         decode_options: &JxlDecoderOptions,
         mut output_buffers: Option<&mut [JxlOutputBuffer]>,
     ) -> Result<()> {

--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -25,6 +25,7 @@ use super::{CodestreamParser, SectionBuffer};
 use crate::api::ToneMapping;
 
 impl CodestreamParser {
+    #[cold]
     pub(super) fn process_non_section(&mut self, decode_options: &JxlDecoderOptions) -> Result<()> {
         if self.decoder_state.is_none() && self.file_header.is_none() {
             // We don't have a file header yet. Try parsing that.

--- a/jxl/src/api/inner/process.rs
+++ b/jxl/src/api/inner/process.rs
@@ -100,9 +100,10 @@ impl JxlDecoderInner {
     /// file/frame header, or finished decoding a frame).
     /// If called when decoding a frame with `None` for buffers, the frame will still be read,
     /// but pixel data will not be produced.
-    pub fn process<In: JxlBitstreamInput>(
+    #[inline(never)]
+    pub fn process(
         &mut self,
-        input: &mut In,
+        input: &mut dyn JxlBitstreamInput,
         buffers: Option<&mut [JxlOutputBuffer]>,
     ) -> Result<ProcessingResult<(), ()>> {
         ProcessingResult::new(self.codestream_parser.process(

--- a/jxl/src/frame/quant_weights.rs
+++ b/jxl/src/frame/quant_weights.rs
@@ -47,6 +47,7 @@ impl DctQuantWeightParams {
     const LOG2_MAX_DISTANCE_BANDS: usize = 4;
     const MAX_DISTANCE_BANDS: usize = 1 + (1 << Self::LOG2_MAX_DISTANCE_BANDS);
 
+    #[inline(never)]
     pub fn from_array<const N: usize>(values: &[[f32; N]; 3]) -> Self {
         let mut result = Self {
             params: [[0.0; Self::MAX_DISTANCE_BANDS]; 3],
@@ -58,6 +59,7 @@ impl DctQuantWeightParams {
         result
     }
 
+    #[inline(never)]
     pub fn decode(br: &mut BitReader) -> Result<Self> {
         let num_bands = br.read(Self::LOG2_MAX_DISTANCE_BANDS)? as usize + 1;
         let mut params = [[0.0; Self::MAX_DISTANCE_BANDS]; 3];

--- a/jxl_macros/src/lib.rs
+++ b/jxl_macros/src/lib.rs
@@ -625,6 +625,8 @@ fn derive_struct(input: &DeriveInput) -> TokenStream2 {
         #impl_default
         impl crate::headers::encodings::UnconditionalCoder<()> for #name {
             type Nonserialized = #nonserialized;
+            #[cold]
+            #[inline(never)]
             fn read_unconditional(_: &(), br: &mut BitReader, nonserialized: &Self::Nonserialized) -> Result<#name, Error> {
                 use crate::headers::encodings::UnconditionalCoder;
                 use crate::headers::encodings::ConditionalCoder;


### PR DESCRIPTION
- Add inline(never) and cold attributes to functions that are not often used.
- Avoid moving large structs on the stack
- Use dynamic dispatch for JxlBitstreamInput

This reduces code size by ~200kB on aarch64.