### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "jxl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arbtest",
  "array-init",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "color-eyre",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_simd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arbtest",
  "paste",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_transforms"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "jxl_simd",

--- a/jxl/Cargo.toml
+++ b/jxl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl"
 description = "High performance Rust implementation of a JPEG XL decoder"
-version = "0.2.0"
+version = "0.2.1"
 readme = "../README.md"
 keywords = ["jpeg-xl", "decoder"]
 categories = ["multimedia::images"]
@@ -13,15 +13,15 @@ license = "BSD-3-Clause"
 exclude = ["resources/"]
 
 [dependencies]
-jxl_transforms = { path = "../jxl_transforms", version = "0.2.0" }
+jxl_transforms = { path = "../jxl_transforms", version = "0.2.1" }
 thiserror = "2.0"
 byteorder = "1.4.3"
 num-derive = "0.4"
 num-traits = "0.2.14"
 array-init = "2.0.0"
 tracing = { version = "0.1.40", optional = true }
-jxl_macros = { path = "../jxl_macros", version = "=0.2.0" }
-jxl_simd = { path = "../jxl_simd", version = "=0.2.0" }
+jxl_macros = { path = "../jxl_macros", version = "=0.2.1" }
+jxl_simd = { path = "../jxl_simd", version = "=0.2.1" }
 
 [dev-dependencies]
 arbtest = "0.3.2"
@@ -29,7 +29,7 @@ paste = "1.0.15"
 rand = "0.9.2"
 rand_xorshift = "0.4.0"
 test-log = { version = "0.2.16", features = ["trace"] }
-jxl_macros = { path = "../jxl_macros", version = "=0.2.0", features = ["test"] }
+jxl_macros = { path = "../jxl_macros", version = "=0.2.1", features = ["test"] }
 
 [features]
 all-simd = ["jxl_simd/all-simd"]

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "jxl_cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "BSD-3-Clause"
 default-run = "jxl_cli"
 
 [dependencies]
-jxl = { path = "../jxl", version = "=0.2.0" }
+jxl = { path = "../jxl", version = "=0.2.1" }
 clap = { version = "4.5.18", features = ["derive"] }
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",
@@ -18,7 +18,7 @@ exr = { version = "1.73.0", optional = true }
 color-eyre = "0.6.5"
 
 [dev-dependencies]
-jxl_macros = { path = "../jxl_macros", features = ["test"], version = "=0.2.0" }
+jxl_macros = { path = "../jxl_macros", features = ["test"], version = "=0.2.1" }
 criterion = { version = "0.7.0", features = ["html_reports"] }
 
 [features]

--- a/jxl_macros/Cargo.toml
+++ b/jxl_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl_macros"
 description = "High performance Rust implementation of a JPEG XL decoder - supporting macros"
-version = "0.2.0"
+version = "0.2.1"
 readme = "../README.md"
 keywords = ["jpeg-xl", "decoder"]
 categories = ["multimedia::images"]

--- a/jxl_simd/Cargo.toml
+++ b/jxl_simd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl_simd"
 description = "High performance Rust implementation of a JPEG XL decoder - SIMD support code"
-version = "0.2.0"
+version = "0.2.1"
 readme = "../README.md"
 keywords = ["jpeg-xl", "simd"]
 categories = ["multimedia::images"]

--- a/jxl_transforms/Cargo.toml
+++ b/jxl_transforms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl_transforms"
 description = "High performance Rust implementation of a JPEG XL decoder - Transforms"
-version = "0.2.0"
+version = "0.2.1"
 readme = "../README.md"
 keywords = ["jpeg-xl", "simd", "dct"]
 categories = ["multimedia::images"]
@@ -11,7 +11,7 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-jxl_simd = { path = "../jxl_simd", version = "=0.2.0" }
+jxl_simd = { path = "../jxl_simd", version = "=0.2.1" }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }


### PR DESCRIPTION
## Summary
- Bump all crate versions from 0.2.0 to 0.2.1

## Test plan
- [x] `cargo check` passes