### PR TITLE
Small optimizations

### DIFF
--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -47,9 +47,11 @@ fn decode_modular_channel_small(
 
     const { assert!(IMAGE_OFFSET.1 == 2) };
 
+    let mut property_buffer: Vec<i32> = vec![0; num_properties];
+
     for y in 0..size.1 {
         precompute_references(buffers, chan, y, &mut references);
-        let mut property_buffer: Vec<i32> = vec![0; num_properties];
+        property_buffer.fill(0);
         property_buffer[0] = chan as i32;
         property_buffer[1] = stream_id as i32;
         let [row, row_top, row_toptop] =


### PR DESCRIPTION
```
================================================================================
BENCHMARK RESULTS using jxl/resources/test/green_queen_modular_e3.jxl
  https://github.com/zond/jxl-perfhistory
  CPU architecture: x86_64
  WARNING: System appears noisy: high system load (1.71). Results may be unreliable.
================================================================================

Statistics:
  Revisions:                        2
  Confidence:                    99.0%
  Max relative error:             1.0%
  Min:                     6858693.45 pixels/s
  Max:                     7150099.78 pixels/s
  Average:                 7004396.61 pixels/s
  Improvement:                   4.25% (max vs min)

================================================================================
Performance Graph (with credible intervals):
------------------------------------------------------------------------------------------------------------------------------------------------------
[ 1] 8420b310 Small optimizations of modular mode                |                                            [-------|-------] |   1.04 / prev ^ MAX (1.04 / min)
[ 2] 5bf71c87 Fix (or silence) clippy warnings/errors in `jxl... | [--------|---------]                                         |               v MIN (0.96 / max)
------------------------------------------------------------------------------------------------------------------------------------------------------
Scale: 6791724 to 7205499 pixels/s
```