### PR TITLE
fix: use checked arithmetic in ICC tag parsing

### DIFF
--- a/jxl/src/icc/tag.rs
+++ b/jxl/src/icc/tag.rs
@@ -51,7 +51,9 @@ pub(super) fn read_tag_list(
         };
 
         let tagstart = if command & 64 == 0 {
-            prev_tagstart + prev_tagsize
+            prev_tagstart
+                .checked_add(prev_tagsize)
+                .ok_or(Error::InvalidIccStream)?
         } else {
             read_varint_from_reader(commands_stream)? as u32
         };
@@ -68,6 +70,13 @@ pub(super) fn read_tag_list(
         prev_tagstart = tagstart;
         prev_tagsize = tagsize;
 
+        let tagstart_plus_size = tagstart
+            .checked_add(tagsize)
+            .ok_or(Error::InvalidIccStream)?;
+        let tagstart_plus_size_x2 = tagstart
+            .checked_add(tagsize.checked_mul(2).ok_or(Error::InvalidIccStream)?)
+            .ok_or(Error::InvalidIccStream)?;
+
         let write_result = (|| -> std::io::Result<()> {
             decoded_profile.write_all(&tag)?;
             decoded_profile.write_u32::<BigEndian>(tagstart)?;
@@ -81,10 +90,10 @@ pub(super) fn read_tag_list(
                 decoded_profile.write_u32::<BigEndian>(tagsize)?;
             } else if tagcode == 3 {
                 decoded_profile.write_all(b"gXYZ")?;
-                decoded_profile.write_u32::<BigEndian>(tagstart + tagsize)?;
+                decoded_profile.write_u32::<BigEndian>(tagstart_plus_size)?;
                 decoded_profile.write_u32::<BigEndian>(tagsize)?;
                 decoded_profile.write_all(b"bXYZ")?;
-                decoded_profile.write_u32::<BigEndian>(tagstart + tagsize * 2)?;
+                decoded_profile.write_u32::<BigEndian>(tagstart_plus_size_x2)?;
                 decoded_profile.write_u32::<BigEndian>(tagsize)?;
             }
             Ok(())


### PR DESCRIPTION
Malformed ICC streams could trigger integer overflow when calculating tag offsets. This causes panics in debug builds and silent wraparound in release builds.

This uses `checked_add`/`checked_mul` to detect overflow and return `InvalidIccStream` instead.

Extracted from #602 as a standalone fix per review feedback.