### PR TITLE
Skipping zero size buffers

### DIFF
--- a/jxl/src/frame/modular/borrowed_buffers.rs
+++ b/jxl/src/frame/modular/borrowed_buffers.rs
@@ -17,6 +17,7 @@ pub fn with_buffers<T>(
     buffers: &[ModularBufferInfo],
     indices: &[usize],
     grid: usize,
+    skip_empty: bool,
     f: impl FnOnce(Vec<&mut ModularChannel>) -> Result<T>,
 ) -> Result<T> {
     let mut bufs = vec![];
@@ -32,6 +33,13 @@ pub fn with_buffers<T>(
                 shift: buf.info.shift,
                 bit_depth: buf.info.bit_depth,
             });
+        }
+
+        // Skip zero-sized buffers when decoding - they don't contribute to the bitstream.
+        // This matches libjxl's behavior in DecodeGroup where zero-sized rects are skipped.
+        // The buffer is still allocated above so transforms can access it.
+        if skip_empty && (b.size.0 == 0 || b.size.1 == 0) {
+            continue;
         }
 
         bufs.push(RefMut::map(data, |x| x.as_mut().unwrap()));

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -474,7 +474,7 @@ impl FullModularImage {
             trace!("Transform {i}: {ts:?}");
         }
 
-        with_buffers(&buffer_info, &section_buffer_indices[0], 0, |bufs| {
+        with_buffers(&buffer_info, &section_buffer_indices[0], 0, true, |bufs| {
             decode_modular_subbitstream(
                 bufs,
                 ModularStreamId::GlobalData.get_id(frame_header),
@@ -519,6 +519,7 @@ impl FullModularImage {
             &self.buffer_info,
             &self.section_buffer_indices[section_id],
             grid,
+            true,
             |bufs| {
                 decode_modular_subbitstream(
                     bufs,

--- a/jxl/src/frame/modular/transforms/apply.rs
+++ b/jxl/src/frame/modular/transforms/apply.rs
@@ -115,7 +115,7 @@ impl TransformStepChunk {
                     *buffers[buf_out[i]].buffer_grid[out_grid].data.borrow_mut() =
                         Some(buffers[buf_in[i]].buffer_grid[out_grid].get_buffer()?);
                 }
-                with_buffers(buffers, buf_out, out_grid, |mut bufs| {
+                with_buffers(buffers, buf_out, out_grid, false, |mut bufs| {
                     super::rct::do_rct_step(&mut bufs, *op, *perm);
                     Ok(())
                 })?;
@@ -130,7 +130,7 @@ impl TransformStepChunk {
                 // Nothing to do, just bookkeeping.
                 buffers[*buf_in].buffer_grid[out_grid].mark_used();
                 buffers[*buf_pal].buffer_grid[0].mark_used();
-                with_buffers(buffers, buf_out, out_grid, |_| Ok(()))?;
+                with_buffers(buffers, buf_out, out_grid, false, |_| Ok(()))?;
                 Ok(buf_out.iter().map(|x| (*x, out_grid)).collect())
             }
             TransformStep::Palette {
@@ -155,7 +155,7 @@ impl TransformStepChunk {
                     });
                     // Ensure that the output buffers are present.
                     // TODO(szabadka): Extend the callback to support many grid points.
-                    with_buffers(buffers, buf_out, out_grid, |_| Ok(()))?;
+                    with_buffers(buffers, buf_out, out_grid, false, |_| Ok(()))?;
                     let grid_shape = buffers[buf_out[0]].grid_shape;
                     let grid_x = out_grid % grid_shape.0;
                     let grid_y = out_grid / grid_shape.0;
@@ -222,7 +222,7 @@ impl TransformStepChunk {
                         ));
                         // Ensure that the output buffers are present.
                         // TODO(szabadka): Extend the callback to support many grid points.
-                        with_buffers(buffers, buf_out, out_grid + grid_x, |_| Ok(()))?;
+                        with_buffers(buffers, buf_out, out_grid + grid_x, false, |_| Ok(()))?;
                     }
                     let in_buf_refs: Vec<&ModularChannel> =
                         in_bufs.iter().map(|x| x.deref()).collect();
@@ -308,7 +308,7 @@ impl TransformStepChunk {
                         ))
                     };
 
-                    with_buffers(buffers, &[*buf_out], out_grid, |mut bufs| {
+                    with_buffers(buffers, &[*buf_out], out_grid, false, |mut bufs| {
                         super::squeeze::do_hsqueeze_step(
                             &in_avg.data.get_rect(buf_avg.get_grid_rect(
                                 frame_header,
@@ -378,7 +378,7 @@ impl TransformStepChunk {
                         buf_avg.get_grid_rect(frame_header, out_grid_kind, (gx, gy));
                     let res_grid_rect =
                         buf_res.get_grid_rect(frame_header, out_grid_kind, (gx, gy));
-                    with_buffers(buffers, &[*buf_out], out_grid, |mut bufs| {
+                    with_buffers(buffers, &[*buf_out], out_grid, false, |mut bufs| {
                         super::squeeze::do_vsqueeze_step(
                             &in_avg.data.get_rect(avg_grid_rect),
                             &in_res.data.get_rect(res_grid_rect),


### PR DESCRIPTION
The zero size buffers made decoding use wrong context due to invalid channel indices.

Fixes #512