### PR TITLE
Cache default quantization tables per-table using OnceLock

### DIFF
--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -309,8 +309,7 @@ impl Frame {
             return Ok(());
         }
         let lf_global = self.lf_global.as_mut().unwrap();
-        let mut dequant_matrices = DequantMatrices::decode(&self.header, lf_global, br)?;
-        dequant_matrices.ensure_computed(self.hf_meta.as_ref().unwrap().used_hf_types)?;
+        let dequant_matrices = DequantMatrices::decode(&self.header, lf_global, br)?;
         let block_context_map = lf_global.block_context_map.as_mut().unwrap();
         let num_histo_bits = self.header.num_groups().ceil_log2();
         let num_histograms: u32 = br.read(num_histo_bits)? as u32 + 1;


### PR DESCRIPTION
## Summary

Apply the same optimization pattern from coefficient orders (#525) to quantization tables.

- Each table encoding is now computed lazily on first access via `get_library(idx)` 
- Large transforms (128x128, 256x256) won't be computed if never used
- Follows the exact pattern used for `NATURAL_COEFF_ORDERS` in `coeff_order.rs`

## Changes

- Add `LIBRARY_QUANTS: [OnceLock<QuantEncoding>; 17]` static array
- Replace `library() -> &'static [QuantEncoding; 17]` with `get_library(idx) -> &'static QuantEncoding`
- Update single call site in `compute_quant_table()`