### PR TITLE
Make AUTHORS check optional

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
 
   authors:
     runs-on: [ubuntu-latest]
+    continue-on-error: true
     steps:
     - name: Checkout the source
       uses: actions/checkout@v4


### PR DESCRIPTION
Allow AUTHORS check to fail without failing the workflow run, so the benchmark comment workflow can proceed.