### PR TITLE
Add jxl-perfhistory benchmark CI stage

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -244,6 +244,8 @@ jobs:
         mkdir testimages
         cp jxl/resources/test/conformance_test_images/sunset_logo.jxl testimages
         cp jxl/resources/test/conformance_test_images/bike.jxl testimages
+        cp jxl/resources/test/green_queen_modular_e3.jxl testimages
+        cp jxl/resources/test/green_queen_vardct_e3.jxl testimages
 
     - name: Cache benchmark binaries
       uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Adds automatic performance benchmarking to every PR using [jxl-perfhistory](https://github.com/zond/jxl-perfhistory).

## Features

- Runs on every PR automatically
- Posts benchmark results as a PR comment for easy visibility
- Never fails the PR (`continue-on-error: true`)
- Compares last 5 revisions using statistical analysis
- Results also shown in step summary and uploaded as artifact

## Example Output

The benchmark will post a comment like:

```
## 📊 Performance Benchmark (bike 2048x2560)

================================================================================
Performance Graph (with credible intervals):
...
================================================================================

Generated by jxl-perfhistory
```

This helps reviewers quickly see if a PR has any performance impact.