### PR TITLE
api: Expose is_visible() in JxlFrameHeader

### DIFF
--- a/jxl/src/api/data_types.rs
+++ b/jxl/src/api/data_types.rs
@@ -256,4 +256,7 @@ pub struct JxlFrameHeader {
     pub duration: Option<f64>,
     /// Frame size (width, height)
     pub size: (usize, usize),
+    /// Whether this frame should be displayed.
+    /// False for reference-only frames (used for blending but not shown).
+    pub is_visible: bool,
 }

--- a/jxl/src/api/inner/mod.rs
+++ b/jxl/src/api/inner/mod.rs
@@ -92,6 +92,7 @@ impl JxlDecoderInner {
                 .as_ref()
                 .map(|anim| frame_header.duration(anim)),
             size,
+            is_visible: frame_header.is_visible(),
         })
     }
 


### PR DESCRIPTION
## Summary

Add `is_visible: bool` field to the public `JxlFrameHeader` struct, exposing the existing `FrameHeader::is_visible()` method.

## Motivation

This is needed for Chromium's JXL decoder to properly handle animations with reference frames. Currently, the internal `FrameHeader::is_visible()` method exists but isn't exposed in the public API, forcing consumers to compute visibility heuristics themselves.

The Chromium JXL decoder needs to know whether a frame should be displayed or is a reference-only frame (used for blending but not shown). Without this field exposed, we have to approximate visibility using `duration > 0 || is_last`, which doesn't account for `frame_type` (ReferenceOnly, LFFrame, etc.).

## Changes

- Added `is_visible: bool` field to `JxlFrameHeader` in `api/data_types.rs`
- Updated `frame_header()` in `api/inner/mod.rs` to populate the new field
