### PR TITLE
Add store_interleaved functions to jxl_simd

### DIFF
--- a/jxl_simd/src/aarch64/neon.rs
+++ b/jxl_simd/src/aarch64/neon.rs
@@ -123,6 +123,113 @@ impl F32SimdVec for F32VecNeon {
     }
 
     #[inline(always)]
+    fn store_interleaved_2(a: Self, b: Self, base: &mut [f32], offset: usize) {
+        assert!(base.len() >= offset + 2 * Self::LEN);
+        // SAFETY: we just checked that `base` has enough space.
+        unsafe {
+            // vst2q_f32 stores two vectors interleaved
+            vst2q_f32(base.as_mut_ptr().add(offset), float32x4x2_t(a.0, b.0));
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_4(a: Self, b: Self, c: Self, d: Self, base: &mut [f32], offset: usize) {
+        assert!(base.len() >= offset + 4 * Self::LEN);
+        // SAFETY: we just checked that `base` has enough space.
+        unsafe {
+            // vst4q_f32 stores four vectors interleaved
+            vst4q_f32(
+                base.as_mut_ptr().add(offset),
+                float32x4x4_t(a.0, b.0, c.0, d.0),
+            );
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_8(
+        a: Self,
+        b: Self,
+        c: Self,
+        d: Self,
+        e: Self,
+        f: Self,
+        g: Self,
+        h: Self,
+        base: &mut [f32],
+        offset: usize,
+    ) {
+        assert!(base.len() >= offset + 8 * Self::LEN);
+        // NEON doesn't have vst8, so we use manual interleaving
+        // For 4-wide vectors, output is 32 elements: [a0,b0,c0,d0,e0,f0,g0,h0, a1,...]
+        unsafe {
+            let ptr = base.as_mut_ptr().add(offset);
+
+            // Use zip to interleave pairs
+            let ae_lo = vzip1q_f32(a.0, e.0); // [a0, e0, a1, e1]
+            let ae_hi = vzip2q_f32(a.0, e.0); // [a2, e2, a3, e3]
+            let bf_lo = vzip1q_f32(b.0, f.0);
+            let bf_hi = vzip2q_f32(b.0, f.0);
+            let cg_lo = vzip1q_f32(c.0, g.0);
+            let cg_hi = vzip2q_f32(c.0, g.0);
+            let dh_lo = vzip1q_f32(d.0, h.0);
+            let dh_hi = vzip2q_f32(d.0, h.0);
+
+            // Now interleave ae with bf, and cg with dh
+            let aebf_0 = vzip1q_f32(ae_lo, bf_lo); // [a0, b0, e0, f0]
+            let aebf_1 = vzip2q_f32(ae_lo, bf_lo); // [a1, b1, e1, f1]
+            let aebf_2 = vzip1q_f32(ae_hi, bf_hi);
+            let aebf_3 = vzip2q_f32(ae_hi, bf_hi);
+            let cgdh_0 = vzip1q_f32(cg_lo, dh_lo); // [c0, d0, g0, h0]
+            let cgdh_1 = vzip2q_f32(cg_lo, dh_lo);
+            let cgdh_2 = vzip1q_f32(cg_hi, dh_hi);
+            let cgdh_3 = vzip2q_f32(cg_hi, dh_hi);
+
+            // Final interleave to get [a0,b0,c0,d0,e0,f0,g0,h0]
+            let out0 = vreinterpretq_f32_f64(vzip1q_f64(
+                vreinterpretq_f64_f32(aebf_0),
+                vreinterpretq_f64_f32(cgdh_0),
+            ));
+            let out1 = vreinterpretq_f32_f64(vzip2q_f64(
+                vreinterpretq_f64_f32(aebf_0),
+                vreinterpretq_f64_f32(cgdh_0),
+            ));
+            let out2 = vreinterpretq_f32_f64(vzip1q_f64(
+                vreinterpretq_f64_f32(aebf_1),
+                vreinterpretq_f64_f32(cgdh_1),
+            ));
+            let out3 = vreinterpretq_f32_f64(vzip2q_f64(
+                vreinterpretq_f64_f32(aebf_1),
+                vreinterpretq_f64_f32(cgdh_1),
+            ));
+            let out4 = vreinterpretq_f32_f64(vzip1q_f64(
+                vreinterpretq_f64_f32(aebf_2),
+                vreinterpretq_f64_f32(cgdh_2),
+            ));
+            let out5 = vreinterpretq_f32_f64(vzip2q_f64(
+                vreinterpretq_f64_f32(aebf_2),
+                vreinterpretq_f64_f32(cgdh_2),
+            ));
+            let out6 = vreinterpretq_f32_f64(vzip1q_f64(
+                vreinterpretq_f64_f32(aebf_3),
+                vreinterpretq_f64_f32(cgdh_3),
+            ));
+            let out7 = vreinterpretq_f32_f64(vzip2q_f64(
+                vreinterpretq_f64_f32(aebf_3),
+                vreinterpretq_f64_f32(cgdh_3),
+            ));
+
+            vst1q_f32(ptr, out0);
+            vst1q_f32(ptr.add(4), out1);
+            vst1q_f32(ptr.add(8), out2);
+            vst1q_f32(ptr.add(12), out3);
+            vst1q_f32(ptr.add(16), out4);
+            vst1q_f32(ptr.add(20), out5);
+            vst1q_f32(ptr.add(24), out6);
+            vst1q_f32(ptr.add(28), out7);
+        }
+    }
+
+    #[inline(always)]
     fn transpose_square(d: NeonDescriptor, data: &mut [[f32; 4]], stride: usize) {
         #[target_feature(enable = "neon")]
         #[inline]

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -102,6 +102,29 @@ pub trait F32SimdVec:
 
     fn store_array(&self, mem: &mut Self::UnderlyingArray);
 
+    /// Stores two vectors interleaved: [a0, b0, a1, b1, a2, b2, ...].
+    /// Requires `base.len() >= offset + 2 * Self::LEN` or it will panic.
+    fn store_interleaved_2(a: Self, b: Self, base: &mut [f32], offset: usize);
+
+    /// Stores four vectors interleaved: [a0, b0, c0, d0, a1, b1, c1, d1, ...].
+    /// Requires `base.len() >= offset + 4 * Self::LEN` or it will panic.
+    fn store_interleaved_4(a: Self, b: Self, c: Self, d: Self, base: &mut [f32], offset: usize);
+
+    /// Stores eight vectors interleaved: [a0, b0, c0, d0, e0, f0, g0, h0, a1, ...].
+    /// Requires `base.len() >= offset + 8 * Self::LEN` or it will panic.
+    fn store_interleaved_8(
+        a: Self,
+        b: Self,
+        c: Self,
+        d: Self,
+        e: Self,
+        f: Self,
+        g: Self,
+        h: Self,
+        base: &mut [f32],
+        offset: usize,
+    );
+
     fn abs(self) -> Self;
 
     fn floor(self) -> Self;
@@ -562,4 +585,137 @@ mod test {
         }
     }
     test_all_instruction_sets!(test_transpose_square);
+
+    fn test_store_interleaved_2<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let a: Vec<f32> = (0..len).map(|i| i as f32).collect();
+        let b: Vec<f32> = (0..len).map(|i| (i + 100) as f32).collect();
+        let mut output = vec![0.0f32; 2 * len];
+
+        let a_vec = D::F32Vec::load(d, &a);
+        let b_vec = D::F32Vec::load(d, &b);
+        D::F32Vec::store_interleaved_2(a_vec, b_vec, &mut output, 0);
+
+        // Verify interleaved output: [a0, b0, a1, b1, ...]
+        for i in 0..len {
+            assert_eq!(
+                output[2 * i],
+                a[i],
+                "store_interleaved_2 failed at position {}: expected a[{}]={}, got {}",
+                2 * i,
+                i,
+                a[i],
+                output[2 * i]
+            );
+            assert_eq!(
+                output[2 * i + 1],
+                b[i],
+                "store_interleaved_2 failed at position {}: expected b[{}]={}, got {}",
+                2 * i + 1,
+                i,
+                b[i],
+                output[2 * i + 1]
+            );
+        }
+    }
+    test_all_instruction_sets!(test_store_interleaved_2);
+
+    fn test_store_interleaved_4<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let a: Vec<f32> = (0..len).map(|i| i as f32).collect();
+        let b: Vec<f32> = (0..len).map(|i| (i + 100) as f32).collect();
+        let c: Vec<f32> = (0..len).map(|i| (i + 200) as f32).collect();
+        let e: Vec<f32> = (0..len).map(|i| (i + 300) as f32).collect();
+        let mut output = vec![0.0f32; 4 * len];
+
+        let a_vec = D::F32Vec::load(d, &a);
+        let b_vec = D::F32Vec::load(d, &b);
+        let c_vec = D::F32Vec::load(d, &c);
+        let d_vec = D::F32Vec::load(d, &e);
+        D::F32Vec::store_interleaved_4(a_vec, b_vec, c_vec, d_vec, &mut output, 0);
+
+        // Verify interleaved output: [a0, b0, c0, d0, a1, b1, c1, d1, ...]
+        for i in 0..len {
+            assert_eq!(
+                output[4 * i],
+                a[i],
+                "store_interleaved_4 failed at position {}: expected a[{}]={}, got {}",
+                4 * i,
+                i,
+                a[i],
+                output[4 * i]
+            );
+            assert_eq!(
+                output[4 * i + 1],
+                b[i],
+                "store_interleaved_4 failed at position {}: expected b[{}]={}, got {}",
+                4 * i + 1,
+                i,
+                b[i],
+                output[4 * i + 1]
+            );
+            assert_eq!(
+                output[4 * i + 2],
+                c[i],
+                "store_interleaved_4 failed at position {}: expected c[{}]={}, got {}",
+                4 * i + 2,
+                i,
+                c[i],
+                output[4 * i + 2]
+            );
+            assert_eq!(
+                output[4 * i + 3],
+                e[i],
+                "store_interleaved_4 failed at position {}: expected d[{}]={}, got {}",
+                4 * i + 3,
+                i,
+                e[i],
+                output[4 * i + 3]
+            );
+        }
+    }
+    test_all_instruction_sets!(test_store_interleaved_4);
+
+    fn test_store_interleaved_8<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let arr_a: Vec<f32> = (0..len).map(|i| i as f32).collect();
+        let arr_b: Vec<f32> = (0..len).map(|i| (i + 100) as f32).collect();
+        let arr_c: Vec<f32> = (0..len).map(|i| (i + 200) as f32).collect();
+        let arr_d: Vec<f32> = (0..len).map(|i| (i + 300) as f32).collect();
+        let arr_e: Vec<f32> = (0..len).map(|i| (i + 400) as f32).collect();
+        let arr_f: Vec<f32> = (0..len).map(|i| (i + 500) as f32).collect();
+        let arr_g: Vec<f32> = (0..len).map(|i| (i + 600) as f32).collect();
+        let arr_h: Vec<f32> = (0..len).map(|i| (i + 700) as f32).collect();
+        let mut output = vec![0.0f32; 8 * len];
+
+        let a = D::F32Vec::load(d, &arr_a);
+        let b = D::F32Vec::load(d, &arr_b);
+        let c = D::F32Vec::load(d, &arr_c);
+        let dv = D::F32Vec::load(d, &arr_d);
+        let e = D::F32Vec::load(d, &arr_e);
+        let f = D::F32Vec::load(d, &arr_f);
+        let g = D::F32Vec::load(d, &arr_g);
+        let h = D::F32Vec::load(d, &arr_h);
+        D::F32Vec::store_interleaved_8(a, b, c, dv, e, f, g, h, &mut output, 0);
+
+        // Verify interleaved output: [a0, b0, c0, d0, e0, f0, g0, h0, a1, ...]
+        let arrays = [
+            &arr_a, &arr_b, &arr_c, &arr_d, &arr_e, &arr_f, &arr_g, &arr_h,
+        ];
+        for i in 0..len {
+            for (j, arr) in arrays.iter().enumerate() {
+                assert_eq!(
+                    output[8 * i + j],
+                    arr[i],
+                    "store_interleaved_8 failed at position {}: expected {}[{}]={}, got {}",
+                    8 * i + j,
+                    ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'][j],
+                    i,
+                    arr[i],
+                    output[8 * i + j]
+                );
+            }
+        }
+    }
+    test_all_instruction_sets!(test_store_interleaved_8);
 }

