### PR TITLE
Fix noise generation seeding for upsampled frames

### DIFF
--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -172,18 +172,17 @@ impl CodestreamParser {
             };
             self.embedded_color_profile = Some(embedded_color_profile.clone());
             // Only set default output_color_profile if not already configured by user
-            if self.output_color_profile.is_none() {
-                self.output_color_profile = Some(output_color_profile);
-            } else {
+            if let Some(user_profile) = &self.output_color_profile {
                 // Validate user's output color profile choice (libjxl compatibility)
                 // For non-XYB without CMS: only same encoding as embedded is allowed
-                let user_profile = self.output_color_profile.as_ref().unwrap();
                 if !file_header.image_metadata.xyb_encoded
                     && decode_options.cms.is_none()
                     && *user_profile != embedded_color_profile
                 {
                     return Err(Error::NonXybOutputNoCMS);
                 }
+            } else {
+                self.output_color_profile = Some(output_color_profile);
             }
             // Only set default pixel_format if not already configured (e.g. via rewind)
             if self.pixel_format.is_none() {

--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -378,52 +378,101 @@ impl Frame {
             let xsize_groups = self.header.size_groups().0;
             let gx = (group % xsize_groups) as u32;
             let gy = (group / xsize_groups) as u32;
-            // TODO(sboukortt): test upsampling+noise
             let upsampling = self.header.upsampling;
-            let x0 = gx * upsampling * group_dim;
-            let y0 = gy * upsampling * group_dim;
-            let x1 = ((x0 + upsampling * group_dim) as usize).min(self.header.size_upsampled().0);
-            let y1 = ((y0 + upsampling * group_dim) as usize).min(self.header.size_upsampled().1);
-            let xsize = x1 - x0 as usize;
-            let ysize = y1 - y0 as usize;
-            let mut rng = Xorshift128Plus::new_with_seeds(
-                self.decoder_state.visible_frame_index as u32,
-                self.decoder_state.nonvisible_frame_index as u32,
-                x0,
-                y0,
-            );
-            let bits_to_float = |bits: u32| f32::from_bits((bits >> 9) | 0x3F800000);
-            for i in 0..3 {
-                let mut buf = pipeline!(self, p, p.get_buffer(num_channels + i)?);
-                const FLOATS_PER_BATCH: usize =
-                    Xorshift128Plus::N * std::mem::size_of::<u64>() / std::mem::size_of::<f32>();
-                let mut batch = [0u64; Xorshift128Plus::N];
+            let upsampled_size = self.header.size_upsampled();
 
-                for y in 0..ysize {
-                    let row = buf.row_mut(y);
-                    for batch_index in 0..xsize.div_ceil(FLOATS_PER_BATCH) {
-                        rng.fill(&mut batch);
-                        let batch_size =
-                            (xsize - batch_index * FLOATS_PER_BATCH).min(FLOATS_PER_BATCH);
-                        for i in 0..batch_size {
-                            let x = FLOATS_PER_BATCH * batch_index + i;
-                            let k = i / 2;
-                            let high_bytes = i % 2 != 0;
-                            let bits = if high_bytes {
-                                ((batch[k] & 0xFFFFFFFF00000000) >> 32) as u32
-                            } else {
-                                (batch[k] & 0xFFFFFFFF) as u32
-                            };
-                            row[x] = bits_to_float(bits);
+            // Total buffer covers the upsampled region for this group
+            let buf_x1 = ((gx + 1) * upsampling * group_dim) as usize;
+            let buf_y1 = ((gy + 1) * upsampling * group_dim) as usize;
+            let buf_xsize = buf_x1.min(upsampled_size.0) - (gx * upsampling * group_dim) as usize;
+            let buf_ysize = buf_y1.min(upsampled_size.1) - (gy * upsampling * group_dim) as usize;
+
+            let bits_to_float = |bits: u32| f32::from_bits((bits >> 9) | 0x3F800000);
+
+            // Get all 3 noise channel buffers upfront
+            let mut bufs = [
+                pipeline!(self, p, p.get_buffer(num_channels)?),
+                pipeline!(self, p, p.get_buffer(num_channels + 1)?),
+                pipeline!(self, p, p.get_buffer(num_channels + 2)?),
+            ];
+
+            const FLOATS_PER_BATCH: usize =
+                Xorshift128Plus::N * std::mem::size_of::<u64>() / std::mem::size_of::<f32>();
+            let mut batch = [0u64; Xorshift128Plus::N];
+
+            // libjxl iterates through upsampling subdivisions with separate RNG seeds.
+            // For each subregion, a single RNG is shared across all 3 channels.
+            for iy in 0..upsampling {
+                for ix in 0..upsampling {
+                    // Seed coordinates for this subregion (matches libjxl)
+                    let x0 = (gx * upsampling + ix) * group_dim;
+                    let y0 = (gy * upsampling + iy) * group_dim;
+
+                    // Create RNG with this subregion's seed - shared across all 3 channels
+                    let mut rng = Xorshift128Plus::new_with_seeds(
+                        self.decoder_state.visible_frame_index as u32,
+                        self.decoder_state.nonvisible_frame_index as u32,
+                        x0,
+                        y0,
+                    );
+
+                    // Subregion boundaries within the buffer
+                    let sub_x0 = (ix * group_dim) as usize;
+                    let sub_y0 = (iy * group_dim) as usize;
+                    let sub_x1 = ((ix + 1) * group_dim) as usize;
+                    let sub_y1 = ((iy + 1) * group_dim) as usize;
+
+                    // Clamp to actual buffer size
+                    let sub_xsize = sub_x1.min(buf_xsize).saturating_sub(sub_x0);
+                    let sub_ysize = sub_y1.min(buf_ysize).saturating_sub(sub_y0);
+
+                    // Skip if this subregion is entirely outside the buffer
+                    if sub_xsize == 0 || sub_ysize == 0 {
+                        continue;
+                    }
+
+                    // Fill all 3 channels with this subregion's noise, sharing the RNG
+                    for buf in &mut bufs {
+                        for y in 0..sub_ysize {
+                            let row = buf.row_mut(sub_y0 + y);
+                            for batch_index in 0..sub_xsize.div_ceil(FLOATS_PER_BATCH) {
+                                rng.fill(&mut batch);
+                                let batch_size = (sub_xsize - batch_index * FLOATS_PER_BATCH)
+                                    .min(FLOATS_PER_BATCH);
+                                for i in 0..batch_size {
+                                    let x = sub_x0 + FLOATS_PER_BATCH * batch_index + i;
+                                    let k = i / 2;
+                                    let high_bytes = i % 2 != 0;
+                                    let bits = if high_bytes {
+                                        ((batch[k] & 0xFFFFFFFF00000000) >> 32) as u32
+                                    } else {
+                                        (batch[k] & 0xFFFFFFFF) as u32
+                                    };
+                                    row[x] = bits_to_float(bits);
+                                }
+                            }
                         }
                     }
                 }
-                pipeline!(
-                    self,
-                    p,
-                    p.set_buffer_for_group(num_channels + i, group, 1, buf, buffer_splitter)?
-                )
             }
+
+            // Set all buffers after filling
+            let [buf0, buf1, buf2] = bufs;
+            pipeline!(
+                self,
+                p,
+                p.set_buffer_for_group(num_channels, group, 1, buf0, buffer_splitter)?
+            );
+            pipeline!(
+                self,
+                p,
+                p.set_buffer_for_group(num_channels + 1, group, 1, buf1, buffer_splitter)?
+            );
+            pipeline!(
+                self,
+                p,
+                p.set_buffer_for_group(num_channels + 2, group, 1, buf2, buffer_splitter)?
+            );
         }
 
         let lf_global = self.lf_global.as_mut().unwrap();


### PR DESCRIPTION
## Summary

Fix incorrect noise generation when `upsampling > 1`. The code now iterates through upsampling subdivisions with separate RNG seeds per subregion, matching libjxl's behavior.

**Problem:** When upsampling > 1, jxl-rs was using a single RNG seed for the entire upsampled area instead of creating separate seeds for each upsampling subdivision. This caused ~37% pixel errors for files like `multiple_layers_noise_spline.jxl`.

**Solution:** Restructure noise generation to:
1. Loop over `(iy, ix)` upsampling subdivisions first
2. Create one RNG per subregion with subdivision-specific seed coordinates: `x0 = (gx * upsampling + ix) * group_dim`
3. Share that RNG across all 3 color channels for each subregion

This matches the libjxl reference implementation.

Fixes #610

## Changes

- `jxl/src/frame/decode.rs`: Restructured noise generation loop
- `jxl/src/frame/mod.rs`: Added `noise_with_upsampling` regression test

## Credit

Based on the fix analysis from @lilith in issue #610.