### PR TITLE
Fix panic in as_icc() for malformed color profiles

### DIFF
--- a/jxl/src/api/color.rs
+++ b/jxl/src/api/color.rs
@@ -1176,11 +1176,13 @@ impl JxlColorProfile {
     /// # Panics
     /// Panics if the color encoding cannot generate an ICC profile.
     /// Consider using `try_as_icc` for fallible conversion.
+    #[deprecated(
+        since = "0.3.1",
+        note = "Use try_as_icc() instead to handle errors gracefully"
+    )]
     pub fn as_icc(&self) -> Cow<'_, Vec<u8>> {
-        match self {
-            Self::Icc(x) => Cow::Borrowed(x),
-            Self::Simple(encoding) => Cow::Owned(encoding.maybe_create_profile().unwrap().unwrap()),
-        }
+        self.try_as_icc()
+            .expect("Failed to generate ICC profile from color encoding")
     }
 
     /// Attempts to get an ICC profile, returning None if unavailable.

--- a/jxl_cli/src/main.rs
+++ b/jxl_cli/src/main.rs
@@ -276,8 +276,17 @@ fn main() -> Result<()> {
     };
 
     // Get metadata from typed output before converting
-    let output_icc = typed_output.output_profile().as_icc().to_vec();
-    let embedded_icc = typed_output.embedded_profile().as_icc().to_vec();
+    // Use try_as_icc() to gracefully handle malformed color profiles
+    let output_icc = typed_output
+        .output_profile()
+        .try_as_icc()
+        .map(|c| c.into_owned())
+        .unwrap_or_default();
+    let embedded_icc = typed_output
+        .embedded_profile()
+        .try_as_icc()
+        .map(|c| c.into_owned())
+        .unwrap_or_default();
     let image_size = typed_output.size();
     let original_bit_depth = typed_output.original_bit_depth().clone();
 


### PR DESCRIPTION
## Summary

ClusterFuzz found that `as_icc()` could panic when processing malformed JXL files with invalid color profiles. The method used `.unwrap().unwrap()` which aborts on error.

## Changes

- Deprecate `as_icc()` in favor of `try_as_icc()` for safe error handling
- Make `as_icc()` delegate to `try_as_icc()` with `.expect()` for a clearer panic message
- Update CLI to use `try_as_icc()` to gracefully handle invalid profiles

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test

Fixes ClusterFuzz issue for Chromium bug 474417800.