### PR TITLE
Add SIMD versions of transfer functions

### DIFF
--- a/jxl/src/render/stages/from_linear.rs
+++ b/jxl/src/render/stages/from_linear.rs
@@ -77,7 +77,7 @@ fn from_linear_process(tf: &TransferFunction, xsize: usize, row: &mut [&mut [f32
         }
         TransferFunction::Pq { intensity_target } => {
             for row in row {
-                tf::linear_to_pq_simd(d, intensity_target, &mut row[..xsize.next_multiple_of(D::F32Vec::LEN)]);
+                tf::linear_to_pq_simd(d, intensity_target, xsize, row);
             }
         }
         TransferFunction::Hlg {

--- a/jxl/src/render/stages/to_linear.rs
+++ b/jxl/src/render/stages/to_linear.rs
@@ -71,7 +71,7 @@ fn to_linear_process(tf: &TransferFunction, xsize: usize, row: &mut [&mut [f32]]
     match *tf {
         TransferFunction::Bt709 => {
             for row in row {
-                tf::bt709_to_linear_simd(d, &mut row[..xsize.next_multiple_of(D::F32Vec::LEN)]);
+                tf::bt709_to_linear_simd(d, xsize, row);
             }
         }
         TransferFunction::Srgb => {
@@ -81,7 +81,7 @@ fn to_linear_process(tf: &TransferFunction, xsize: usize, row: &mut [&mut [f32]]
         }
         TransferFunction::Pq { intensity_target } => {
             for row in row {
-                tf::pq_to_linear_simd(d, intensity_target, &mut row[..xsize.next_multiple_of(D::F32Vec::LEN)]);
+                tf::pq_to_linear_simd(d, intensity_target, xsize, row);
             }
         }
         TransferFunction::Hlg {


### PR DESCRIPTION
## Summary

Add SIMD-accelerated versions of BT.709 and PQ transfer functions (related to #521):

- `bt709_to_linear_simd` - uses `fast_powf_simd` for the gamma curve
- `pq_to_linear_simd` - uses `eval_rational_poly_simd` with existing PQ coefficients
- `linear_to_pq_simd` - uses `eval_rational_poly_simd` with existing PQ coefficients

Updates `ToLinearStage` and `FromLinearStage` to use the SIMD versions.

## Benchmarks

Tested with `--speedtest --num-reps 10` on conformance test images:

| Image | main (MP/s) | PR (MP/s) | Change |
|-------|-------------|-----------|--------|
| cafe_5 | 27.2 | 30.7 | +13% |
| bicycles | 7.6 | 8.0 | +6% |
| bike_5 | 25.5 | 26.1 | +2% |