### PR TITLE
Validate blending alpha channels

### DIFF
--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -153,8 +153,6 @@ pub enum Error {
     InvalidProperty(u32),
     #[error("Invalid alpha channel for blending: {0}, limit is {1}")]
     InvalidBlendingAlphaChannel(usize, usize),
-    #[error("Invalid blending info count: {0}, expected {1}")]
-    InvalidBlendingInfoCount(usize, usize),
     #[error("Invalid alpha channel for blending: {0}, limit is {1}")]
     PatchesInvalidAlphaChannel(usize, usize),
     #[error("Invalid patch blend mode: {0}, limit is {1}")]

--- a/jxl/src/headers/frame_header.rs
+++ b/jxl/src/headers/frame_header.rs
@@ -682,16 +682,10 @@ impl FrameHeader {
         }
 
         let num_extra_channels = nonserialized.extra_channel_info.len();
-        let uses_alpha = |mode| {
-            matches!(mode, BlendingMode::Blend | BlendingMode::AlphaWeightedAdd)
-        };
+        let uses_alpha =
+            |mode| matches!(mode, BlendingMode::Blend | BlendingMode::AlphaWeightedAdd);
 
-        if self.ec_blending_info.len() != num_extra_channels {
-            return Err(Error::InvalidBlendingInfoCount(
-                self.ec_blending_info.len(),
-                num_extra_channels,
-            ));
-        }
+        debug_assert_eq!(self.ec_blending_info.len(), num_extra_channels);
 
         if num_extra_channels > 0
             && uses_alpha(self.blending_info.mode)
@@ -811,6 +805,19 @@ mod test_frame_header {
         assert_eq!(frame_header.name, String::from(""));
         assert_eq!(frame_header.restoration_filter.epf_iters, 0);
         assert!(!frame_header.restoration_filter.gab);
+    }
+
+    #[test]
+    fn test_invalid_blending_alpha_channel() {
+        let (file_header, mut frame_header, _) =
+            read_headers_and_toc(include_bytes!("../../resources/test/extra_channels.jxl"))
+                .unwrap();
+        let nonserialized = file_header.frame_header_nonserialized();
+        frame_header.blending_info.mode = BlendingMode::Blend;
+        frame_header.blending_info.alpha_channel = nonserialized.extra_channel_info.len() as u32;
+
+        let err = frame_header.check(&nonserialized).unwrap_err();
+        assert!(matches!(err, Error::InvalidBlendingAlphaChannel(_, _)));
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://issues.chromium.org/issues/475333717

ClusterFuzz: https://clusterfuzz.com/testcase?key=6033369720619008

Validate blending alpha channel indices against the extra-channel count before rendering.