### PR TITLE
Improve memory & cache usage of the low-memory pipeline.

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -191,7 +191,6 @@ pub(crate) mod tests {
     use crate::api::{JxlDataFormat, JxlDecoderOptions};
     use crate::error::Error;
     use crate::image::{Image, Rect};
-    use crate::util::test::assert_almost_abs_eq_coords;
     use jxl_macros::for_each_test_file;
     use std::path::Path;
 
@@ -375,10 +374,6 @@ pub(crate) mod tests {
                     sb.size(),
                     "Channel {c} in frame {fc} has different sizes",
                 );
-                // TODO(veluca): This check actually succeeds if we disable SIMD.
-                // With SIMD, the exact output of computations in epf.rs appear to depend on the
-                // lane that the computation was done in (???). We should investigate this.
-                // b.as_rect().check_equal(sb.as_rect());
                 let sz = b.size();
                 if false {
                     let f = std::fs::File::create(Path::new("/tmp/").join(format!(
@@ -401,7 +396,11 @@ pub(crate) mod tests {
                 }
                 for y in 0..sz.1 {
                     for x in 0..sz.0 {
-                        assert_almost_abs_eq_coords(b.row(y)[x], sb.row(y)[x], 1e-5, (x, y), c);
+                        assert_eq!(
+                            b.row(y)[x],
+                            sb.row(y)[x],
+                            "Pixels differ at position ({x}, {y}), channel {c}"
+                        );
                     }
                 }
             }

--- a/jxl/src/headers/frame_header.rs
+++ b/jxl/src/headers/frame_header.rs
@@ -44,6 +44,8 @@ impl Flags {
     pub const SKIP_ADAPTIVE_LF_SMOOTHING: u64 = 0x80;
 }
 
+pub const MAX_NUM_PASSES: usize = 11;
+
 #[derive(UnconditionalCoder, Debug, PartialEq)]
 pub struct Passes {
     #[coder(u2S(1, 2, 3, Bits(3) + 4))]

--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -1,0 +1,381 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use std::array;
+use std::ops::Range;
+
+use crate::error::Result;
+use crate::headers::frame_header::MAX_NUM_PASSES;
+use crate::image::{OwnedRawImage, Rect};
+use crate::render::LowMemoryRenderPipeline;
+use crate::render::buffer_splitter::BufferSplitter;
+use crate::render::internal::{ChannelInfo, Stage};
+use crate::util::tracing_wrappers::*;
+
+pub(super) struct InputBuffer {
+    // One buffer per channel.
+    pub(super) data: Vec<Option<OwnedRawImage>>,
+    // Storage for left/right borders (one per pass). Includes corners.
+    pub(super) leftright: [Vec<Option<OwnedRawImage>>; MAX_NUM_PASSES],
+    // Storage for top/bottom borders (one per pass). Includes corners.
+    pub(super) topbottom: [Vec<Option<OwnedRawImage>>; MAX_NUM_PASSES],
+    // Number of ready channels in the current pass.
+    ready_channels: usize,
+    pass_is_ready: [bool; MAX_NUM_PASSES],
+    pub(super) current_pass: usize,
+    num_completed_groups_3x3: usize,
+}
+
+impl InputBuffer {
+    pub(super) fn set_buffer(&mut self, chan: usize, buf: OwnedRawImage) {
+        assert!(self.data[chan].is_none());
+        self.data[chan] = Some(buf);
+        self.ready_channels += 1;
+    }
+
+    pub(super) fn new(num_channels: usize) -> Self {
+        let b = || (0..num_channels).map(|_| None).collect();
+        Self {
+            data: b(),
+            leftright: array::from_fn(|_| b()),
+            topbottom: array::from_fn(|_| b()),
+            ready_channels: 0,
+            pass_is_ready: [false; MAX_NUM_PASSES],
+            current_pass: 0,
+            num_completed_groups_3x3: 0,
+        }
+    }
+
+    fn is_ready(&self, pass: usize) -> bool {
+        self.pass_is_ready[pass]
+    }
+}
+
+// Finds a small set of rectangles that cover all the "true" values in `ready_mask`,
+// and calls `f` on each such rectangle.
+fn foreach_ready_rect(
+    ready_mask: [bool; 9],
+    mut f: impl FnMut(Range<u8>, Range<u8>) -> Result<()>,
+) -> Result<()> {
+    // x range in middle row
+    let xrange = (1 - ready_mask[3] as u8)..(2 + ready_mask[5] as u8);
+    let can_extend_top = xrange.clone().all(|x| ready_mask[x as usize]);
+    let can_extend_bottom = xrange.clone().all(|x| ready_mask[6 + x as usize]);
+    let yrange = (1 - can_extend_top as u8)..(2 + can_extend_bottom as u8);
+    f(xrange.clone(), yrange)?;
+
+    if !can_extend_top {
+        if ready_mask[1] {
+            let xrange = (1 - ready_mask[0] as u8)..(2 + ready_mask[2] as u8);
+            f(xrange, 0..1)?;
+        } else {
+            if ready_mask[0] {
+                f(0..1, 0..1)?;
+            }
+            if ready_mask[2] {
+                f(2..3, 0..1)?;
+            }
+        }
+    } else {
+        if ready_mask[0] && !xrange.contains(&0) {
+            f(0..1, 0..1)?;
+        }
+        if ready_mask[2] && !xrange.contains(&2) {
+            f(2..3, 0..1)?;
+        }
+    }
+
+    if !can_extend_bottom {
+        if ready_mask[7] {
+            let xrange = (1 - ready_mask[6] as u8)..(2 + ready_mask[8] as u8);
+            f(xrange, 2..3)?;
+        } else {
+            if ready_mask[6] {
+                f(0..1, 2..3)?;
+            }
+            if ready_mask[8] {
+                f(2..3, 2..3)?;
+            }
+        }
+    } else {
+        if ready_mask[6] && !xrange.contains(&0) {
+            f(0..1, 2..3)?;
+        }
+        if ready_mask[8] && !xrange.contains(&2) {
+            f(2..3, 2..3)?;
+        }
+    }
+
+    Ok(())
+}
+
+impl LowMemoryRenderPipeline {
+    pub(super) fn maybe_get_scratch_buffer(
+        &mut self,
+        channel: usize,
+        kind: usize,
+    ) -> Option<OwnedRawImage> {
+        self.scratch_channel_buffers[channel * 3 + kind].pop()
+    }
+
+    fn store_scratch_buffer(&mut self, channel: usize, kind: usize, image: OwnedRawImage) {
+        self.scratch_channel_buffers[channel * 3 + kind].push(image)
+    }
+
+    pub(super) fn render_with_new_group(
+        &mut self,
+        g: usize,
+        buffer_splitter: &mut BufferSplitter,
+    ) -> Result<()> {
+        let pass = {
+            let buf = &mut self.input_buffers[g];
+            if buf.ready_channels != buf.data.len() {
+                return Ok(());
+            }
+            buf.ready_channels = 0;
+            *self.shared.group_chan_ready_passes[g].iter().min().unwrap()
+        };
+
+        let (gx, gy) = self.shared.group_position(g);
+        debug!("new data ready for group {gx},{gy}, pass {pass}");
+
+        // Prepare output buffers for the group.
+        let (origin, size) = if let Some(e) = self.shared.extend_stage_index {
+            let Stage::Extend(e) = &self.shared.stages[e] else {
+                unreachable!("extend stage is not an extend stage");
+            };
+            (e.frame_origin, e.image_size)
+        } else {
+            ((0, 0), self.shared.input_size)
+        };
+        let gsz = 1 << self.shared.log_group_size;
+        let group_rect = Rect {
+            size: (gsz, gsz),
+            origin: (gsz * gx, gsz * gy),
+        }
+        .clip(self.shared.input_size);
+
+        {
+            for c in 0..self.shared.num_channels() {
+                let (bx, by) = self.border_size;
+                let (sx, sy) = self.input_buffers[g].data[c].as_ref().unwrap().byte_size();
+                let ChannelInfo {
+                    ty,
+                    downsample: (dx, dy),
+                } = self.shared.channel_info[0][c];
+                let ty = ty.unwrap();
+                let bx = bx >> dx;
+                let by = by >> dy;
+                let mut topbottom = if let Some(b) = self.maybe_get_scratch_buffer(c, 1) {
+                    b
+                } else {
+                    let height = 4 * by;
+                    let width = (1 << self.shared.log_group_size) * ty.size();
+                    OwnedRawImage::new_zeroed_with_padding((width, height), (0, 0), (0, 0))?
+                };
+                let mut leftright = if let Some(b) = self.maybe_get_scratch_buffer(c, 2) {
+                    b
+                } else {
+                    let height = 1 << self.shared.log_group_size;
+                    let width = 4 * bx * ty.size();
+                    OwnedRawImage::new_zeroed_with_padding((width, height), (0, 0), (0, 0))?
+                };
+                let input = self.input_buffers[g].data[c].as_ref().unwrap();
+                if by != 0 {
+                    for y in 0..(2 * by).min(sy) {
+                        topbottom.row_mut(y)[..sx].copy_from_slice(input.row(y));
+                        topbottom.row_mut(4 * by - 1 - y)[..sx]
+                            .copy_from_slice(input.row(sy - y - 1));
+                    }
+                }
+                if bx != 0 {
+                    let cs = (bx * 2 * ty.size()).min(sx);
+                    for y in 0..sy {
+                        let row_out = leftright.row_mut(y);
+                        let row_in = input.row(y);
+                        row_out[..cs].copy_from_slice(&row_in[..cs]);
+                        row_out[4 * bx * ty.size() - cs..].copy_from_slice(&row_in[sx - cs..]);
+                    }
+                }
+                self.input_buffers[g].leftright[pass][c] = Some(leftright);
+                self.input_buffers[g].topbottom[pass][c] = Some(topbottom);
+            }
+            self.input_buffers[g].current_pass = pass;
+            self.input_buffers[g].pass_is_ready[pass] = true;
+        }
+
+        let gxm1 = gx.saturating_sub(1);
+        let gym1 = gy.saturating_sub(1);
+        let gxp1 = (gx + 1).min(self.shared.group_count.0 - 1);
+        let gyp1 = (gy + 1).min(self.shared.group_count.1 - 1);
+        let gw = self.shared.group_count.0;
+        // TODO(veluca): this code probably needs to be adapted for multithreading.
+        let mut ready_mask = [
+            self.input_buffers[gym1 * gw + gxm1].is_ready(pass),
+            self.input_buffers[gym1 * gw + gx].is_ready(pass),
+            self.input_buffers[gym1 * gw + gxp1].is_ready(pass),
+            self.input_buffers[gy * gw + gxm1].is_ready(pass),
+            self.input_buffers[gy * gw + gx].is_ready(pass), // should be guaranteed to be 1.
+            self.input_buffers[gy * gw + gxp1].is_ready(pass),
+            self.input_buffers[gyp1 * gw + gxm1].is_ready(pass),
+            self.input_buffers[gyp1 * gw + gx].is_ready(pass),
+            self.input_buffers[gyp1 * gw + gxp1].is_ready(pass),
+        ];
+        // We can only render a corner if we have all the 4 adjacent groups. Thus, mask out corners if
+        // the corresponding side buffers are not ready.
+        ready_mask[0] &= ready_mask[1];
+        ready_mask[0] &= ready_mask[3];
+        ready_mask[2] &= ready_mask[1];
+        ready_mask[2] &= ready_mask[5];
+        ready_mask[6] &= ready_mask[3];
+        ready_mask[6] &= ready_mask[7];
+        ready_mask[8] &= ready_mask[5];
+        ready_mask[8] &= ready_mask[7];
+
+        foreach_ready_rect(ready_mask, |xrange, yrange| {
+            let y0 = match (gy == 0, yrange.start) {
+                (true, 0) => group_rect.origin.1,
+                (false, 0) => group_rect.origin.1 - self.border_size.1,
+                (_, 1) => group_rect.origin.1 + self.border_size.1,
+                // (_, 2)
+                _ => group_rect.end().1 - self.border_size.1,
+            };
+            let x0 = match (gx == 0, xrange.start) {
+                (true, 0) => group_rect.origin.0,
+                (false, 0) => group_rect.origin.0 - self.border_size.0,
+                (_, 1) => group_rect.origin.0 + self.border_size.0,
+                // (_, 2)
+                _ => group_rect.end().0 - self.border_size.0,
+            };
+
+            let y1 = match (gy + 1 == self.shared.group_count.1, yrange.end) {
+                (true, 3) => group_rect.end().1,
+                (false, 3) => group_rect.end().1 + self.border_size.1,
+                (_, 2) => group_rect.end().1 - self.border_size.1,
+                // (_, 1)
+                _ => group_rect.origin.1 + self.border_size.1,
+            };
+
+            let x1 = match (gx + 1 == self.shared.group_count.0, xrange.end) {
+                (true, 3) => group_rect.end().0,
+                (false, 3) => group_rect.end().0 + self.border_size.0,
+                (_, 2) => group_rect.end().0 - self.border_size.0,
+                // (_, 1)
+                _ => group_rect.origin.0 + self.border_size.0,
+            };
+
+            let image_area = Rect {
+                origin: (x0, y0),
+                size: (x1 - x0, y1 - y0),
+            };
+
+            let mut local_buffers = buffer_splitter.get_local_buffers(
+                &self.save_buffer_info,
+                image_area,
+                false,
+                self.shared.input_size,
+                size,
+                origin,
+            );
+
+            self.render_group((gx, gy), image_area, &mut local_buffers)?;
+            Ok(())
+        })?;
+
+        for c in 0..self.input_buffers[g].data.len() {
+            if let Some(b) = std::mem::take(&mut self.input_buffers[g].data[c]) {
+                self.store_scratch_buffer(c, 0, b);
+            }
+        }
+
+        // Clear border buffers that will not be used again.
+        // This is certainly the case if *all* the groups in the 3x3 group area around
+        // the current group have had all their passes rendered.
+        if pass + 1 == self.shared.num_passes {
+            for g in [
+                gym1 * gw + gxm1,
+                gym1 * gw + gx,
+                gym1 * gw + gxp1,
+                gy * gw + gxm1,
+                gy * gw + gx,
+                gy * gw + gxp1,
+                gyp1 * gw + gxm1,
+                gyp1 * gw + gx,
+                gyp1 * gw + gxp1,
+            ] {
+                self.input_buffers[g].num_completed_groups_3x3 += 1;
+                if self.input_buffers[g].num_completed_groups_3x3 != 9 {
+                    continue;
+                }
+                for c in 0..self.input_buffers[g].data.len() {
+                    for p in 0..self.shared.num_passes {
+                        if let Some(b) = std::mem::take(&mut self.input_buffers[g].topbottom[p][c])
+                        {
+                            self.store_scratch_buffer(c, 1, b);
+                        }
+                        if let Some(b) = std::mem::take(&mut self.input_buffers[g].leftright[p][c])
+                        {
+                            self.store_scratch_buffer(c, 2, b);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foreach_ready_rect() {
+        for i in 0..512 {
+            let mut ready_mask = [false; 9];
+            for j in 0..9 {
+                if (i >> j) & 1 == 1 {
+                    ready_mask[j] = true;
+                }
+            }
+            if !ready_mask[4] {
+                continue;
+            }
+
+            let mut covered = [false; 9];
+            foreach_ready_rect(ready_mask, |xr, yr| {
+                for y in yr {
+                    for x in xr.clone() {
+                        let idx = (y as usize) * 3 + (x as usize);
+                        assert!(
+                            ready_mask[idx],
+                            "Covered not ready index {} in mask {:?} (x={}, y={})",
+                            idx, ready_mask, x, y
+                        );
+                        assert!(
+                            !covered[idx],
+                            "Double coverage of index {} in mask {:?}",
+                            idx, ready_mask
+                        );
+                        covered[idx] = true;
+                    }
+                }
+                Ok(())
+            })
+            .unwrap();
+
+            for j in 0..9 {
+                if ready_mask[j] {
+                    assert!(
+                        covered[j],
+                        "Failed to cover index {} in mask {:?}",
+                        j, ready_mask
+                    );
+                }
+            }
+        }
+    }
+}

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -15,22 +15,18 @@ use crate::image::{Image, ImageDataType, OwnedRawImage, Rect};
 use crate::render::MAX_BORDER;
 use crate::render::buffer_splitter::{BufferSplitter, SaveStageBufferInfo};
 use crate::render::internal::Stage;
+use crate::render::low_memory_pipeline::group_scheduler::InputBuffer;
 use crate::util::{ShiftRightCeil, tracing_wrappers::*};
 
 use super::RenderPipeline;
 use super::internal::{RenderPipelineShared, RunInOutStage, RunInPlaceStage};
 
+mod group_scheduler;
 mod helpers;
 mod render_group;
 pub(super) mod row_buffers;
 mod run_stage;
 mod save;
-
-struct InputBuffer {
-    // One buffer per channel.
-    data: Vec<Option<OwnedRawImage>>,
-    completed_passes: usize,
-}
 
 pub struct LowMemoryRenderPipeline {
     shared: RenderPipelineShared<RowBuffer>,
@@ -49,7 +45,8 @@ pub struct LowMemoryRenderPipeline {
     // The amount of pixels that we need to read (for every channel) in non-edge groups to run all
     // stages correctly.
     input_border_pixels: Vec<(usize, usize)>,
-    has_nontrivial_border: bool,
+    // Size of the border, in image (i.e. non-downsampled) pixels.
+    border_size: (usize, usize),
     // For every stage, the downsampling level of *any* channel that the stage uses at that point.
     // Note that this must be equal across all the used channels.
     downsampling_for_stage: Vec<(usize, usize)>,
@@ -60,143 +57,10 @@ pub struct LowMemoryRenderPipeline {
     opaque_alpha_buffers: Vec<Option<RowBuffer>>,
     // Sorted indices to call get_distinct_indices.
     sorted_buffer_indices: Vec<Vec<(usize, usize, usize)>>,
-    // For each channel, buffers that could be reused to store group data for that channel.
+    // For each channel and the 3 kinds of buffers (center / topbottom / leftright), buffers that
+    // could be reused to store group data for that channel.
+    // Indexed by [3*channel] = center, [3*channel+1] = topbottom, [3*channel+2] = leftright.
     scratch_channel_buffers: Vec<Vec<OwnedRawImage>>,
-}
-
-impl LowMemoryRenderPipeline {
-    // TODO(veluca): most of this logic will need to change to ensure better cache utilization and
-    // lower memory usage.
-    fn render_with_new_group(
-        &mut self,
-        new_group_id: usize,
-        buffer_splitter: &mut BufferSplitter,
-    ) -> Result<()> {
-        let (gx, gy) = self.shared.group_position(new_group_id);
-
-        // We put groups that are 2 afar here, because even if they could not have become
-        // renderable, they might have become freeable.
-        let mut possible_groups = vec![];
-        for dy in -2..=2 {
-            let igy = gy as isize + dy;
-            if igy < 0 || igy >= self.shared.group_count.1 as isize {
-                continue;
-            }
-            for dx in -2..=2 {
-                let igx = gx as isize + dx;
-                if igx < 0 || igx >= self.shared.group_count.0 as isize {
-                    continue;
-                }
-                possible_groups.push(igy as usize * self.shared.group_count.0 + igx as usize);
-            }
-        }
-
-        // First, render all groups that have made progress; only check those that *could* have
-        // made progress.
-        for g in possible_groups.iter().copied() {
-            let ready_passes = self.shared.group_chan_ready_passes[g]
-                .iter()
-                .copied()
-                .min()
-                .unwrap();
-            if self.input_buffers[g].completed_passes < ready_passes {
-                let (gx, gy) = self.shared.group_position(g);
-                let mut fully_ready_passes = ready_passes;
-                // Here we assume that we never need more than one group worth of border.
-                if self.has_nontrivial_border {
-                    for dy in -1..=1 {
-                        let igy = gy as isize + dy;
-                        if igy < 0 || igy >= self.shared.group_count.1 as isize {
-                            continue;
-                        }
-                        for dx in -1..=1 {
-                            let igx = gx as isize + dx;
-                            if igx < 0 || igx >= self.shared.group_count.0 as isize {
-                                continue;
-                            }
-                            let ig = (igy as usize) * self.shared.group_count.0 + igx as usize;
-                            let ready_passes = self.shared.group_chan_ready_passes[ig]
-                                .iter()
-                                .copied()
-                                .min()
-                                .unwrap();
-                            fully_ready_passes = fully_ready_passes.min(ready_passes);
-                        }
-                    }
-                }
-                if self.input_buffers[g].completed_passes >= fully_ready_passes {
-                    continue;
-                }
-                debug!(
-                    "new ready passes for group {gx},{gy} ({} completed, \
-                    {ready_passes} ready, {fully_ready_passes} ready including neighbours)",
-                    self.input_buffers[g].completed_passes
-                );
-
-                // Prepare output buffers for the group.
-                let (origin, size) = if let Some(e) = self.shared.extend_stage_index {
-                    let Stage::Extend(e) = &self.shared.stages[e] else {
-                        unreachable!("extend stage is not an extend stage");
-                    };
-                    (e.frame_origin, e.image_size)
-                } else {
-                    ((0, 0), self.shared.input_size)
-                };
-                let gsz = (
-                    1 << self.shared.log_group_size,
-                    1 << self.shared.log_group_size,
-                );
-                let rect_to_render = Rect {
-                    size: gsz,
-                    origin: (gsz.0 * gx, gsz.1 * gy),
-                };
-                let mut local_buffers = buffer_splitter.get_local_buffers(
-                    &self.save_buffer_info,
-                    rect_to_render,
-                    false,
-                    self.shared.input_size,
-                    size,
-                    origin,
-                );
-
-                self.render_group((gx, gy), &mut local_buffers)?;
-
-                self.input_buffers[g].completed_passes = fully_ready_passes;
-            }
-        }
-
-        // Clear buffers that will not be used again.
-        for g in possible_groups.iter().copied() {
-            let (gx, gy) = self.shared.group_position(g);
-            let mut neigh_complete_passes = self.input_buffers[g].completed_passes;
-            if self.has_nontrivial_border {
-                for dy in -1..=1 {
-                    let igy = gy as isize + dy;
-                    if igy < 0 || igy >= self.shared.group_count.1 as isize {
-                        continue;
-                    }
-                    for dx in -1..=1 {
-                        let igx = gx as isize + dx;
-                        if igx < 0 || igx >= self.shared.group_count.0 as isize {
-                            continue;
-                        }
-                        let ig = (igy as usize) * self.shared.group_count.0 + igx as usize;
-                        neigh_complete_passes = self.input_buffers[ig]
-                            .completed_passes
-                            .min(neigh_complete_passes);
-                    }
-                }
-            }
-            if self.shared.num_passes <= neigh_complete_passes {
-                for (c, b) in self.input_buffers[g].data.iter_mut().enumerate() {
-                    if let Some(b) = std::mem::take(b) {
-                        self.scratch_channel_buffers[c].push(b);
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 impl RenderPipeline for LowMemoryRenderPipeline {
@@ -205,13 +69,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
     fn new_from_shared(shared: RenderPipelineShared<Self::Buffer>) -> Result<Self> {
         let mut input_buffers = vec![];
         for _ in 0..shared.group_chan_ready_passes.len() {
-            input_buffers.push(InputBuffer {
-                data: vec![],
-                completed_passes: 0,
-            });
-            for _ in 0..shared.group_chan_ready_passes[0].len() {
-                input_buffers.last_mut().unwrap().data.push(None);
-            }
+            input_buffers.push(InputBuffer::new(shared.group_chan_ready_passes[0].len()));
         }
         let nc = shared.channel_info[0].len();
         let mut previous_inout: Vec<_> = (0..nc).map(|x| (0usize, x)).collect();
@@ -385,6 +243,24 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             })
             .collect();
 
+        let mut border_size = (0, 0);
+        for c in 0..nc {
+            border_size.0 = border_size
+                .0
+                .max(border_pixels[c].0 << shared.channel_info[0][c].downsample.0);
+            border_size.1 = border_size
+                .1
+                .max(border_pixels[c].1 << shared.channel_info[0][c].downsample.1);
+        }
+        for s in 0..shared.stages.len() {
+            border_size.0 = border_size
+                .0
+                .max(border_pixels_per_stage[s].0 << downsampling_for_stage[s].0);
+            border_size.1 = border_size
+                .1
+                .max(border_pixels_per_stage[s].1 << downsampling_for_stage[s].1);
+        }
+
         Ok(Self {
             input_buffers,
             stage_input_buffer_index,
@@ -392,7 +268,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             padding_was_rendered: false,
             save_buffer_info,
             stage_output_border_pixels: border_pixels_per_stage,
-            has_nontrivial_border: border_pixels.iter().any(|x| *x != (0, 0)),
+            border_size,
             input_border_pixels: border_pixels,
             local_states: shared
                 .stages
@@ -403,13 +279,13 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             downsampling_for_stage,
             opaque_alpha_buffers,
             sorted_buffer_indices,
-            scratch_channel_buffers: (0..nc).map(|_| vec![]).collect(),
+            scratch_channel_buffers: (0..nc * 3).map(|_| vec![]).collect(),
         })
     }
 
     #[instrument(skip_all, err)]
     fn get_buffer<T: ImageDataType>(&mut self, channel: usize) -> Result<Image<T>> {
-        if let Some(b) = self.scratch_channel_buffers[channel].pop() {
+        if let Some(b) = self.maybe_get_scratch_buffer(channel, 0) {
             return Ok(Image::from_raw(b));
         }
         let sz = self.shared.group_size_for_channel(channel, T::DATA_TYPE_ID);
@@ -430,7 +306,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             channel,
             T::DATA_TYPE_ID,
         );
-        self.input_buffers[group_id].data[channel] = Some(buf.into_raw());
+        self.input_buffers[group_id].set_buffer(channel, buf.into_raw());
         self.shared.group_chan_ready_passes[group_id][channel] += num_passes;
 
         self.render_with_new_group(group_id, buffer_splitter)

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -8,9 +8,9 @@ use std::ops::Range;
 use crate::{
     api::JxlOutputBuffer,
     error::Result,
-    image::DataTypeTag,
+    image::{DataTypeTag, Rect},
     render::{
-        internal::Stage,
+        internal::{ChannelInfo, Stage},
         low_memory_pipeline::{
             helpers::{get_distinct_indices, mirror},
             run_stage::ExtraInfo,
@@ -70,79 +70,135 @@ fn apply_x_padding(
 }
 
 impl LowMemoryRenderPipeline {
-    fn fill_initial_buffers(&mut self, c: usize, y: usize, y0: usize, (gx, gy): (usize, usize)) {
-        let ty = self.shared.channel_info[0][c]
-            .ty
-            .expect("Channel info should be populated at this point");
-        let gys = 1
-            << (self.shared.log_group_size - self.shared.channel_info[0][c].downsample.1 as usize);
+    fn fill_initial_buffers(
+        &mut self,
+        c: usize,
+        y: usize,
+        (x0, xsize): (usize, usize),
+        (gx, gy): (usize, usize),
+    ) {
+        let ChannelInfo {
+            ty,
+            downsample: (dx, dy),
+        } = self.shared.channel_info[0][c];
+        let ty = ty.expect("Channel info should be populated at this point");
+        let group_ysize = 1 << (self.shared.log_group_size - dy as usize);
+        let group_xsize = 1 << (self.shared.log_group_size - dx as usize);
 
-        let (input_y, igy) = if y < y0 {
-            (y + gys - y0, gy - 1)
-        } else if y >= y0 + gys {
-            (y - y0 - gys, gy + 1)
+        let (bx, by) = self.border_size;
+
+        let group_y0 = gy * group_ysize;
+        let group_x0 = gx << (self.shared.log_group_size - dx as usize);
+        let group_x1 = group_x0 + group_xsize;
+
+        let (input_y, igy, is_topbottom) = if y < group_y0 {
+            (y + (by >> dy) * 4 - group_y0, gy - 1, true)
+        } else if y >= group_y0 + group_ysize {
+            (y - group_y0 - group_ysize, gy + 1, true)
         } else {
-            (y - y0, gy)
+            (y - group_y0, gy, false)
         };
 
         let output_row = self.row_buffers[0][c].get_row_mut::<u8>(y);
-        // Both are in units of bytes.
-        let x0_offset = RowBuffer::x0_byte_offset();
-        let extrax = self.input_border_pixels[c].0 * ty.size();
+
+        let copy_x0 = x0.saturating_sub(self.input_border_pixels[c].0);
+        let copy_x1 =
+            (x0 + xsize + self.input_border_pixels[c].0).min(self.shared.input_size.0.shrc(dx));
+
+        debug_assert!(copy_x1 >= group_x0);
+
+        let mut copy_byte_offset = RowBuffer::x0_byte_offset() - (x0 - copy_x0) * ty.size();
 
         let base_gid = igy * self.shared.group_count.0 + gx;
 
-        // Previous group horizontally, if any.
-        if gx > 0 && extrax != 0 {
-            let input_buf = self.input_buffers[base_gid - 1].data[c].as_ref().unwrap();
+        let pass = self.input_buffers[gy * self.shared.group_count.0 + gx].current_pass;
+
+        // Previous group horizontally, if needed.
+        if copy_x0 < group_x0 {
+            let (input_buf, xs) = if is_topbottom {
+                (
+                    self.input_buffers[base_gid - 1].topbottom[pass][c]
+                        .as_ref()
+                        .unwrap(),
+                    group_xsize,
+                )
+            } else {
+                (
+                    self.input_buffers[base_gid - 1].leftright[pass][c]
+                        .as_ref()
+                        .unwrap(),
+                    4 * (bx >> dx),
+                )
+            };
             let input_row = input_buf.row(input_y);
-            output_row[x0_offset - extrax..x0_offset]
-                .copy_from_slice(&input_row[input_buf.byte_size().0 - extrax..]);
+
+            let to_copy = (group_x0 - copy_x0) * ty.size();
+            let src_byte_offset = xs * ty.size() - to_copy;
+
+            output_row[copy_byte_offset..copy_byte_offset + to_copy]
+                .copy_from_slice(&input_row[src_byte_offset..src_byte_offset + to_copy]);
+            copy_byte_offset += to_copy;
         }
-        let input_buf = self.input_buffers[base_gid].data[c].as_ref().unwrap();
+        let input_buf = if is_topbottom {
+            self.input_buffers[base_gid].topbottom[pass][c]
+                .as_ref()
+                .unwrap()
+        } else {
+            self.input_buffers[base_gid].data[c].as_ref().unwrap()
+        };
         let input_row = input_buf.row(input_y);
-        let gxs = input_buf.byte_size().0; // bytes
-        output_row[x0_offset..x0_offset + gxs].copy_from_slice(input_row);
+        let copy_start = copy_x0.saturating_sub(group_x0) * ty.size();
+        let copy_end = (copy_x1.min(group_x1) - group_x0) * ty.size();
+        let to_copy = copy_end - copy_start;
+        output_row[copy_byte_offset..copy_byte_offset + to_copy]
+            .copy_from_slice(&input_row[copy_start..copy_end]);
+        copy_byte_offset += to_copy;
         // Next group horizontally, if any.
-        if gx + 1 < self.shared.group_count.0 && extrax != 0 {
-            let input_buf = self.input_buffers[base_gid + 1].data[c].as_ref().unwrap();
+        if copy_x1 > group_x1 {
+            let input_buf = if is_topbottom {
+                self.input_buffers[base_gid + 1].topbottom[pass][c]
+                    .as_ref()
+                    .unwrap()
+            } else {
+                self.input_buffers[base_gid + 1].leftright[pass][c]
+                    .as_ref()
+                    .unwrap()
+            };
             let input_row = input_buf.row(input_y);
             let dx = self.shared.channel_info[0][c].downsample.0;
             let gid = gy * self.shared.group_count.0 + gx;
             let next_group_xsize = self.shared.group_size(gid + 1).0.shrc(dx);
-            let border_x = extrax.min(next_group_xsize * ty.size());
-            output_row[gxs + x0_offset..gxs + x0_offset + border_x]
-                .copy_from_slice(&input_row[..border_x]);
-            if border_x < extrax {
-                let pad_from = ((gxs + border_x) / ty.size()) as isize;
-                let pad_to = ((gxs + extrax) / ty.size()) as isize;
+            let border_x = (copy_x1 - group_x1).min(next_group_xsize);
+            output_row[copy_byte_offset..copy_byte_offset + border_x * ty.size()]
+                .copy_from_slice(&input_row[..border_x * ty.size()]);
+            if border_x + group_x1 < copy_x1 {
+                let pad_from = (xsize + border_x) as isize;
+                let pad_to = (xsize + copy_x1 - group_x1) as isize;
                 apply_x_padding(ty, output_row, pad_from..pad_to, 0..pad_from);
             }
         }
     }
 
-    // Renders a single group worth of data.
+    // Renders *parts* of group's worth of data.
+    // In particular, renders the sub-rectangle given in `image_area`, where (1, 1) refers to
+    // the center of the group, and 0 and 2 include data from the neighbouring group (if any).
     #[instrument(skip(self, buffers))]
     pub(super) fn render_group(
         &mut self,
         (gx, gy): (usize, usize),
+        image_area: Rect,
         buffers: &mut [Option<JxlOutputBuffer>],
     ) -> Result<()> {
-        let gid = gy * self.shared.group_count.0 + gx;
-        let (xsize, num_rows) = self.shared.group_size(gid);
-        let (x0, y0) = self.shared.group_offset(gid);
+        let start_of_row = image_area.origin.0 == 0;
+        let end_of_row = image_area.end().0 == self.shared.input_size.0;
+
+        let Rect {
+            origin: (x0, y0),
+            size: (xsize, num_rows),
+        } = image_area;
 
         let num_channels = self.shared.num_channels();
-        let mut num_extra_rows = 0;
-
-        for c in 0..num_channels {
-            num_extra_rows = num_extra_rows
-                .max(self.input_border_pixels[c].1 << self.shared.channel_info[0][c].downsample.1);
-        }
-        for s in 0..self.shared.stages.len() {
-            num_extra_rows = num_extra_rows
-                .max(self.stage_output_border_pixels[s].1 << self.downsampling_for_stage[s].1);
-        }
+        let num_extra_rows = self.border_size.1;
 
         // This follows the same implementation strategy as the C++ code in libjxl.
         // We pretend that every stage has a vertical shift of 0, i.e. it is as tall
@@ -152,7 +208,7 @@ impl LowMemoryRenderPipeline {
         // when vy % (1<<vshift) == 0.
 
         let vy0 = y0.saturating_sub(num_extra_rows);
-        let vy1 = y0 + num_rows + num_extra_rows;
+        let vy1 = image_area.end().1 + num_extra_rows;
 
         for vy in vy0..vy1 {
             let mut current_origin = (0, 0);
@@ -161,7 +217,7 @@ impl LowMemoryRenderPipeline {
             // Step 1: read input channels.
             for c in 0..num_channels {
                 // Same logic as below, but adapted to the input stage.
-                let dy = self.shared.channel_info[0][c].downsample.1;
+                let (dx, dy) = self.shared.channel_info[0][c].downsample;
                 let scaled_y_border = self.input_border_pixels[c].1 << dy;
                 let stage_vy = vy as isize - num_extra_rows as isize + scaled_y_border as isize;
                 if stage_vy % (1 << dy) != 0 {
@@ -176,7 +232,7 @@ impl LowMemoryRenderPipeline {
                     continue;
                 }
                 let y = y as usize;
-                self.fill_initial_buffers(c, y, y0 >> dy, (gx, gy));
+                self.fill_initial_buffers(c, y, (x0 >> dx, xsize >> dx), (gx, gy));
             }
             // Step 2: go through stages one by one.
             for (i, stage) in self.shared.stages.iter().enumerate() {
@@ -215,8 +271,8 @@ impl LowMemoryRenderPipeline {
                                 current_row: y,
                                 group_x0: x0 >> dx,
                                 out_extra_x,
-                                is_first_xgroup: gx == 0,
-                                is_last_xgroup: gx + 1 == self.shared.group_count.0,
+                                start_of_row,
+                                end_of_row,
                                 image_height: shifted_ysize,
                             },
                             &mut buffers,
@@ -294,8 +350,8 @@ impl LowMemoryRenderPipeline {
                                 current_row: y,
                                 group_x0: x0 >> dx,
                                 out_extra_x,
-                                is_first_xgroup: gx == 0,
-                                is_last_xgroup: gx + 1 == self.shared.group_count.0,
+                                start_of_row,
+                                end_of_row,
                                 image_height: shifted_ysize,
                             },
                             &input_data,
@@ -351,8 +407,8 @@ impl LowMemoryRenderPipeline {
                                 current_row: y,
                                 group_x0: x0,
                                 out_extra_x: 0,
-                                is_first_xgroup: false,
-                                is_last_xgroup: false,
+                                start_of_row: false,
+                                end_of_row: false,
                                 image_height: self.shared.input_size.1,
                             },
                             &mut buffers,
@@ -397,8 +453,8 @@ impl LowMemoryRenderPipeline {
                                 current_row: y,
                                 group_x0: x0,
                                 out_extra_x: 0,
-                                is_first_xgroup: false,
-                                is_last_xgroup: false,
+                                start_of_row: false,
+                                end_of_row: false,
                                 image_height: self.shared.input_size.1,
                             },
                             &input_data,

--- a/jxl/src/render/low_memory_pipeline/run_stage.rs
+++ b/jxl/src/render/low_memory_pipeline/run_stage.rs
@@ -26,8 +26,8 @@ pub struct ExtraInfo {
     pub(super) out_extra_x: usize,
     pub(super) current_row: usize,
     pub(super) group_x0: usize,
-    pub(super) is_first_xgroup: bool,
-    pub(super) is_last_xgroup: bool,
+    pub(super) start_of_row: bool,
+    pub(super) end_of_row: bool,
     pub(super) image_height: usize,
 }
 
@@ -46,16 +46,16 @@ impl<T: RenderPipelineInPlaceStage> RunInPlaceStage<RowBuffer> for T {
             group_x0,
             out_extra_x,
             image_height: _,
-            is_first_xgroup,
-            is_last_xgroup,
+            start_of_row,
+            end_of_row,
         }: ExtraInfo,
         buffers: &mut [&mut RowBuffer],
         state: Option<&mut dyn Any>,
     ) {
         let x0 = RowBuffer::x0_offset::<T::Type>();
-        let xpre = if is_first_xgroup { 0 } else { out_extra_x };
+        let xpre = if start_of_row { 0 } else { out_extra_x };
         let xstart = x0 - xpre;
-        let xend = x0 + xsize + if is_last_xgroup { 0 } else { out_extra_x };
+        let xend = x0 + xsize + if end_of_row { 0 } else { out_extra_x };
         let mut rows: ChannelVec<_> = buffers
             .iter_mut()
             .map(|x| &mut x.get_row_mut::<T::Type>(current_row)[xstart..])
@@ -80,8 +80,8 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<RowBuffer> for T {
             group_x0,
             out_extra_x,
             image_height,
-            is_first_xgroup,
-            is_last_xgroup,
+            start_of_row,
+            end_of_row,
         }: ExtraInfo,
         input_buffers: &[&RowBuffer],
         output_buffers: &mut [RowBuffer],
@@ -89,7 +89,7 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<RowBuffer> for T {
     ) {
         let ibordery = Self::BORDER.1 as isize;
         let x0 = RowBuffer::x0_offset::<T::InputT>();
-        let xpre = if is_first_xgroup {
+        let xpre = if start_of_row {
             0
         } else {
             out_extra_x.shrc(T::SHIFT.0)
@@ -97,7 +97,7 @@ impl<T: RenderPipelineInOutStage> RunInOutStage<RowBuffer> for T {
         let xstart = x0 - xpre;
         let xend = x0
             + xsize
-            + if is_last_xgroup {
+            + if end_of_row {
                 0
             } else {
                 out_extra_x.shrc(T::SHIFT.0)

--- a/jxl/src/render/stages/epf/epf0.rs
+++ b/jxl/src/render/stages/epf/epf0.rs
@@ -76,7 +76,8 @@ simd_function!(
         let sigma = get_sigma(d, x + xpos, row_sigma);
         let sad_mul = D::F32Vec::load(d, &sad_mul_storage[x % 8..]);
 
-        if D::F32Vec::splat(d, MIN_SIGMA).gt(sigma).all() {
+        let sigma_mask = D::F32Vec::splat(d, MIN_SIGMA).gt(sigma);
+        if sigma_mask.all() {
             for (input_c, output_c) in input_rows.iter().zip(output_rows.iter_mut()) {
                 D::F32Vec::load(d, &input_c[3][3 + x..]).store(&mut output_c[0][x..]);
             }
@@ -204,7 +205,10 @@ simd_function!(
             ] {
                 out = D::F32Vec::load(d, &input_c[row_idx][col_idx..]).mul_add(sads[sad_idx], out);
             }
-            (out * inv_w).store(&mut output_c[0][x..]);
+            out *= inv_w;
+            let p33 = D::F32Vec::load(d, &input_c[3][3 + x..]);
+            let out = sigma_mask.if_then_else_f32(p33, out);
+            out.store(&mut output_c[0][x..]);
         }
     }
 });


### PR DESCRIPTION
Instead of waiting until all the neighbours of a group are ready,
we render the interior of the group immediately, and store the borders
of the group in temporary storage.

By doing so, we allow re-using the group storage for other groups
immediately, and thus reduce memory usage. Also, we process the group
data much closer to when it gets produced, significantly improving
cache usage.

Also fixes a long-standing bug in the EPF implementation that caused
small discrepancies between simple and low-memory pipeline. Thanks
to that fix, we can now simply assert equality of the output pixels.

Depending on the machine, this is a 6 to a 12% speedup.