### PR TITLE
Fix buffer sizing for large VarDCT transforms

### DIFF
--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -234,7 +234,10 @@ fn dequant_and_transform_to_pixels<D: SimdDescriptor>(
                 block_rect.origin.0 >> hshift[c],
                 block_rect.origin.1 >> vshift[c],
             ),
-            size: block_rect.size,
+            size: (
+                block_rect.size.0 >> hshift[c],
+                block_rect.size.1 >> vshift[c],
+            ),
         };
         let mut output_rect = pixels[c].get_rect_mut(downsampled_rect);
         for i in 0..downsampled_rect.size.1 {

--- a/jxl/src/render/internal.rs
+++ b/jxl/src/render/internal.rs
@@ -143,11 +143,18 @@ impl<Buffer> RenderPipelineShared<Buffer> {
                 requested_data_type
             );
         }
+        // Round up to 32-pixel multiples to accommodate largest VarDCT transforms (DCT32x8/DCT8x32)
         (
-            (1 << (self.log_group_size - downsample.0 as usize))
-                .min(self.input_size.0.next_multiple_of(8)),
-            (1 << (self.log_group_size - downsample.1 as usize))
-                .min(self.input_size.1.next_multiple_of(8)),
+            (1 << (self.log_group_size - downsample.0 as usize)).min(
+                (self.input_size.0 >> downsample.0 as usize)
+                    .next_multiple_of(32)
+                    .max(32),
+            ),
+            (1 << (self.log_group_size - downsample.1 as usize)).min(
+                (self.input_size.1 >> downsample.1 as usize)
+                    .next_multiple_of(32)
+                    .max(32),
+            ),
         )
     }
 


### PR DESCRIPTION
## Summary
- Fix downsampled rect size calculation in `group.rs` to properly apply horizontal and vertical shift factors to the size, not just the origin
- Round buffer sizes up to 32-pixel multiples in render pipeline to accommodate the largest VarDCT transforms (DCT32x8/DCT8x32)
