### PR TITLE
Add SIMD F32 to U8/U16 conversions

### DIFF
--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -184,6 +184,16 @@ pub unsafe trait F32SimdVec:
         dest: &mut [f32],
     );
 
+    /// Rounds to nearest integer and stores as u8.
+    /// Behavior is unspecified if values would overflow u8.
+    /// Requires `dest.len() >= Self::LEN` or it will panic.
+    fn round_store_u8(self, dest: &mut [u8]);
+
+    /// Rounds to nearest integer and stores as u16.
+    /// Behavior is unspecified if values would overflow u16.
+    /// Requires `dest.len() >= Self::LEN` or it will panic.
+    fn round_store_u16(self, dest: &mut [u16]);
+
     fn abs(self) -> Self;
 
     fn floor(self) -> Self;

--- a/jxl_simd/src/scalar.rs
+++ b/jxl_simd/src/scalar.rs
@@ -175,6 +175,16 @@ unsafe impl F32SimdVec for f32 {
         self.to_bits() as i32
     }
 
+    #[inline(always)]
+    fn round_store_u8(self, dest: &mut [u8]) {
+        dest[0] = self.round() as u8;
+    }
+
+    #[inline(always)]
+    fn round_store_u16(self, dest: &mut [u16]) {
+        dest[0] = self.round() as u16;
+    }
+
     impl_f32_array_interface!();
 
     #[inline(always)]


### PR DESCRIPTION
## Summary

Add SIMD-accelerated versions of F32 to U8 and F32 to U16 conversions (related to #521):

- `f32_to_u8_simd` - vectorized clamp to [0,1], scale, and convert
- `f32_to_u16_simd` - vectorized clamp to [0,1], scale, and convert

Uses `simd_function!` macro for automatic dispatch across instruction sets.

> **Note**: This PR depends on #533 (min function). Please merge #533 first.

## Benchmarks

The data conversion stage is not a significant bottleneck - benchmarks show results within noise (~1%). This PR adds SIMD support for consistency with other stages.