### PR TITLE
Add SIMD upsampling for 2x, 4x, and 8x

### DIFF
--- a/jxl/src/render/stages/upsample.rs
+++ b/jxl/src/render/stages/upsample.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 #![allow(clippy::needless_range_loop)]
+#![allow(clippy::too_many_arguments)]
 
 use std::any::Any;
 


### PR DESCRIPTION
## Summary

This implements SIMD-accelerated upsampling using a two-pass algorithm matching the libjxl approach (related to #521):

- **Pass 1**: Precompute min/max values to temp buffers for better cache locality across the 5x5 kernel window
- **Pass 2**: Apply the 5x5 convolution kernel with FMA using 3-way ILP, then clamp results using precomputed min/max values

Key optimizations:
- Pre-broadcast kernel weights to SIMD vectors (avoids repeated splats in inner loop)
- Chunked processing (1024 elements) for L1 cache efficiency
- Use `store_interleaved_2/4/8` for efficient output of interleaved results
- 3-way accumulator pattern for instruction-level parallelism

> **Note**: This PR depends on #533 (min and store_interleaved functions). Please merge #533 first.

## Benchmarks

Tested with `--speedtest --num-reps 10` on conformance test images:

| Image | main (MP/s) | PR (MP/s) | Change |
|-------|-------------|-----------|--------|
| upsampling | 5.5 | 38.9 | **+7.0x** |
| cafe_5 | 24.8 | 26.6 | +7% |
| bicycles | 8.0 | 7.5 | -6% |
| progressive | 22.6 | 22.4 | ~0% |

The `upsampling` test case specifically exercises the upsampling code path and shows a 7x speedup. Other images that don't use upsampling show no significant regression.