--- a/jxl_simd/src/scalar.rs
+++ b/jxl_simd/src/scalar.rs
@@ -53,6 +53,43 @@ impl F32SimdVec for f32 {
     }
 
     #[inline(always)]
+    fn store_interleaved_2(a: Self, b: Self, base: &mut [f32], offset: usize) {
+        base[offset] = a;
+        base[offset + 1] = b;
+    }
+
+    #[inline(always)]
+    fn store_interleaved_4(a: Self, b: Self, c: Self, d: Self, base: &mut [f32], offset: usize) {
+        base[offset] = a;
+        base[offset + 1] = b;
+        base[offset + 2] = c;
+        base[offset + 3] = d;
+    }
+
+    #[inline(always)]
+    fn store_interleaved_8(
+        a: Self,
+        b: Self,
+        c: Self,
+        d: Self,
+        e: Self,
+        f: Self,
+        g: Self,
+        h: Self,
+        base: &mut [f32],
+        offset: usize,
+    ) {
+        base[offset] = a;
+        base[offset + 1] = b;
+        base[offset + 2] = c;
+        base[offset + 3] = d;
+        base[offset + 4] = e;
+        base[offset + 5] = f;
+        base[offset + 6] = g;
+        base[offset + 7] = h;
+    }
+
+    #[inline(always)]
     fn mul_add(self, mul: Self, add: Self) -> Self {
         (self * mul) + add
     }


### PR DESCRIPTION
## Summary

Adds SIMD-accelerated interleaved store operations:
- `store_interleaved_2`: stores two vectors interleaved \[a0,b0,a1,b1,...\]
- `store_interleaved_4`: stores four vectors interleaved \[a0,b0,c0,d0,...\]
- `store_interleaved_8`: stores eight vectors interleaved

Implementations for all backends: scalar, NEON, SSE4.2, AVX, AVX512.
Includes comprehensive tests for all instruction sets.

## Context

Split out from #537 per review feedback - this functionality can be merged when there is actual usage for it.