### PR TITLE
Replace pointer `as` casts with `.cast()`.

### DIFF
--- a/jxl/src/image/internal.rs
+++ b/jxl/src/image/internal.rs
@@ -355,7 +355,7 @@ impl<const S: usize> DistinctRowsIndexes for [usize; S] {
             // SAFETY: The caller guarantees the transmute is safe and proper alignment.
             unsafe {
                 std::slice::from_raw_parts_mut(
-                    row.as_mut_ptr() as *mut T,
+                    row.as_mut_ptr().cast::<T>(),
                     row.len() / std::mem::size_of::<T>(),
                 )
             }

--- a/jxl/src/image/raw.rs
+++ b/jxl/src/image/raw.rs
@@ -86,7 +86,7 @@ impl OwnedRawImage {
         let row = &mut unsafe { self.data.row_mut(row + offset.1) }[offset.0..end];
         // SAFETY: MaybeUninit<u8> and u8 have the same size and layout, and our safety invariant
         // guarantees the data is initialized.
-        unsafe { std::slice::from_raw_parts_mut(row.as_mut_ptr() as *mut u8, row.len()) }
+        unsafe { std::slice::from_raw_parts_mut(row.as_mut_ptr().cast::<u8>(), row.len()) }
     }
 
     #[inline(always)]
@@ -97,7 +97,7 @@ impl OwnedRawImage {
         let row = &unsafe { self.data.row(row + offset.1) }[offset.0..end];
         // SAFETY: MaybeUninit<u8> and u8 have the same size and layout, and our safety invariant
         // guarantees the data is initialized.
-        unsafe { std::slice::from_raw_parts(row.as_ptr() as *const u8, row.len()) }
+        unsafe { std::slice::from_raw_parts(row.as_ptr().cast::<u8>(), row.len()) }
     }
 
     pub fn byte_size(&self) -> (usize, usize) {
@@ -149,7 +149,7 @@ impl<'a> RawImageRect<'a> {
         let row = unsafe { self.data.row(row) };
         // SAFETY: MaybeUninit<u8> and u8 have the same size and layout, and our safety invariant
         // guarantees the data is initialized.
-        unsafe { std::slice::from_raw_parts(row.as_ptr() as *const u8, row.len()) }
+        unsafe { std::slice::from_raw_parts(row.as_ptr().cast::<u8>(), row.len()) }
     }
 
     pub fn rect(&self, rect: Rect) -> RawImageRect<'a> {
@@ -181,7 +181,7 @@ impl<'a> RawImageRectMut<'a> {
         let row = unsafe { self.data.row_mut(row) };
         // SAFETY: MaybeUninit<u8> and u8 have the same size and layout, and our safety invariant
         // guarantees the data is initialized.
-        unsafe { std::slice::from_raw_parts_mut(row.as_mut_ptr() as *mut u8, row.len()) }
+        unsafe { std::slice::from_raw_parts_mut(row.as_mut_ptr().cast::<u8>(), row.len()) }
     }
 
     pub fn rect_mut(&'_ mut self, rect: Rect) -> RawImageRectMut<'_> {

--- a/jxl/src/image/typed.rs
+++ b/jxl/src/image/typed.rs
@@ -128,7 +128,7 @@ impl<T: ImageDataType> Image<T> {
         // requires T to be a bag-of-bits type with no padding, so the implicit transmute is not
         // an issue.
         unsafe {
-            std::slice::from_raw_parts(row.as_ptr() as *const T, row.len() / T::DATA_TYPE_ID.size())
+            std::slice::from_raw_parts(row.as_ptr().cast::<T>(), row.len() / T::DATA_TYPE_ID.size())
         }
     }
 
@@ -142,7 +142,7 @@ impl<T: ImageDataType> Image<T> {
         // an issue.
         unsafe {
             std::slice::from_raw_parts_mut(
-                row.as_mut_ptr() as *mut T,
+                row.as_mut_ptr().cast::<T>(),
                 row.len() / T::DATA_TYPE_ID.size(),
             )
         }
@@ -193,7 +193,7 @@ impl<'a, T: ImageDataType> ImageRect<'a, T> {
         // requires T to be a bag-of-bits type with no padding, so the implicit transmute is not
         // an issue.
         unsafe {
-            std::slice::from_raw_parts(row.as_ptr() as *const T, row.len() / T::DATA_TYPE_ID.size())
+            std::slice::from_raw_parts(row.as_ptr().cast::<T>(), row.len() / T::DATA_TYPE_ID.size())
         }
     }
 
@@ -244,7 +244,7 @@ impl<'a, T: ImageDataType> ImageRectMut<'a, T> {
         // an issue.
         unsafe {
             std::slice::from_raw_parts_mut(
-                row.as_mut_ptr() as *mut T,
+                row.as_mut_ptr().cast::<T>(),
                 row.len() / T::DATA_TYPE_ID.size(),
             )
         }

--- a/jxl/src/render/low_memory_pipeline/save/identity.rs
+++ b/jxl/src/render/low_memory_pipeline/save/identity.rs
@@ -162,7 +162,7 @@ pub(super) fn store(
                 // of T for any T).
                 let output_f32 = unsafe {
                     std::slice::from_raw_parts_mut(
-                        output_buf.as_mut_ptr() as *mut MaybeUninit<f32>,
+                        output_buf.as_mut_ptr().cast::<MaybeUninit<f32>>(),
                         len_f32,
                     )
                 };

--- a/jxl/src/util/cacheline.rs
+++ b/jxl/src/util/cacheline.rs
@@ -45,7 +45,7 @@ pub fn slice_from_cachelines<T: ImageDataType>(slice: &[CacheLine]) -> &[T] {
     // slice.
     unsafe {
         std::slice::from_raw_parts(
-            slice.as_ptr() as *const T,
+            slice.as_ptr().cast::<T>(),
             slice.len() * (CACHE_LINE_BYTE_SIZE / std::mem::size_of::<T>()),
         )
     }
@@ -62,7 +62,7 @@ pub fn slice_from_cachelines_mut<T: ImageDataType>(slice: &mut [CacheLine]) -> &
     // slice.
     unsafe {
         std::slice::from_raw_parts_mut(
-            slice.as_mut_ptr() as *mut T,
+            slice.as_mut_ptr().cast::<T>(),
             slice.len() * (CACHE_LINE_BYTE_SIZE / std::mem::size_of::<T>()),
         )
     }

--- a/jxl/src/util/smallvec.rs
+++ b/jxl/src/util/smallvec.rs
@@ -33,7 +33,7 @@ impl<T, const N: usize> Deref for SmallVec<T, N> {
                 let data = &data[..*len];
                 // SAFETY: the safety invariant on `self` guarantees that the elements are
                 // initialized, and T and MaybeUninit<T> have the same size and alignment.
-                unsafe { slice::from_raw_parts(data.as_ptr() as *const T, data.len()) }
+                unsafe { slice::from_raw_parts(data.as_ptr().cast::<T>(), data.len()) }
             }
             SmallVec::Heap(v) => &v[..],
         }
@@ -47,7 +47,7 @@ impl<T, const N: usize> DerefMut for SmallVec<T, N> {
                 let data = &mut data[..*len];
                 // SAFETY: the safety invariant on `self` guarantees that the elements are
                 // initialized, and T and MaybeUninit<T> have the same size and alignment.
-                unsafe { slice::from_raw_parts_mut(data.as_mut_ptr() as *mut T, data.len()) }
+                unsafe { slice::from_raw_parts_mut(data.as_mut_ptr().cast::<T>(), data.len()) }
             }
             SmallVec::Heap(v) => &mut v[..],
         }


### PR DESCRIPTION
These are less error-prone. No actual behavioural changes.