### PR TITLE
fix: validate Size/Preview once instead of per-frame

### DIFF
--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -47,6 +47,7 @@ impl CodestreamParser {
             let mut br = BitReader::new(&self.non_section_buf);
             br.skip_bits(self.non_section_bit_offset as usize)?;
             let file_header = FileHeader::read(&mut br)?;
+            file_header.validate()?;
             let xsize = file_header.size.xsize() as usize;
             let ysize = file_header.size.ysize() as usize;
             check_size_limit(

--- a/jxl/src/headers/mod.rs
+++ b/jxl/src/headers/mod.rs
@@ -51,6 +51,16 @@ where
 }
 
 impl FileHeader {
+    /// Validate Size and Preview dimensions to prevent integer overflow.
+    /// Must be called once after decoding the FileHeader.
+    pub fn validate(&self) -> Result<(), Error> {
+        self.size.validate()?;
+        if let Some(preview) = &self.image_metadata.preview {
+            preview.validate()?;
+        }
+        Ok(())
+    }
+
     pub fn frame_header_nonserialized(&self) -> FrameHeaderNonserialized {
         self.frame_header_nonserialized_with_size(self.size.xsize(), self.size.ysize())
     }

--- a/jxl/src/headers/size.rs
+++ b/jxl/src/headers/size.rs
@@ -3,11 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use crate::{
-    bit_reader::BitReader,
-    error::Error,
-    headers::encodings::{self, *},
-};
+use crate::{bit_reader::BitReader, error::Error, headers::encodings::*};
 use jxl_macros::UnconditionalCoder;
 use num_derive::FromPrimitive;
 
@@ -25,7 +21,6 @@ enum AspectRatio {
 }
 
 #[derive(UnconditionalCoder, Debug, Clone, Default)]
-#[validate]
 pub struct Size {
     small: bool,
     #[condition(small)]
@@ -45,7 +40,6 @@ pub struct Size {
 }
 
 #[derive(UnconditionalCoder, Debug, Clone)]
-#[validate]
 pub struct Preview {
     div8: bool,
     #[condition(div8)]
@@ -64,7 +58,23 @@ pub struct Preview {
     xsize: Option<u32>,
 }
 
-fn map_aspect_ratio<T: Fn() -> u64>(ysize: u32, ratio: AspectRatio, fallback: T) -> u64 {
+/// Fast aspect ratio mapping returning u32 (for xsize() hot path).
+/// Caller must ensure no overflow via validate().
+fn map_aspect_ratio<T: Fn() -> u32>(ysize: u32, ratio: AspectRatio, fallback: T) -> u32 {
+    match ratio {
+        AspectRatio::Unknown => fallback(),
+        AspectRatio::Ratio1Over1 => ysize,
+        AspectRatio::Ratio12Over10 => (ysize as u64 * 12 / 10) as u32,
+        AspectRatio::Ratio4Over3 => (ysize as u64 * 4 / 3) as u32,
+        AspectRatio::Ratio3Over2 => (ysize as u64 * 3 / 2) as u32,
+        AspectRatio::Ratio16Over9 => (ysize as u64 * 16 / 9) as u32,
+        AspectRatio::Ratio5Over4 => (ysize as u64 * 5 / 4) as u32,
+        AspectRatio::Ratio2Over1 => ysize * 2,
+    }
+}
+
+/// Safe aspect ratio mapping returning u64 (for validation).
+fn map_aspect_ratio_checked<T: Fn() -> u64>(ysize: u32, ratio: AspectRatio, fallback: T) -> u64 {
     match ratio {
         AspectRatio::Unknown => fallback(),
         AspectRatio::Ratio1Over1 => ysize as u64,
@@ -86,26 +96,30 @@ impl Size {
         }
     }
 
-    fn compute_xsize(&self) -> Result<u32, Error> {
-        let x = map_aspect_ratio(self.ysize(), self.ratio, /* fallback */ || {
+    /// Validate that xsize computation doesn't overflow.
+    /// Must be called once after decoding FileHeader.
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        let x = map_aspect_ratio_checked(self.ysize(), self.ratio, || {
             if self.small {
                 self.xsize_div8.unwrap() as u64 * 8
             } else {
                 self.xsize.unwrap() as u64
             }
         });
-        u32::try_from(x).map_err(|_| Error::ImageDimensionTooLarge(x))
-    }
-
-    fn check(&self, _: &encodings::Empty) -> Result<(), Error> {
-        self.compute_xsize()?;
+        u32::try_from(x).map_err(|_| Error::ImageDimensionTooLarge(x))?;
         Ok(())
     }
 
+    #[inline]
     pub fn xsize(&self) -> u32 {
-        // Validation happens during struct decoding via #[validate].
-        // If we reach here, compute_xsize() is guaranteed to succeed.
-        self.compute_xsize().unwrap()
+        // Fast path - validation ensures no overflow.
+        map_aspect_ratio(self.ysize(), self.ratio, || {
+            if self.small {
+                self.xsize_div8.unwrap() * 8
+            } else {
+                self.xsize.unwrap()
+            }
+        })
     }
 }
 
@@ -118,25 +132,29 @@ impl Preview {
         }
     }
 
-    fn compute_xsize(&self) -> Result<u32, Error> {
-        let x = map_aspect_ratio(self.ysize(), self.ratio, /* fallback */ || {
+    /// Validate that xsize computation doesn't overflow.
+    /// Must be called once after decoding FileHeader.
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        let x = map_aspect_ratio_checked(self.ysize(), self.ratio, || {
             if self.div8 {
                 self.xsize_div8.unwrap() as u64 * 8
             } else {
                 self.xsize.unwrap() as u64
             }
         });
-        u32::try_from(x).map_err(|_| Error::ImageDimensionTooLarge(x))
-    }
-
-    fn check(&self, _: &encodings::Empty) -> Result<(), Error> {
-        self.compute_xsize()?;
+        u32::try_from(x).map_err(|_| Error::ImageDimensionTooLarge(x))?;
         Ok(())
     }
 
+    #[inline]
     pub fn xsize(&self) -> u32 {
-        // Validation happens during struct decoding via #[validate].
-        // If we reach here, compute_xsize() is guaranteed to succeed.
-        self.compute_xsize().unwrap()
+        // Fast path - validation ensures no overflow.
+        map_aspect_ratio(self.ysize(), self.ratio, || {
+            if self.div8 {
+                self.xsize_div8.unwrap() * 8
+            } else {
+                self.xsize.unwrap()
+            }
+        })
     }
 }


### PR DESCRIPTION
Removes #[validate] from Size and Preview structs to avoid 20% performance regression on modular images.

The overflow check now runs once via FileHeader::validate() after decoding, instead of on every frame decode via #[validate] attribute.

This is secure because frames don't have their own Size struct - they reference the main header dimensions via FrameHeaderNonserialized.

Fixes #638 regression