### PR TITLE
Add faster decoding fast paths for single-node MA trees

### DIFF
--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -195,6 +195,9 @@ pub(super) fn decode_modular_channel(
         TreeSpecialCase::WpOnly(t) => {
             decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
         }
+        TreeSpecialCase::GradientTable(t) => {
+            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
+        }
         TreeSpecialCase::SingleZero(t) => {
             decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
         }


### PR DESCRIPTION
Fixes #546

Adds specialized fast paths for modular decoding:

**Single-node fast paths** (skip tree traversal):
- `SingleZero`: No prediction, no neighbor access (for LZ77)
- `SingleGradient`: Gradient predictor with any multiplier/offset
- `SingleWest`: West/WestWest predictors (no top row needed)
- `SingleNodeTopOnly`: North, Select, NorthEast, etc.
- `SingleNodeFull`: AverageAll (needs toptop)

**LUT-based fast path for effort 2**:
- `GradientTableLookup`: For trees splitting only on property 9 with Gradient predictor
- Based on https://github.com/tirr-c/jxl-oxide/pull/306