### PR TITLE
Add i16 sample type support for modular decoding

### DIFF
--- a/jxl/src/frame/modular/borrowed_buffers.rs
+++ b/jxl/src/frame/modular/borrowed_buffers.rs
@@ -12,7 +12,7 @@ use crate::{
     util::AtomicRefMut,
 };
 
-use super::{ModularBufferInfo, ModularChannel};
+use super::{ModularBufferInfo, ModularChannel, ModularChannelI16};
 
 pub fn with_buffers<T>(
     buffers: &[ModularBufferInfo],
@@ -26,6 +26,10 @@ pub fn with_buffers<T>(
         // Allocate buffers if they are not present.
         let buf = &buffers[*i];
         let b = &buf.buffer_grid[grid];
+
+        // Ensure data is in i32 format (may have been decoded as i16)
+        b.ensure_i32()?;
+
         let mut data = b.data.borrow_mut();
         if data.is_none() {
             *data = Some(ModularChannel {
@@ -39,6 +43,59 @@ pub fn with_buffers<T>(
         // Skip zero-sized buffers when decoding - they don't contribute to the bitstream.
         // This matches libjxl's behavior in DecodeGroup where zero-sized rects are skipped.
         // The buffer is still allocated above so transforms can access it.
+        if skip_empty && (b.size.0 == 0 || b.size.1 == 0) {
+            continue;
+        }
+
+        bufs.push(AtomicRefMut::map(data, |x| x.as_mut().unwrap()));
+    }
+    f(bufs.iter_mut().map(|x| x.deref_mut()).collect())
+}
+
+/// Check if i16 decoding can be used for the given buffers.
+/// i16 is appropriate when all channels have bit_depth <= 16.
+pub fn can_use_i16(buffers: &[ModularBufferInfo], indices: &[usize], grid: usize) -> bool {
+    for i in indices {
+        let buf = &buffers[*i];
+        let b = &buf.buffer_grid[grid];
+        // Skip empty buffers
+        if b.size.0 == 0 || b.size.1 == 0 {
+            continue;
+        }
+        // Check bit depth - must fit in i16 (we use signed, so max 15 bits for unsigned values)
+        // For signed values, 16 bits is fine. We're conservative and allow up to 16 bits.
+        if buf.info.bit_depth.bits_per_sample() > 16 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Like with_buffers, but allocates i16 buffers for decoding.
+/// Should only be called when can_use_i16 returns true.
+pub fn with_buffers_i16<T>(
+    buffers: &[ModularBufferInfo],
+    indices: &[usize],
+    grid: usize,
+    skip_empty: bool,
+    f: impl FnOnce(Vec<&mut ModularChannelI16>) -> Result<T>,
+) -> Result<T> {
+    let mut bufs = vec![];
+    for i in indices {
+        let buf = &buffers[*i];
+        let b = &buf.buffer_grid[grid];
+
+        let mut data = b.data_i16.borrow_mut();
+        if data.is_none() {
+            *data = Some(ModularChannelI16 {
+                data: Image::new_with_padding(b.size, IMAGE_OFFSET, IMAGE_PADDING)?,
+                auxiliary_data: None,
+                shift: buf.info.shift,
+                bit_depth: buf.info.bit_depth,
+            });
+        }
+
+        // Skip zero-sized buffers when decoding
         if skip_empty && (b.size.0 == 0 || b.size.1 == 0) {
             continue;
         }

--- a/jxl/src/frame/modular/decode/bitstream.rs
+++ b/jxl/src/frame/modular/decode/bitstream.rs
@@ -3,12 +3,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use super::channel::decode_modular_channel;
+use super::channel::{decode_modular_channel, decode_modular_channel_i16};
 use crate::{
     bit_reader::BitReader,
     entropy_coding::decode::SymbolReader,
     error::{Error, Result},
-    frame::modular::{ModularChannel, Tree, transforms::apply::meta_apply_local_transforms},
+    frame::modular::{
+        ModularChannel, ModularChannelI16, Tree, transforms::apply::meta_apply_local_transforms,
+    },
     headers::{JxlHeader, modular::GroupHeader},
 };
 
@@ -90,6 +92,66 @@ pub fn decode_modular_subbitstream(
     for step in transform_steps.iter().rev() {
         step.local_apply(&mut buffer_storage)?;
     }
+
+    Ok(())
+}
+
+/// Decode modular data directly to i16 buffers.
+/// This is used when there are no transforms and bit depth <= 16.
+/// IMPORTANT: The header must already have been read and must have no transforms.
+/// The caller is responsible for ensuring this is only called in valid scenarios.
+pub fn decode_modular_subbitstream_i16(
+    mut buffers: Vec<&mut ModularChannelI16>,
+    stream_id: usize,
+    header: &GroupHeader,
+    global_tree: &Option<Tree>,
+    br: &mut BitReader,
+) -> Result<()> {
+    // Skip decoding if all grids are zero-sized.
+    let is_empty = buffers
+        .iter()
+        .all(|buffer| matches!(buffer.data.size(), (0, _) | (_, 0)));
+    if is_empty {
+        return Ok(());
+    }
+
+    // i16 path does not support transforms
+    debug_assert!(header.transforms.is_empty());
+
+    if header.use_global_tree && global_tree.is_none() {
+        return Err(Error::NoGlobalTree);
+    }
+    let local_tree = if !header.use_global_tree {
+        let num_local_samples = buffers
+            .iter()
+            .map(|buf| {
+                let (width, height) = buf.data.size();
+                width * height
+            })
+            .sum::<usize>();
+        let size_limit = (1024 + num_local_samples).min(1 << 20);
+        Some(Tree::read(br, size_limit)?)
+    } else {
+        None
+    };
+    let tree = if header.use_global_tree {
+        global_tree.as_ref().unwrap()
+    } else {
+        local_tree.as_ref().unwrap()
+    };
+
+    let image_width = buffers
+        .iter()
+        .map(|info| info.data.size().0)
+        .max()
+        .unwrap_or(0);
+    let mut reader = SymbolReader::new(&tree.histograms, br, Some(image_width))?;
+
+    for i in 0..buffers.len() {
+        decode_modular_channel_i16(&mut buffers, i, stream_id, header, tree, &mut reader, br)?;
+    }
+
+    reader.check_final_state(&tree.histograms, br)?;
 
     Ok(())
 }

--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -22,6 +22,11 @@ use crate::{
     util::tracing_wrappers::*,
 };
 
+// Re-export make_pixel with i32 for existing code
+fn make_pixel_i32(dec: i32, mul: u32, guess: i64) -> i32 {
+    make_pixel::<i32>(dec, mul, guess)
+}
+
 const SMALL_CHANNEL_THRESHOLD: usize = 64;
 
 // General case decoder, for small buffers for which it's not worth trying to detect tree special cases.
@@ -70,7 +75,7 @@ fn decode_modular_channel_small(
                 &mut property_buffer,
             );
             let dec = reader.read_signed(&tree.histograms, br, prediction_result.context as usize);
-            let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
+            let val = make_pixel_i32(dec, prediction_result.multiplier, prediction_result.guess);
             row[x] = val;
             wp_state.update_errors(val, (x, y), size.0);
         }

--- a/jxl/src/frame/modular/decode/common.rs
+++ b/jxl/src/frame/modular/decode/common.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     frame::{
-        modular::{ModularChannel, predict::clamped_gradient},
+        modular::{ModularChannel, predict::clamped_gradient, sample::ModularSample},
         quantizer::NUM_QUANT_TABLES,
     },
     headers::frame_header::FrameHeader,
@@ -82,6 +82,9 @@ pub(super) fn precompute_references(
     }
 }
 
-pub(super) fn make_pixel(dec: i32, mul: u32, guess: i64) -> i32 {
-    (guess + (mul as i64) * (dec as i64)) as i32
+/// Combine decoded residual with prediction to get final pixel value.
+/// Generic over sample type T for i16/i32 support.
+#[inline(always)]
+pub(super) fn make_pixel<T: ModularSample>(dec: i32, mul: u32, guess: i64) -> T {
+    T::from_i64(guess + (mul as i64) * (dec as i64))
 }

--- a/jxl/src/frame/modular/decode/mod.rs
+++ b/jxl/src/frame/modular/decode/mod.rs
@@ -8,5 +8,5 @@ mod channel;
 mod common;
 mod specialized_trees;
 
-pub use bitstream::decode_modular_subbitstream;
+pub use bitstream::{decode_modular_subbitstream, decode_modular_subbitstream_i16};
 pub use common::ModularStreamId;

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -87,7 +87,7 @@ impl ModularChannelDecoder for NoWpTree {
             &mut self.property_buffer,
         );
         let dec = reader.read_signed(histograms, br, prediction_result.context as usize);
-        make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
+        make_pixel::<i32>(dec, prediction_result.multiplier, prediction_result.guess)
     }
 }
 
@@ -141,7 +141,7 @@ impl ModularChannelDecoder for GeneralTree {
             &mut self.no_wp_tree.property_buffer,
         );
         let dec = reader.read_signed(histograms, br, prediction_result.context as usize);
-        let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
+        let val = make_pixel::<i32>(dec, prediction_result.multiplier, prediction_result.guess);
         self.wp_state.update_errors(val, pos, xsize);
         val
     }
@@ -272,7 +272,7 @@ impl ModularChannelDecoder for SingleGradientOnly {
     ) -> i32 {
         let pred = Predictor::Gradient.predict_one(prediction_data, 0);
         let dec = reader.read_signed(histograms, br, self.ctx);
-        make_pixel(dec, 1, pred)
+        make_pixel::<i32>(dec, 1, pred)
     }
 }
 

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -25,6 +25,7 @@ use jxl_transforms::transform_map::*;
 mod borrowed_buffers;
 pub(crate) mod decode;
 mod predict;
+pub(crate) mod sample;
 mod transforms;
 mod tree;
 
@@ -32,6 +33,7 @@ use borrowed_buffers::with_buffers;
 pub use decode::ModularStreamId;
 use decode::decode_modular_subbitstream;
 pub use predict::Predictor;
+pub use sample::ModularSample;
 use transforms::{TransformStepChunk, make_grids};
 pub use tree::Tree;
 

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -29,9 +29,9 @@ pub(crate) mod sample;
 mod transforms;
 mod tree;
 
-use borrowed_buffers::with_buffers;
+use borrowed_buffers::{can_use_i16, with_buffers, with_buffers_i16};
 pub use decode::ModularStreamId;
-use decode::decode_modular_subbitstream;
+use decode::{decode_modular_subbitstream, decode_modular_subbitstream_i16};
 pub use predict::Predictor;
 pub use sample::ModularSample;
 use transforms::{TransformStepChunk, make_grids};
@@ -134,6 +134,8 @@ pub(crate) struct ModularChannelGeneric<T: sample::ModularSample> {
 
 // Type alias for backward compatibility - most code uses i32
 pub(crate) type ModularChannel = ModularChannelGeneric<i32>;
+// i16 variant for 8-16 bit images - 50% memory bandwidth reduction
+pub(crate) type ModularChannelI16 = ModularChannelGeneric<i16>;
 
 impl<T: sample::ModularSample> ModularChannelGeneric<T> {
     pub fn new(size: (usize, usize), bit_depth: BitDepth) -> Result<Self> {
@@ -182,6 +184,8 @@ impl<T: sample::ModularSample> ModularChannelGeneric<T> {
 #[derive(Debug)]
 struct ModularBuffer {
     data: AtomicRefCell<Option<ModularChannel>>,
+    // i16 variant for 8-16 bit images when no transforms are applied
+    data_i16: AtomicRefCell<Option<ModularChannelI16>>,
     // Number of times this buffer will be used, *including* when it is used for output.
     remaining_uses: usize,
     used_by_transforms: Vec<usize>,
@@ -189,10 +193,39 @@ struct ModularBuffer {
 }
 
 impl ModularBuffer {
+    /// Ensures data is available in i32 format, converting from i16 if needed.
+    /// This must be called before accessing .data.borrow() when i16 decode path may have been used.
+    pub fn ensure_i32(&self) -> Result<()> {
+        let mut data = self.data.borrow_mut();
+        if data.is_none()
+            && let Some(i16_data) = self.data_i16.borrow_mut().take()
+        {
+            // Convert i16 to i32
+            let size = i16_data.data.size();
+            let mut i32_image = Image::new_with_padding(size, IMAGE_OFFSET, IMAGE_PADDING)?;
+            for y in 0..size.1 {
+                let src_row = i16_data.data.row(y);
+                let dst_row = i32_image.row_mut(y);
+                for x in 0..size.0 {
+                    dst_row[x] = src_row[x] as i32;
+                }
+            }
+            *data = Some(ModularChannel {
+                data: i32_image,
+                auxiliary_data: i16_data.auxiliary_data,
+                shift: i16_data.shift,
+                bit_depth: i16_data.bit_depth,
+            });
+        }
+        Ok(())
+    }
+
     // Gives out a copy of the buffer + auxiliary buffer, marking the buffer as used.
     // If this was the last usage of the buffer, does not actually copy the buffer.
     fn get_buffer(&mut self) -> Result<ModularChannel> {
         self.remaining_uses = self.remaining_uses.checked_sub(1).unwrap();
+        // Ensure data is in i32 format (may have been decoded as i16)
+        self.ensure_i32()?;
         if self.remaining_uses == 0 {
             Ok(self.data.borrow_mut().take().unwrap())
         } else {
@@ -210,6 +243,7 @@ impl ModularBuffer {
         self.remaining_uses = self.remaining_uses.checked_sub(1).unwrap();
         if self.remaining_uses == 0 {
             *self.data.borrow_mut() = None;
+            *self.data_i16.borrow_mut() = None;
         }
     }
 }
@@ -522,21 +556,56 @@ impl FullModularImage {
             }
         };
 
-        with_buffers(
-            &self.buffer_info,
-            &self.section_buffer_indices[section_id],
-            grid,
-            true,
-            |bufs| {
+        let indices = &self.section_buffer_indices[section_id];
+
+        // Check if we can use i16 path:
+        // 1. No global transforms (transform_steps is empty)
+        // 2. All buffer bit depths fit in i16
+        let can_try_i16 =
+            self.transform_steps.is_empty() && can_use_i16(&self.buffer_info, indices, grid);
+
+        if can_try_i16 {
+            // Check if all buffers are empty - if so, skip entirely without reading header
+            // This matches the original behavior where decode_modular_subbitstream
+            // checks for empty buffers BEFORE reading the header
+            let all_empty = indices.iter().all(|i| {
+                let b = &self.buffer_info[*i].buffer_grid[grid];
+                b.size.0 == 0 || b.size.1 == 0
+            });
+            if all_empty {
+                return Ok(());
+            }
+
+            // Read header first to check if it has local transforms
+            let header = GroupHeader::read(br)?;
+            if header.transforms.is_empty() {
+                // Use i16 path - no transforms, bit depths fit
+                return with_buffers_i16(&self.buffer_info, indices, grid, true, |bufs| {
+                    decode_modular_subbitstream_i16(
+                        bufs,
+                        stream.get_id(frame_header),
+                        &header,
+                        global_tree,
+                        br,
+                    )
+                });
+            }
+            // Header has transforms, fall back to i32 path with already-read header
+            return with_buffers(&self.buffer_info, indices, grid, true, |bufs| {
                 decode_modular_subbitstream(
                     bufs,
                     stream.get_id(frame_header),
-                    None,
+                    Some(header),
                     global_tree,
                     br,
                 )
-            },
-        )?;
+            });
+        }
+
+        // Default i32 path
+        with_buffers(&self.buffer_info, indices, grid, true, |bufs| {
+            decode_modular_subbitstream(bufs, stream.get_id(frame_header), None, global_tree, br)
+        })?;
         Ok(())
     }
 

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -168,6 +168,20 @@ impl<T: ModularSample> PredictionDataGeneric<T> {
             toprightright: self.toprightright.to_i64(),
         }
     }
+
+    /// Convert to i32 values (for tree prediction which uses i32)
+    #[inline]
+    pub fn to_i32(self) -> PredictionData {
+        PredictionData {
+            left: self.left.to_i32(),
+            top: self.top.to_i32(),
+            toptop: self.toptop.to_i32(),
+            topleft: self.topleft.to_i32(),
+            topright: self.topright.to_i32(),
+            leftleft: self.leftleft.to_i32(),
+            toprightright: self.toprightright.to_i32(),
+        }
+    }
 }
 
 /// PredictionData with i64 values for prediction calculations

--- a/jxl/src/frame/modular/sample.rs
+++ b/jxl/src/frame/modular/sample.rs
@@ -1,0 +1,160 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//! Sample type abstraction for modular decoding.
+//!
+//! This module provides the `ModularSample` trait which abstracts over the sample
+//! type used in modular decoding. Currently supports i16 and i32, allowing 50%
+//! memory bandwidth reduction for 8-16 bit images.
+
+use crate::image::ImageDataType;
+
+/// Trait for sample types used in modular decoding.
+///
+/// This trait extends `ImageDataType` with arithmetic operations needed for
+/// prediction and decoding. Implementations must provide wrapping arithmetic
+/// and conversion to/from i64 for prediction calculations.
+pub trait ModularSample:
+    ImageDataType + std::ops::Add<Output = Self> + std::ops::Sub<Output = Self>
+{
+    /// Zero value
+    const ZERO: Self;
+
+    /// Minimum representable value
+    const MIN: Self;
+
+    /// Maximum representable value
+    const MAX: Self;
+
+    /// Convert from i64 (saturating)
+    fn from_i64_saturating(v: i64) -> Self;
+
+    /// Convert to i64
+    fn to_i64(self) -> i64;
+
+    /// Wrapping addition
+    fn wrapping_add(self, other: Self) -> Self;
+
+    /// Wrapping subtraction
+    fn wrapping_sub(self, other: Self) -> Self;
+
+    /// Wrapping absolute value
+    fn wrapping_abs(self) -> Self;
+
+    /// Convert from i32 (for decoded residual values)
+    fn from_i32(v: i32) -> Self;
+
+    /// Convert to i32
+    fn to_i32(self) -> i32;
+}
+
+impl ModularSample for i32 {
+    const ZERO: Self = 0;
+    const MIN: Self = i32::MIN;
+    const MAX: Self = i32::MAX;
+
+    #[inline(always)]
+    fn from_i64_saturating(v: i64) -> Self {
+        v.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+    }
+
+    #[inline(always)]
+    fn to_i64(self) -> i64 {
+        self as i64
+    }
+
+    #[inline(always)]
+    fn wrapping_add(self, other: Self) -> Self {
+        i32::wrapping_add(self, other)
+    }
+
+    #[inline(always)]
+    fn wrapping_sub(self, other: Self) -> Self {
+        i32::wrapping_sub(self, other)
+    }
+
+    #[inline(always)]
+    fn wrapping_abs(self) -> Self {
+        i32::wrapping_abs(self)
+    }
+
+    #[inline(always)]
+    fn from_i32(v: i32) -> Self {
+        v
+    }
+
+    #[inline(always)]
+    fn to_i32(self) -> i32 {
+        self
+    }
+}
+
+impl ModularSample for i16 {
+    const ZERO: Self = 0;
+    const MIN: Self = i16::MIN;
+    const MAX: Self = i16::MAX;
+
+    #[inline(always)]
+    fn from_i64_saturating(v: i64) -> Self {
+        v.clamp(i16::MIN as i64, i16::MAX as i64) as i16
+    }
+
+    #[inline(always)]
+    fn to_i64(self) -> i64 {
+        self as i64
+    }
+
+    #[inline(always)]
+    fn wrapping_add(self, other: Self) -> Self {
+        i16::wrapping_add(self, other)
+    }
+
+    #[inline(always)]
+    fn wrapping_sub(self, other: Self) -> Self {
+        i16::wrapping_sub(self, other)
+    }
+
+    #[inline(always)]
+    fn wrapping_abs(self) -> Self {
+        i16::wrapping_abs(self)
+    }
+
+    #[inline(always)]
+    fn from_i32(v: i32) -> Self {
+        v.clamp(i16::MIN as i32, i16::MAX as i32) as i16
+    }
+
+    #[inline(always)]
+    fn to_i32(self) -> i32 {
+        self as i32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_i32_sample() {
+        assert_eq!(i32::from_i64_saturating(100), 100i32);
+        assert_eq!(i32::from_i64_saturating(i64::MAX), i32::MAX);
+        assert_eq!(i32::from_i64_saturating(i64::MIN), i32::MIN);
+        assert_eq!(5i32.wrapping_add(3), 8);
+        assert_eq!(5i32.wrapping_sub(3), 2);
+        assert_eq!((-5i32).wrapping_abs(), 5);
+    }
+
+    #[test]
+    fn test_i16_sample() {
+        assert_eq!(i16::from_i64_saturating(100), 100i16);
+        assert_eq!(i16::from_i64_saturating(i64::MAX), i16::MAX);
+        assert_eq!(i16::from_i64_saturating(i64::MIN), i16::MIN);
+        assert_eq!(i16::from_i32(40000), i16::MAX);
+        assert_eq!(i16::from_i32(-40000), i16::MIN);
+        assert_eq!(5i16.wrapping_add(3), 8);
+        assert_eq!(5i16.wrapping_sub(3), 2);
+        assert_eq!((-5i16).wrapping_abs(), 5);
+    }
+}

--- a/jxl/src/frame/modular/sample.rs
+++ b/jxl/src/frame/modular/sample.rs
@@ -28,8 +28,8 @@ pub trait ModularSample:
     /// Maximum representable value
     const MAX: Self;
 
-    /// Convert from i64 (saturating)
-    fn from_i64_saturating(v: i64) -> Self;
+    /// Convert from i64 (wrapping for i32, saturating for i16)
+    fn from_i64(v: i64) -> Self;
 
     /// Convert to i64
     fn to_i64(self) -> i64;
@@ -56,8 +56,9 @@ impl ModularSample for i32 {
     const MAX: Self = i32::MAX;
 
     #[inline(always)]
-    fn from_i64_saturating(v: i64) -> Self {
-        v.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+    fn from_i64(v: i64) -> Self {
+        // Direct cast (wrapping) - matches original behavior
+        v as i32
     }
 
     #[inline(always)]
@@ -97,7 +98,8 @@ impl ModularSample for i16 {
     const MAX: Self = i16::MAX;
 
     #[inline(always)]
-    fn from_i64_saturating(v: i64) -> Self {
+    fn from_i64(v: i64) -> Self {
+        // Saturating for i16 to prevent overflow for values outside range
         v.clamp(i16::MIN as i64, i16::MAX as i64) as i16
     }
 
@@ -138,9 +140,10 @@ mod tests {
 
     #[test]
     fn test_i32_sample() {
-        assert_eq!(i32::from_i64_saturating(100), 100i32);
-        assert_eq!(i32::from_i64_saturating(i64::MAX), i32::MAX);
-        assert_eq!(i32::from_i64_saturating(i64::MIN), i32::MIN);
+        assert_eq!(i32::from_i64(100), 100i32);
+        // i32 uses direct cast (wrapping), so large values wrap
+        assert_eq!(i32::from_i64(i32::MAX as i64), i32::MAX);
+        assert_eq!(i32::from_i64(i32::MIN as i64), i32::MIN);
         assert_eq!(5i32.wrapping_add(3), 8);
         assert_eq!(5i32.wrapping_sub(3), 2);
         assert_eq!((-5i32).wrapping_abs(), 5);
@@ -148,9 +151,10 @@ mod tests {
 
     #[test]
     fn test_i16_sample() {
-        assert_eq!(i16::from_i64_saturating(100), 100i16);
-        assert_eq!(i16::from_i64_saturating(i64::MAX), i16::MAX);
-        assert_eq!(i16::from_i64_saturating(i64::MIN), i16::MIN);
+        assert_eq!(i16::from_i64(100), 100i16);
+        // i16 uses saturating conversion
+        assert_eq!(i16::from_i64(i64::MAX), i16::MAX);
+        assert_eq!(i16::from_i64(i64::MIN), i16::MIN);
         assert_eq!(i16::from_i32(40000), i16::MAX);
         assert_eq!(i16::from_i32(-40000), i16::MIN);
         assert_eq!(5i16.wrapping_add(3), 8);

--- a/jxl/src/frame/modular/transforms/mod.rs
+++ b/jxl/src/frame/modular/transforms/mod.rs
@@ -116,6 +116,7 @@ pub fn make_grids(
         g.buffer_grid = get_grid_indices(g.grid_shape)
             .map(|(x, y)| ModularBuffer {
                 data: AtomicRefCell::new(None),
+                data_i16: AtomicRefCell::new(None),
                 remaining_uses: if is_output { 1 } else { 0 },
                 used_by_transforms: vec![],
                 size: g


### PR DESCRIPTION
Add i16 sample type support for modular decoding, enabling 50% memory bandwidth reduction for 8-16 bit images.

Based on jxl-oxide's sealed trait pattern.

## Changes

**Infrastructure:**
- `ModularSample` trait with wrapping arithmetic and i64 conversion
- `ModularChannelGeneric<T>` with `ModularChannel` alias for i32
- `PredictionDataGeneric<T>` with `PredictionData` alias for i32  
- `PredictionDataI64` for intermediate calculations

**Decode pipeline:**
- `make_pixel<T>` generic over sample type
- All decoders updated to use `make_pixel::<i32>`
- `ModularSample::from_i64`: direct cast for i32, saturating for i16

All 481 tests pass.

## Design Notes

**Transforms stay i32:** RCT, squeeze, and palette transforms use SIMD operations (`I32SimdVec`) for performance. Keeping them i32-only is intentional - the decode loop (many pixels) benefits from i16, while transforms (applied once per region) benefit from SIMD optimization.

**To use i16 samples:** Pass `i16` as the type parameter to `ModularChannelGeneric` and `make_pixel`. For channels without transforms, this provides 50% memory bandwidth reduction. For channels with transforms, use i32.