### PR TITLE
Fix rendering bugs introduced in PR #577

### DIFF
--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -356,9 +356,16 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             }
         }
 
+        let default_channels: Vec<usize> = (0..nc).collect();
         for (s, ibi) in stage_input_buffer_index.iter_mut().enumerate() {
             let mut filtered = vec![];
-            for c in 0..nc {
+            // For SaveStage, use s.channels to get correct output ordering (e.g., BGRA).
+            let channels = if let Stage::Save(save_stage) = &shared.stages[s] {
+                save_stage.channels.as_slice()
+            } else {
+                default_channels.as_slice()
+            };
+            for &c in channels {
                 if shared.stages[s].uses_channel(c) {
                     filtered.push(ibi[c]);
                 }

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -225,6 +225,7 @@ impl LowMemoryRenderPipeline {
                     }
                     Stage::Save(s) => {
                         // Find buffers for channels that will be saved.
+                        // Channel ordering is handled in stage_input_buffer_index construction.
                         let mut input_data: ChannelVec<_> = self.stage_input_buffer_index[i]
                             .iter()
                             .map(|(si, ci)| &self.row_buffers[*si][*ci])
@@ -360,6 +361,7 @@ impl LowMemoryRenderPipeline {
                     }
                     Stage::Save(s) => {
                         // Find buffers for channels that will be saved.
+                        // Channel ordering is handled in stage_input_buffer_index construction.
                         let mut input_data: ChannelVec<_> = self.stage_input_buffer_index[i]
                             .iter()
                             .map(|(si, ci)| &self.row_buffers[*si][*ci])

--- a/jxl/src/render/low_memory_pipeline/run_stage.rs
+++ b/jxl/src/render/low_memory_pipeline/run_stage.rs
@@ -123,9 +123,12 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<RowBuffer> for T {
         let mut output_row_data = SmallVec::new();
         // optimize for the common case of a single output row per channel.
         if output_rows_per_channel == 1 {
+            // Use OutputT's x0_offset, not InputT's - they differ for type conversions (e.g., f32→u8).
+            // Must apply the same offset calculation as the else branch.
+            let output_xstart = RowBuffer::x0_offset::<T::OutputT>() - (xpre << T::SHIFT.0);
             for x in output_buffers.iter_mut() {
                 let row = x.get_row_mut::<T::OutputT>(current_row);
-                output_row_data.push(&mut row[xstart..]);
+                output_row_data.push(&mut row[output_xstart..]);
             }
         } else {
             for x in output_buffers.iter_mut() {


### PR DESCRIPTION
## Summary

This fixes two rendering bugs introduced by PR #577 (SmallVec optimization).

### Bug 1: BGRA color swap (render_group.rs)

The optimization changed SaveStage to iterate through `stage_input_buffer_index` directly instead of using `s.channels`. This lost the channel reordering needed for BGRA output - buffers were always output in RGBA order.

**Fix:** Restore iteration through `s.channels` to get correct output ordering.

### Bug 2: Black bars in output (run_stage.rs)

The optimized path for `output_rows_per_channel == 1` used `xstart` (based on `x0_offset::<InputT>()`) but should use `x0_offset::<OutputT>()`. 

For stages that convert between types (e.g., f32→u8), these offsets differ:
- f32: `x0_offset() = 64 / 4 = 16` elements
- u8: `x0_offset() = 64 / 1 = 64` elements

This 48-element offset mismatch caused output to be written at wrong positions, resulting in black bars approximately every 64 pixels.

**Fix:** Use `x0_offset::<OutputT>()` in the optimized path, matching the else branch.

## Test plan

- [x] Tested with BGRA U8 output - colors now correct
- [x] Tested with images that previously showed black bars - now render correctly