### PR TITLE
Add SinglePropertyLookup for table-based decision routing

### DIFF
--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -195,7 +195,7 @@ pub(super) fn decode_modular_channel(
         TreeSpecialCase::WpOnly(t) => {
             decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
         }
-        TreeSpecialCase::SingleProperty(t) => {
+        TreeSpecialCase::GradientLookup(t) => {
             decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
         }
         TreeSpecialCase::SingleGradientOnly(t) => {


### PR DESCRIPTION
Generalizes WpOnlyLookup: when a tree only splits on a single non-WP property with all leaves having the same predictor (offset=0, multiplier=1), builds a LUT from property values directly to cluster IDs.

Benefits effort 2/3 encoded images where trees use fixed property-based routing. Based on jxl-oxide's SimpleMaTable approach (https://github.com/tirr-c/jxl-oxide/pull/306).

Note: This should be rebased after #598 merges to ensure proper detection order (more specific fast paths checked first).