### PR TITLE
Implement flush_pixels() for progressive rendering

### DIFF
--- a/jxl/src/api/options.rs
+++ b/jxl/src/api/options.rs
@@ -41,6 +41,11 @@ pub struct JxlDecoderOptions {
     /// This produces premultiplied alpha output, which is useful for compositing.
     /// Default: false (output straight alpha)
     pub premultiply_output: bool,
+    /// If true, enable flush_pixels() to render partially-decoded data.
+    /// This enables progressive rendering where intermediate results can be
+    /// displayed before decoding is complete.
+    /// Default: false (flush_pixels() returns Ok(()) without rendering)
+    pub enable_flush_pixels: bool,
 }
 
 impl Default for JxlDecoderOptions {
@@ -58,6 +63,7 @@ impl Default for JxlDecoderOptions {
             pixel_limit: None,
             high_precision: false,
             premultiply_output: false,
+            enable_flush_pixels: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Implement the `flush_pixels()` method that was previously `todo!()`
- Add `enable_flush_pixels` option to `JxlDecoderOptions` (default: `false`)
- Enables progressive rendering by allowing callers to render partially-decoded pixel data

## Implementation

The implementation:
1. Adds `enable_flush_pixels: bool` to `JxlDecoderOptions` (defaults to `false` for backward compatibility)
2. `flush_pixels()` checks this option - returns `Ok(())` immediately if disabled
3. When enabled, calls `decode_and_render_hf_groups()` with an empty group list to render already-decoded data

This works with the existing infrastructure:
- `LowMemoryRenderPipeline` tracks `completed_passes` per group
- `BufferSplitter` manages writing to output buffers  
- Save stages handle format conversion (F32→U8/U16)

## Usage Pattern

```rust
let mut options = JxlDecoderOptions::default();
options.enable_flush_pixels = true;  // Opt-in to progressive flush

loop {
    match decoder.process(&mut input, &mut buffers) {
        ProcessingResult::NeedsMoreInput { fallback, .. } => {
            decoder = fallback;
            let passes = decoder.num_completed_passes();
            if passes > last_passes {
                decoder.flush_pixels(&mut buffers)?;
                // Display buffers - shows progressive refinement
                last_passes = passes;
            }
        }
        ProcessingResult::Complete { .. } => break,
    }
}
```

## Test Plan

- [x] Tested with progressive JXL files showing intermediate renders
- [x] Verified multiple flush calls are idempotent
- [x] Used in [jxl-ui](https://github.com/hjanuschka/jxl-ui) for real-world progressive rendering
- [x] Default behavior unchanged (option is `false` by default)