### PR TITLE
Handle OOM in section buffer allocation

### DIFF
--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -365,7 +365,10 @@ impl CodestreamParser {
             if self.non_section_buf.is_empty() {
                 break;
             }
-            buf.data = vec![0; buf.len];
+            let mut data = Vec::new();
+            data.try_reserve_exact(buf.len)?;
+            data.resize(buf.len, 0);
+            buf.data = data;
             self.ready_section_data += self
                 .non_section_buf
                 .take(&mut [IoSliceMut::new(&mut buf.data)]);


### PR DESCRIPTION
## Summary
- avoid infallible allocation for section buffers
- return decoder error on allocation failure to prevent abort

## References
- https://clusterfuzz.com/testcase-detail/4634938502479872
- https://issues.chromium.org/issues/474955262
