### PR TITLE
Make as_icc() return Result instead of panicking

### DIFF
--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -253,6 +253,8 @@ pub enum Error {
     MatrixInversionFailed(f64),
     #[error("Unsupported transfer function when writing ICC")]
     IccUnsupportedTransferFunction,
+    #[error("ICC profile creation returned None")]
+    IccProfileCreationFailed,
     #[error("Table size too large when writing ICC: {0}")]
     IccTableSizeExceeded(usize),
     #[error("Invalid CMS configuration: requested ICC but no CMS is configured")]

--- a/jxl_cli/src/main.rs
+++ b/jxl_cli/src/main.rs
@@ -250,8 +250,8 @@ fn main() -> Result<()> {
     };
 
     // Get metadata from typed output before converting
-    let output_icc = typed_output.output_profile().as_icc().to_vec();
-    let embedded_icc = typed_output.embedded_profile().as_icc().to_vec();
+    let output_icc = typed_output.output_profile().as_icc()?.to_vec();
+    let embedded_icc = typed_output.embedded_profile().as_icc()?.to_vec();
     let image_size = typed_output.size();
     let original_bit_depth = typed_output.original_bit_depth().clone();
 


### PR DESCRIPTION
Malformed color encodings can cause maybe_create_profile() to fail, crashing via unwrap().

Found by Chromium's fuzzer (crbug.com/474417800).

Breaking change: as_icc() now returns Result.