### PR TITLE
Get rid of `RefCell` in Modular buffers

### DIFF
--- a/jxl/src/frame/modular/borrowed_buffers.rs
+++ b/jxl/src/frame/modular/borrowed_buffers.rs
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::{cell::RefMut, ops::DerefMut};
-
 use crate::{
     error::Result,
     frame::modular::{IMAGE_OFFSET, IMAGE_PADDING},
@@ -13,36 +11,110 @@ use crate::{
 
 use super::{ModularBufferInfo, ModularChannel};
 
+pub struct CollectResult<'buf> {
+    pub immutable_grids: Vec<Vec<&'buf ModularChannel>>,
+    pub mutable_grids: Vec<Vec<&'buf mut ModularChannel>>,
+}
+
+pub fn collect_buffers<'buf>(
+    buffers: &'buf mut [ModularBufferInfo],
+    indices_and_grids: &[(usize, &[usize])],
+    indices_and_grids_mut: &[(usize, &[usize])],
+    skip_empty: bool,
+) -> Result<CollectResult<'buf>> {
+    let mut buffer_refs: Vec<_> = buffers.iter_mut().map(Some).collect();
+
+    let bufs = indices_and_grids
+        .iter()
+        .map(|&(idx, grids)| -> Result<_> {
+            let buf = buffer_refs[idx].take().unwrap();
+            let info = &buf.info;
+
+            let mut collected = Vec::new();
+            for &grid in grids {
+                let b = &mut buf.buffer_grid[grid];
+                if b.data.is_none() {
+                    b.data = Some(ModularChannel {
+                        data: Image::new_with_padding(b.size, IMAGE_OFFSET, IMAGE_PADDING)?,
+                        auxiliary_data: None,
+                        shift: info.shift,
+                        bit_depth: info.bit_depth,
+                    });
+                }
+            }
+
+            for &grid in grids {
+                let b = &buf.buffer_grid[grid];
+
+                // Skip zero-sized buffers when decoding - they don't contribute to the bitstream.
+                // This matches libjxl's behavior in DecodeGroup where zero-sized rects are skipped.
+                // The buffer is still allocated above so transforms can access it.
+                if skip_empty && (b.size.0 == 0 || b.size.1 == 0) {
+                    continue;
+                }
+
+                collected.push(b.data.as_ref().unwrap());
+            }
+
+            Ok(collected)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let bufs_mut = indices_and_grids_mut
+        .iter()
+        .map(|&(idx, grids)| -> Result<_> {
+            let buf = buffer_refs[idx].take().unwrap();
+            let info = &buf.info;
+            let mut grid_refs: Vec<_> = buf.buffer_grid.iter_mut().map(Some).collect();
+
+            let mut collected = Vec::new();
+            for &grid in grids {
+                let b = grid_refs[grid].take().unwrap();
+                let data = &mut b.data;
+
+                if data.is_none() {
+                    *data = Some(ModularChannel {
+                        data: Image::new_with_padding(b.size, IMAGE_OFFSET, IMAGE_PADDING)?,
+                        auxiliary_data: None,
+                        shift: info.shift,
+                        bit_depth: info.bit_depth,
+                    });
+                }
+
+                // Skip zero-sized buffers when decoding - they don't contribute to the bitstream.
+                // This matches libjxl's behavior in DecodeGroup where zero-sized rects are skipped.
+                // The buffer is still allocated above so transforms can access it.
+                if skip_empty && (b.size.0 == 0 || b.size.1 == 0) {
+                    continue;
+                }
+
+                collected.push(data.as_mut().unwrap());
+            }
+
+            Ok(collected)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(CollectResult {
+        immutable_grids: bufs,
+        mutable_grids: bufs_mut,
+    })
+}
+
 pub fn with_buffers<T>(
-    buffers: &[ModularBufferInfo],
+    buffers: &mut [ModularBufferInfo],
     indices: &[usize],
     grid: usize,
     skip_empty: bool,
     f: impl FnOnce(Vec<&mut ModularChannel>) -> Result<T>,
 ) -> Result<T> {
-    let mut bufs = vec![];
-    for i in indices {
-        // Allocate buffers if they are not present.
-        let buf = &buffers[*i];
-        let b = &buf.buffer_grid[grid];
-        let mut data = b.data.borrow_mut();
-        if data.is_none() {
-            *data = Some(ModularChannel {
-                data: Image::new_with_padding(b.size, IMAGE_OFFSET, IMAGE_PADDING)?,
-                auxiliary_data: None,
-                shift: buf.info.shift,
-                bit_depth: buf.info.bit_depth,
-            });
-        }
-
-        // Skip zero-sized buffers when decoding - they don't contribute to the bitstream.
-        // This matches libjxl's behavior in DecodeGroup where zero-sized rects are skipped.
-        // The buffer is still allocated above so transforms can access it.
-        if skip_empty && (b.size.0 == 0 || b.size.1 == 0) {
-            continue;
-        }
-
-        bufs.push(RefMut::map(data, |x| x.as_mut().unwrap()));
-    }
-    f(bufs.iter_mut().map(|x| x.deref_mut()).collect())
+    let grid = [grid];
+    let grid = grid.as_ref();
+    let indices_and_grids: Vec<_> = indices.iter().map(|&idx| (idx, grid)).collect();
+    let b = collect_buffers(buffers, &[], &indices_and_grids, skip_empty)?
+        .mutable_grids
+        .into_iter()
+        .flatten()
+        .collect();
+    f(b)
 }

--- a/jxl/src/frame/modular/transforms/mod.rs
+++ b/jxl/src/frame/modular/transforms/mod.rs
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::cell::RefCell;
-
 use apply::TransformStep;
 pub use apply::TransformStepChunk;
 use num_derive::FromPrimitive;
@@ -116,7 +114,7 @@ pub fn make_grids(
         let is_output = g.info.output_channel_idx >= 0;
         g.buffer_grid = get_grid_indices(g.grid_shape)
             .map(|(x, y)| ModularBuffer {
-                data: RefCell::new(None),
+                data: None,
                 remaining_uses: if is_output { 1 } else { 0 },
                 used_by_transforms: vec![],
                 size: g

--- a/jxl/src/frame/modular/transforms/squeeze.rs
+++ b/jxl/src/frame/modular/transforms/squeeze.rs
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::cell::Ref;
-
 use jxl_simd::{
     F32SimdVec, I32SimdVec, SimdDescriptor, SimdMask, U32SimdVec, shl, shr, simd_function,
 };
@@ -205,7 +203,7 @@ fn hsqueeze_impl<D: SimdDescriptor>(
     in_avg: &ImageRect<'_, i32>,
     in_res: &ImageRect<'_, i32>,
     in_next_avg: &Option<ImageRect<'_, i32>>,
-    out_prev: &Option<Ref<'_, ModularChannel>>,
+    out_prev: Option<&ModularChannel>,
     out: &mut Image<i32>,
 ) {
     const {
@@ -398,7 +396,7 @@ fn hsqueeze_scalar(
     in_avg: &ImageRect<'_, i32>,
     in_res: &ImageRect<'_, i32>,
     in_next_avg: &Option<ImageRect<'_, i32>>,
-    out_prev: &Option<Ref<'_, ModularChannel>>,
+    out_prev: Option<&ModularChannel>,
     out: &mut Image<i32>,
 ) {
     let (w, h) = in_res.size();
@@ -447,7 +445,7 @@ simd_function!(
         in_avg: &ImageRect<'_, i32>,
         in_res: &ImageRect<'_, i32>,
         in_next_avg: &Option<ImageRect<'_, i32>>,
-        out_prev: &Option<Ref<'_, ModularChannel>>,
+        out_prev: Option<&ModularChannel>,
         out: &mut Image<i32>,
     ) {
         hsqueeze_impl(d, 0, in_avg, in_res, in_next_avg, out_prev, out)
@@ -458,11 +456,10 @@ pub fn do_hsqueeze_step(
     in_avg: &ImageRect<'_, i32>,
     in_res: &ImageRect<'_, i32>,
     in_next_avg: &Option<ImageRect<'_, i32>>,
-    out_prev: &Option<Ref<'_, ModularChannel>>,
-    buffers: &mut [&mut ModularChannel],
+    out_prev: Option<&ModularChannel>,
+    out: &mut ModularChannel,
 ) {
     trace!("hsqueeze step in_avg: {in_avg:?} in_res: {in_res:?} in_next_avg: {in_next_avg:?}");
-    let out = buffers.first_mut().unwrap();
     // Shortcut: guarantees that row is at least 1px in the main loop
     if out.data.size().0 == 0 {
         return;
@@ -487,7 +484,7 @@ fn vsqueeze_impl<D: SimdDescriptor>(
     in_avg: &ImageRect<'_, i32>,
     in_res: &ImageRect<'_, i32>,
     in_next_avg: &Option<ImageRect<'_, i32>>,
-    out_prev: &Option<Ref<'_, ModularChannel>>,
+    out_prev: Option<&ModularChannel>,
     out: &mut Image<i32>,
 ) {
     const { assert!(D::I32Vec::LEN.is_power_of_two()) };
@@ -578,7 +575,7 @@ fn vsqueeze_scalar(
     in_avg: &ImageRect<'_, i32>,
     in_res: &ImageRect<'_, i32>,
     in_next_avg: &Option<ImageRect<'_, i32>>,
-    out_prev: &Option<Ref<'_, ModularChannel>>,
+    out_prev: Option<&ModularChannel>,
     out: &mut Image<i32>,
 ) {
     let (w, h) = in_res.size();
@@ -642,7 +639,7 @@ simd_function!(
         in_avg: &ImageRect<'_, i32>,
         in_res: &ImageRect<'_, i32>,
         in_next_avg: &Option<ImageRect<'_, i32>>,
-        out_prev: &Option<Ref<'_, ModularChannel>>,
+        out_prev: Option<&ModularChannel>,
         out: &mut Image<i32>,
     ) {
         vsqueeze_impl(d, 0, in_avg, in_res, in_next_avg, out_prev, out)
@@ -653,11 +650,11 @@ pub fn do_vsqueeze_step(
     in_avg: &ImageRect<'_, i32>,
     in_res: &ImageRect<'_, i32>,
     in_next_avg: &Option<ImageRect<'_, i32>>,
-    out_prev: &Option<Ref<'_, ModularChannel>>,
-    buffers: &mut [&mut ModularChannel],
+    out_prev: Option<&ModularChannel>,
+    out: &mut ModularChannel,
 ) {
     trace!("vsqueeze step in_avg: {in_avg:?} in_res: {in_res:?} in_next_avg: {in_next_avg:?}");
-    let out = &mut buffers.first_mut().unwrap().data;
+    let out = &mut out.data;
     // Shortcut: guarantees that there at least 1 output row
     if out.size().1 == 0 {
         return;


### PR DESCRIPTION
I guess `Send + Sync` Modular buffers are needed for multithreading...