### PR TITLE
Refactor handling of data types in jxl_cli.

### DIFF
--- a/jxl/src/api/data_types.rs
+++ b/jxl/src/api/data_types.rs
@@ -40,6 +40,13 @@ impl JxlColorType {
             Self::Rgba | Self::Bgra => false,
         }
     }
+    pub fn add_alpha(&self) -> Self {
+        match self {
+            Self::Grayscale | Self::GrayscaleAlpha => Self::GrayscaleAlpha,
+            Self::Rgb | Self::Rgba => Self::Rgba,
+            Self::Bgr | Self::Bgra => Self::Bgra,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/jxl/src/api/inner/mod.rs
+++ b/jxl/src/api/inner/mod.rs
@@ -75,6 +75,8 @@ impl JxlDecoderInner {
     }
 
     pub fn set_pixel_format(&mut self, pixel_format: JxlPixelFormat) {
+        // TODO(veluca): return an error if we are asking for both planar and
+        // interleaved-in-color alpha.
         self.codestream_parser.pixel_format = Some(pixel_format);
     }
 

--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -133,8 +133,6 @@ pub enum Error {
     // Generic arithmetic overflow. Prefer using other errors if possible.
     #[error("Arithmetic overflow")]
     ArithmeticOverflow,
-    #[error("Empty frame sequence")]
-    NoFrames,
     #[error(
         "Pipeline channel type mismatch: stage {0} channel {1}, expected {2:?} but found {3:?}"
     )]

--- a/jxl/src/image/raw.rs
+++ b/jxl/src/image/raw.rs
@@ -20,6 +20,10 @@ pub struct OwnedRawImage {
 }
 
 impl OwnedRawImage {
+    pub fn new(byte_size: (usize, usize)) -> Result<Self> {
+        Self::new_zeroed_with_padding(byte_size, (0, 0), (0, 0))
+    }
+
     pub fn new_zeroed_with_padding(
         byte_size: (usize, usize),
         offset: (usize, usize),

--- a/jxl_cli/benches/decode.rs
+++ b/jxl_cli/benches/decode.rs
@@ -5,7 +5,7 @@
 
 use criterion::{BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main};
 use jxl::api::JxlDecoderOptions;
-use jxl_cli::dec::{OutputDataType, decode_frames_with_type, decode_header};
+use jxl_cli::dec::{OutputDataType, decode_frames, decode_header};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -16,7 +16,8 @@ fn decode_benches(c: &mut Criterion) {
     let paths: Vec<PathBuf> = std::env::var("JXL_FILES").map_or_else(
         |_| {
             let root_test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("..")
+                .parent()
+                .unwrap()
                 .join("jxl")
                 .join("resources")
                 .join("test");
@@ -52,10 +53,18 @@ fn decode_benches(c: &mut Criterion) {
             |b, bytes| {
                 b.iter(|| {
                     let mut input = bytes.as_slice();
-                    decode_frames_with_type(
+                    decode_frames(
                         &mut input,
                         JxlDecoderOptions::default(),
-                        OutputDataType::F32,
+                        None,
+                        None,
+                        &[
+                            OutputDataType::U8,
+                            OutputDataType::U16,
+                            OutputDataType::F16,
+                            OutputDataType::F32,
+                        ],
+                        true,
                         false,
                     )
                     .unwrap();

--- a/jxl_cli/src/dec/mod.rs
+++ b/jxl_cli/src/dec/mod.rs
@@ -3,7 +3,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::time::{Duration, Instant};
+use std::{
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use color_eyre::eyre::{Result, eyre};
 use jxl::{
@@ -12,19 +15,20 @@ use jxl::{
         JxlDataFormat, JxlDecoder, JxlDecoderOptions, JxlOutputBuffer, JxlPixelFormat,
         ProcessingResult, states::WithImageInfo,
     },
-    image::{Image, ImageDataType, Rect},
-    util::f16,
+    headers::extra_channels::ExtraChannel,
+    image::{OwnedRawImage, Rect},
 };
 
-pub struct ImageFrame<T: ImageDataType> {
-    pub channels: Vec<Image<T>>,
+pub struct ImageFrame {
+    pub channels: Vec<OwnedRawImage>,
     pub duration: f64,
     pub color_type: JxlColorType,
 }
 
-pub struct DecodeOutput<T: ImageDataType> {
+pub struct DecodeOutput {
     pub size: (usize, usize),
-    pub frames: Vec<ImageFrame<T>>,
+    pub frames: Vec<ImageFrame>,
+    pub data_type: OutputDataType,
     pub original_bit_depth: JxlBitDepth,
     pub output_profile: JxlColorProfile,
     pub embedded_profile: JxlColorProfile,
@@ -52,17 +56,27 @@ pub enum OutputDataType {
     F32,
 }
 
-impl OutputDataType {
-    /// Parse from string (case-insensitive).
-    pub fn parse(s: &str) -> Option<Self> {
+impl FromStr for OutputDataType {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "u8" => Some(Self::U8),
-            "u16" => Some(Self::U16),
-            "f16" => Some(Self::F16),
-            "f32" => Some(Self::F32),
-            _ => None,
+            "u8" => Ok(Self::U8),
+            "u16" => Ok(Self::U16),
+            "f16" => Ok(Self::F16),
+            "f32" => Ok(Self::F32),
+            _ => Err(format!("Unknown data type {s}")),
         }
     }
+}
+
+impl OutputDataType {
+    pub const ALL: &'static [OutputDataType] = &[
+        OutputDataType::U8,
+        OutputDataType::U16,
+        OutputDataType::F16,
+        OutputDataType::F32,
+    ];
 
     /// Get the JxlDataFormat for this type.
     pub fn to_data_format(self) -> JxlDataFormat {
@@ -78,150 +92,21 @@ impl OutputDataType {
             Self::F32 => JxlDataFormat::f32(),
         }
     }
-}
 
-/// Typed decode output that preserves the original output type.
-/// The caller is responsible for converting to f32 when needed for saving.
-pub enum TypedDecodeOutput {
-    U8(DecodeOutput<u8>),
-    U16(DecodeOutput<u16>),
-    F16(DecodeOutput<f16>),
-    F32(DecodeOutput<f32>),
-}
-
-impl TypedDecodeOutput {
-    /// Get the image size.
-    pub fn size(&self) -> (usize, usize) {
-        match self {
-            Self::U8(d) => d.size,
-            Self::U16(d) => d.size,
-            Self::F16(d) => d.size,
-            Self::F32(d) => d.size,
-        }
-    }
-
-    /// Get the output color profile.
-    pub fn output_profile(&self) -> &JxlColorProfile {
-        match self {
-            Self::U8(d) => &d.output_profile,
-            Self::U16(d) => &d.output_profile,
-            Self::F16(d) => &d.output_profile,
-            Self::F32(d) => &d.output_profile,
-        }
-    }
-
-    /// Get the embedded color profile.
-    pub fn embedded_profile(&self) -> &JxlColorProfile {
-        match self {
-            Self::U8(d) => &d.embedded_profile,
-            Self::U16(d) => &d.embedded_profile,
-            Self::F16(d) => &d.embedded_profile,
-            Self::F32(d) => &d.embedded_profile,
-        }
-    }
-
-    /// Get the original bit depth.
-    pub fn original_bit_depth(&self) -> &JxlBitDepth {
-        match self {
-            Self::U8(d) => &d.original_bit_depth,
-            Self::U16(d) => &d.original_bit_depth,
-            Self::F16(d) => &d.original_bit_depth,
-            Self::F32(d) => &d.original_bit_depth,
-        }
-    }
-
-    /// Convert to f32 output for saving to encoders.
-    pub fn to_f32(self) -> Result<DecodeOutput<f32>> {
-        match self {
-            Self::U8(d) => convert_decode_output_to_f32(d),
-            Self::U16(d) => convert_decode_output_to_f32(d),
-            Self::F16(d) => convert_decode_output_to_f32(d),
-            Self::F32(d) => Ok(d),
-        }
-    }
-
-    /// Truncate to keep only first N frames.
-    pub fn truncate_frames(&mut self, len: usize) {
-        match self {
-            Self::U8(d) => d.frames.truncate(len),
-            Self::U16(d) => d.frames.truncate(len),
-            Self::F16(d) => d.frames.truncate(len),
-            Self::F32(d) => d.frames.truncate(len),
-        }
-    }
-
-    /// Get the first frame's color type and channel size (for preview handling).
-    pub fn first_frame_info(&self) -> Option<(JxlColorType, (usize, usize))> {
-        match self {
-            Self::U8(d) => d
-                .frames
-                .first()
-                .map(|f| (f.color_type, f.channels[0].size())),
-            Self::U16(d) => d
-                .frames
-                .first()
-                .map(|f| (f.color_type, f.channels[0].size())),
-            Self::F16(d) => d
-                .frames
-                .first()
-                .map(|f| (f.color_type, f.channels[0].size())),
-            Self::F32(d) => d
-                .frames
-                .first()
-                .map(|f| (f.color_type, f.channels[0].size())),
-        }
-    }
-
-    /// Update the size field.
-    pub fn set_size(&mut self, size: (usize, usize)) {
-        match self {
-            Self::U8(d) => d.size = size,
-            Self::U16(d) => d.size = size,
-            Self::F16(d) => d.size = size,
-            Self::F32(d) => d.size = size,
-        }
+    pub fn bits_per_sample(&self) -> usize {
+        self.to_data_format().bytes_per_sample() * 8
     }
 }
 
-/// Decode a JXL image with a specific output data type.
-/// Returns the raw typed output without conversion, so benchmark timing is accurate.
-pub fn decode_frames_with_type<In: JxlBitstreamInput>(
+pub fn decode_frames<In: JxlBitstreamInput>(
     input: &mut In,
     decoder_options: JxlDecoderOptions,
-    output_type: OutputDataType,
+    requested_bit_depth: Option<usize>,
+    requested_output_type: Option<OutputDataType>,
+    accepted_output_types: &[OutputDataType],
+    interleave_alpha: bool,
     linear_output: bool,
-) -> Result<(TypedDecodeOutput, Duration)> {
-    match output_type {
-        OutputDataType::U8 => {
-            let (output, duration) =
-                decode_frames_typed::<u8, _>(input, decoder_options, output_type, linear_output)?;
-            Ok((TypedDecodeOutput::U8(output), duration))
-        }
-        OutputDataType::U16 => {
-            let (output, duration) =
-                decode_frames_typed::<u16, _>(input, decoder_options, output_type, linear_output)?;
-            Ok((TypedDecodeOutput::U16(output), duration))
-        }
-        OutputDataType::F16 => {
-            let (output, duration) =
-                decode_frames_typed::<f16, _>(input, decoder_options, output_type, linear_output)?;
-            Ok((TypedDecodeOutput::F16(output), duration))
-        }
-        OutputDataType::F32 => {
-            let (output, duration) =
-                decode_frames_typed::<f32, _>(input, decoder_options, output_type, linear_output)?;
-            Ok((TypedDecodeOutput::F32(output), duration))
-        }
-    }
-}
-
-/// Generic decoder that decodes to type T.
-fn decode_frames_typed<T: ImageDataType, In: JxlBitstreamInput>(
-    input: &mut In,
-    decoder_options: JxlDecoderOptions,
-    output_type: OutputDataType,
-    linear_output: bool,
-) -> Result<(DecodeOutput<T>, Duration)> {
+) -> Result<(DecodeOutput, Duration)> {
     let start = Instant::now();
 
     let mut decoder_with_image_info = decode_header(input, decoder_options)?;
@@ -229,6 +114,21 @@ fn decode_frames_typed<T: ImageDataType, In: JxlBitstreamInput>(
     // Get info and clone what we need before mutating the decoder
     let info = decoder_with_image_info.basic_info().clone();
     let embedded_profile = decoder_with_image_info.embedded_color_profile().clone();
+
+    let output_type = if let Some(ot) = requested_output_type
+        && accepted_output_types.contains(&ot)
+    {
+        ot
+    } else {
+        if requested_output_type.is_some() {
+            eprintln!("Warning: requested output type is not compatible with output format");
+        }
+        let bit_depth = requested_bit_depth.unwrap_or(info.bit_depth.bits_per_sample() as usize);
+        *accepted_output_types
+            .iter()
+            .find(|x| x.bits_per_sample() >= bit_depth)
+            .unwrap_or(accepted_output_types.last().unwrap())
+    };
 
     // If linear output is requested, modify the output profile
     if linear_output
@@ -239,15 +139,35 @@ fn decode_frames_typed<T: ImageDataType, In: JxlBitstreamInput>(
     }
     let output_profile = decoder_with_image_info.output_color_profile().clone();
 
+    let main_alpha_channel = info
+        .extra_channels
+        .iter()
+        .enumerate()
+        .find(|x| x.1.ec_type == ExtraChannel::Alpha)
+        .map(|x| x.0);
+
+    let interleave_alpha = interleave_alpha && main_alpha_channel.is_some();
+
     // Set the pixel format to the requested data type
     let current_format = decoder_with_image_info.current_pixel_format().clone();
     let new_format = JxlPixelFormat {
-        color_type: current_format.color_type,
+        color_type: if interleave_alpha {
+            current_format.color_type.add_alpha()
+        } else {
+            current_format.color_type
+        },
         color_data_format: Some(output_type.to_data_format()),
         extra_channel_format: current_format
             .extra_channel_format
             .iter()
-            .map(|f| f.as_ref().map(|_| output_type.to_data_format()))
+            .enumerate()
+            .map(|(c, f)| {
+                if interleave_alpha && Some(c) == main_alpha_channel {
+                    None
+                } else {
+                    f.as_ref().map(|_| output_type.to_data_format())
+                }
+            })
             .collect(),
     };
     decoder_with_image_info.set_pixel_format(new_format);
@@ -255,20 +175,17 @@ fn decode_frames_typed<T: ImageDataType, In: JxlBitstreamInput>(
     let mut image_data = DecodeOutput {
         size: info.size,
         frames: Vec::new(),
+        data_type: output_type,
         original_bit_depth: info.bit_depth.clone(),
         output_profile,
         embedded_profile,
         jxl_animation: info.animation.clone(),
     };
 
-    let extra_channels = info.extra_channels.len();
+    let extra_channels = info.extra_channels.len() - if interleave_alpha { 1 } else { 0 };
     let pixel_format = decoder_with_image_info.current_pixel_format().clone();
     let color_type = pixel_format.color_type;
-    let samples_per_pixel = if color_type == JxlColorType::Grayscale {
-        1
-    } else {
-        3
-    };
+    let samples_per_pixel = pixel_format.color_type.samples_per_pixel();
 
     loop {
         let decoder_with_frame_info = match decoder_with_image_info.process(input)? {
@@ -278,25 +195,29 @@ fn decode_frames_typed<T: ImageDataType, In: JxlBitstreamInput>(
 
         let frame_header = decoder_with_frame_info.frame_header();
         let frame_size = frame_header.size;
+        let frame_size = (
+            frame_size.0 * output_type.bits_per_sample() / 8,
+            frame_size.1,
+        );
 
         // Create typed output buffers
-        let mut typed_outputs = vec![Image::<T>::new((
+        let mut outputs = vec![OwnedRawImage::new((
             frame_size.0 * samples_per_pixel,
             frame_size.1,
         ))?];
 
         for _ in 0..extra_channels {
-            typed_outputs.push(Image::<T>::new(frame_size)?);
+            outputs.push(OwnedRawImage::new(frame_size)?);
         }
 
-        let mut output_bufs: Vec<JxlOutputBuffer<'_>> = typed_outputs
+        let mut output_bufs: Vec<JxlOutputBuffer<'_>> = outputs
             .iter_mut()
             .map(|x| {
                 let rect = Rect {
-                    size: x.size(),
+                    size: x.byte_size(),
                     origin: (0, 0),
                 };
-                JxlOutputBuffer::from_image_rect_mut(x.get_rect_mut(rect).into_raw())
+                JxlOutputBuffer::from_image_rect_mut(x.get_rect_mut(rect))
             })
             .collect();
 
@@ -307,7 +228,7 @@ fn decode_frames_typed<T: ImageDataType, In: JxlBitstreamInput>(
 
         image_data.frames.push(ImageFrame {
             duration: frame_header.duration.unwrap_or(0.0),
-            channels: typed_outputs,
+            channels: outputs,
             color_type,
         });
 
@@ -317,72 +238,4 @@ fn decode_frames_typed<T: ImageDataType, In: JxlBitstreamInput>(
     }
 
     Ok((image_data, start.elapsed()))
-}
-
-/// Trait for converting a value to f32.
-trait ConvertToF32: Copy {
-    fn to_f32_normalized(self) -> f32;
-}
-
-impl ConvertToF32 for u8 {
-    fn to_f32_normalized(self) -> f32 {
-        self as f32 / 255.0
-    }
-}
-
-impl ConvertToF32 for u16 {
-    fn to_f32_normalized(self) -> f32 {
-        self as f32 / 65535.0
-    }
-}
-
-impl ConvertToF32 for f16 {
-    fn to_f32_normalized(self) -> f32 {
-        self.to_f32()
-    }
-}
-
-/// Convert a DecodeOutput from type T to f32.
-fn convert_decode_output_to_f32<T: ImageDataType + ConvertToF32>(
-    src: DecodeOutput<T>,
-) -> Result<DecodeOutput<f32>> {
-    let mut frames = Vec::with_capacity(src.frames.len());
-    for frame in src.frames {
-        let channels: Vec<Image<f32>> = frame
-            .channels
-            .into_iter()
-            .map(|img| convert_image_to_f32(img))
-            .collect::<std::result::Result<_, _>>()?;
-        frames.push(ImageFrame {
-            channels,
-            duration: frame.duration,
-            color_type: frame.color_type,
-        });
-    }
-    Ok(DecodeOutput {
-        size: src.size,
-        frames,
-        original_bit_depth: src.original_bit_depth,
-        output_profile: src.output_profile,
-        embedded_profile: src.embedded_profile,
-        jxl_animation: src.jxl_animation,
-    })
-}
-
-/// Convert an image from type T to f32.
-fn convert_image_to_f32<T: ImageDataType + ConvertToF32>(
-    src: Image<T>,
-) -> std::result::Result<Image<f32>, jxl::error::Error> {
-    let size = src.size();
-    let mut dst = Image::<f32>::new(size)?;
-
-    for y in 0..size.1 {
-        let src_row = src.row(y);
-        let dst_row = dst.row_mut(y);
-        for x in 0..size.0 {
-            dst_row[x] = src_row[x].to_f32_normalized();
-        }
-    }
-
-    Ok(dst)
 }

--- a/jxl_cli/src/enc/exr.rs
+++ b/jxl_cli/src/enc/exr.rs
@@ -3,148 +3,121 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-pub use jxl_exr::to_exr;
+use std::io::{Seek, Write};
 
-#[cfg(not(feature = "exr"))]
-mod jxl_exr {
-    use crate::dec::DecodeOutput;
-    use color_eyre::eyre::{Result, eyre};
-    use std::io::{Seek, Write};
+use color_eyre::eyre::{Result, eyre};
+use jxl::api::{JxlColorEncoding, JxlColorProfile, JxlTransferFunction};
 
-    pub fn to_exr<Writer: Write + Seek>(
-        _image_data: &DecodeOutput<f32>,
-        _bit_depth: u32,
-        _writer: &mut Writer,
-    ) -> Result<()> {
-        Err(eyre!("jxl_cli built without support for EXR output"))
-    }
-}
+use exr::meta::attribute::Chromaticities;
+use exr::prelude::*;
 
-#[cfg(feature = "exr")]
-mod jxl_exr {
-    use std::io::{Seek, Write};
+use crate::dec::{DecodeOutput, OutputDataType};
 
-    use color_eyre::eyre::{Result, WrapErr, eyre};
-    use jxl::api::{JxlColorEncoding, JxlColorProfile, JxlTransferFunction};
-    use jxl::error::Error;
-
-    use exr::meta::attribute::Chromaticities;
-    use exr::prelude::*;
-
-    use crate::dec::DecodeOutput;
-
-    pub fn to_exr<Writer: Write + Seek>(
-        image_data: &DecodeOutput<f32>,
-        bit_depth: u32,
-        writer: &mut Writer,
-    ) -> Result<()> {
-        let tuple_to_vec2 = |(x, y)| Vec2(x, y);
-        let chromaticities = match &image_data.output_profile {
-            JxlColorProfile::Simple(JxlColorEncoding::RgbColorSpace {
-                white_point,
-                primaries,
-                transfer_function: JxlTransferFunction::Linear,
-                ..
-            }) => {
-                let [r, g, b] = primaries.to_xy_coords();
-                Some(Chromaticities {
-                    red: tuple_to_vec2(r),
-                    green: tuple_to_vec2(g),
-                    blue: tuple_to_vec2(b),
-                    white: tuple_to_vec2(white_point.to_xy_coords()),
-                })
-            }
-            JxlColorProfile::Simple(JxlColorEncoding::GrayscaleColorSpace {
-                white_point,
-                transfer_function: JxlTransferFunction::Linear,
-                ..
-            }) => Some(Chromaticities {
-                red: Vec2(0.64, 0.33),
-                green: Vec2(0.3, 0.6),
-                blue: Vec2(0.15, 0.06),
+pub fn to_exr<Writer: Write + Seek>(image_data: &DecodeOutput, writer: &mut Writer) -> Result<()> {
+    let tuple_to_vec2 = |(x, y)| Vec2(x, y);
+    let chromaticities = match &image_data.output_profile {
+        JxlColorProfile::Simple(JxlColorEncoding::RgbColorSpace {
+            white_point,
+            primaries,
+            transfer_function: JxlTransferFunction::Linear,
+            ..
+        }) => {
+            let [r, g, b] = primaries.to_xy_coords();
+            Some(Chromaticities {
+                red: tuple_to_vec2(r),
+                green: tuple_to_vec2(g),
+                blue: tuple_to_vec2(b),
                 white: tuple_to_vec2(white_point.to_xy_coords()),
-            }),
-            JxlColorProfile::Icc(_) => {
-                return Err(eyre!("EXR requires a linear colorspace (got ICC profile)"));
-            }
-            JxlColorProfile::Simple(encoding) => {
-                return Err(eyre!(
-                    "Writing of images in colorspace {:?} not yet implemented for EXR output",
-                    encoding.get_color_encoding_description()
-                ));
-            }
-        };
-
-        if image_data.frames.is_empty()
-            || image_data.frames[0].channels.is_empty()
-            || image_data.size.0 == 0
-            || image_data.size.1 == 0
-        {
-            return Err(Error::NoFrames).wrap_err("Invalid JXL image");
+            })
         }
-        let (width, height) = image_data.size;
-        let num_channels = image_data.frames[0].channels.len();
-
-        for (i, frame) in image_data.frames.iter().enumerate() {
-            assert_eq!(
-                frame.channels.len(),
-                num_channels,
-                "Frame {i} num channels mismatch"
-            );
-            for (c, channel) in frame.channels.iter().enumerate() {
-                assert_eq!(
-                    channel.size(),
-                    image_data.size,
-                    "Frame {i} channel {c} size mismatch"
-                );
-            }
+        JxlColorProfile::Simple(JxlColorEncoding::GrayscaleColorSpace {
+            white_point,
+            transfer_function: JxlTransferFunction::Linear,
+            ..
+        }) => Some(Chromaticities {
+            red: Vec2(0.64, 0.33),
+            green: Vec2(0.3, 0.6),
+            blue: Vec2(0.15, 0.06),
+            white: tuple_to_vec2(white_point.to_xy_coords()),
+        }),
+        JxlColorProfile::Icc(_) => {
+            return Err(eyre!("EXR requires a linear colorspace (got ICC profile)"));
         }
-
-        let mut channels = SmallVec::<[AnyChannel<FlatSamples>; 4]>::new();
-        let channel_names = match num_channels {
-            1 => vec!["Y"],
-            2 => vec!["Y", "A"],
-            3 => vec!["R", "G", "B"],
-            4 => vec!["R", "G", "B", "A"],
-            _ => {
-                return Err(eyre!(
-                    "Writing of {:?} channels not yet implemented for EXR output",
-                    num_channels
-                ));
-            }
-        };
-        // TODO(sboukortt): convert unassociated alpha to associated if necessary
-        for (channel, channel_name) in image_data.frames[0].channels.iter().zip(channel_names) {
-            let sample_data = if bit_depth <= 16 {
-                let mut samples = vec![f16::ZERO; height * width];
-                for y in 0..height {
-                    for x in 0..width {
-                        samples[y * width + x] = f16::from_f32(channel.row(y)[x]);
-                    }
-                }
-                FlatSamples::F16(samples)
-            } else {
-                let mut samples = vec![0.0; height * width];
-                for y in 0..height {
-                    for x in 0..width {
-                        samples[y * width + x] = channel.row(y)[x];
-                    }
-                }
-                FlatSamples::F32(samples)
-            };
-            channels.push(AnyChannel::<FlatSamples> {
-                name: channel_name.into(),
-                sample_data,
-                quantize_linearly: channel_name == "A",
-                sampling: Vec2(1, 1),
-            });
+        JxlColorProfile::Simple(encoding) => {
+            return Err(eyre!(
+                "Writing of images in colorspace {:?} not yet implemented for EXR output",
+                encoding.get_color_encoding_description()
+            ));
         }
-        let channels = AnyChannels::sort(channels);
-        let mut image = Image::from_channels((width, height), channels);
-        image.attributes.chromaticities = chromaticities;
-        // TODO(sboukortt): intensity_target -> whiteLuminance
+    };
 
-        image.write().to_buffered(writer)?;
-        Ok(())
+    if image_data.frames.len() > 1 {
+        eprintln!("Warning: More than one frame found, saving just the first one.");
     }
+    if image_data.frames[0].channels.len() > 1 {
+        eprintln!("Warning: Ignoring extra channels.");
+    }
+
+    let (width, height) = image_data.size;
+    let num_channels = image_data.frames[0].color_type.samples_per_pixel();
+
+    let mut channels = SmallVec::<[AnyChannel<FlatSamples>; 4]>::new();
+    let channel_names = match num_channels {
+        1 => vec!["Y"],
+        2 => vec!["Y", "A"],
+        3 => vec!["R", "G", "B"],
+        4 => vec!["R", "G", "B", "A"],
+        _ => {
+            unreachable!()
+        }
+    };
+
+    // TODO(sboukortt): convert unassociated alpha to associated if necessary
+    let buf = &image_data.frames[0].channels[0];
+    for (c, name) in channel_names.iter().copied().enumerate() {
+        let sample_data = if image_data.data_type == OutputDataType::F32 {
+            FlatSamples::F32(
+                (0..height)
+                    .flat_map(|y| {
+                        buf.row(y)
+                            .as_chunks::<4>()
+                            .0
+                            .iter()
+                            .skip(c)
+                            .step_by(num_channels)
+                            .copied()
+                            .map(f32::from_ne_bytes)
+                    })
+                    .collect(),
+            )
+        } else {
+            FlatSamples::F16(
+                (0..height)
+                    .flat_map(|y| {
+                        buf.row(y)
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .skip(c)
+                            .step_by(num_channels)
+                            .copied()
+                            .map(f16::from_ne_bytes)
+                    })
+                    .collect(),
+            )
+        };
+        channels.push(AnyChannel::<FlatSamples> {
+            name: name.into(),
+            sample_data,
+            quantize_linearly: name == "A",
+            sampling: Vec2(1, 1),
+        });
+    }
+    let channels = AnyChannels::sort(channels);
+    let mut image = Image::from_channels((width, height), channels);
+    image.attributes.chromaticities = chromaticities;
+    // TODO(sboukortt): intensity_target -> whiteLuminance
+
+    image.write().to_buffered(writer)?;
+    Ok(())
 }

--- a/jxl_cli/src/enc/mod.rs
+++ b/jxl_cli/src/enc/mod.rs
@@ -3,7 +3,78 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+use std::{fs::File, io::BufWriter, path::PathBuf};
+
+use color_eyre::eyre::{Result, eyre};
+
+use crate::dec::{DecodeOutput, OutputDataType};
+
+#[cfg(feature = "exr")]
 pub mod exr;
 pub mod numpy;
 pub mod png;
 pub mod pnm;
+
+#[derive(Clone, Copy)]
+pub enum OutputFormat {
+    Ppm,
+    Pgm,
+    Npy,
+    Png,
+    #[cfg(feature = "exr")]
+    Exr,
+}
+
+impl OutputFormat {
+    pub fn from_output_filename(filename: &str) -> Result<Self> {
+        #[cfg(feature = "exr")]
+        if filename.ends_with(".exr") {
+            return Ok(OutputFormat::Exr);
+        }
+        if filename.ends_with(".ppm") {
+            return Ok(OutputFormat::Ppm);
+        }
+        if filename.ends_with(".pgm") {
+            return Ok(OutputFormat::Pgm);
+        }
+        if filename.ends_with(".npy") {
+            return Ok(OutputFormat::Npy);
+        }
+        if filename.ends_with(".png") || filename.ends_with(".apng") {
+            return Ok(OutputFormat::Png);
+        }
+        Err(eyre!("Output format not supported for {:?}", filename))
+    }
+
+    pub fn supported_output_data_types(&self) -> &'static [OutputDataType] {
+        match self {
+            Self::Ppm | Self::Pgm => &[OutputDataType::U8],
+            Self::Npy => &[OutputDataType::F32],
+            Self::Png => &[OutputDataType::U8, OutputDataType::U16],
+            #[cfg(feature = "exr")]
+            Self::Exr => &[OutputDataType::F16, OutputDataType::F32],
+        }
+    }
+
+    pub fn should_fold_alpha(&self) -> bool {
+        match self {
+            Self::Ppm | Self::Pgm | Self::Npy => false,
+            Self::Png => true,
+            #[cfg(feature = "exr")]
+            Self::Exr => true,
+        }
+    }
+
+    pub fn save_image(&self, image_data: &DecodeOutput, output_filename: &PathBuf) -> Result<()> {
+        let mut writer = BufWriter::new(File::create(output_filename)?);
+        match self {
+            Self::Ppm => pnm::to_ppm(image_data, &mut writer)?,
+            Self::Pgm => pnm::to_pgm(image_data, &mut writer)?,
+            Self::Npy => numpy::to_numpy(image_data, &mut writer)?,
+            Self::Png => png::to_png(image_data, &mut writer)?,
+            #[cfg(feature = "exr")]
+            Self::Exr => exr::to_exr(image_data, &mut writer)?,
+        };
+        Ok(())
+    }
+}

--- a/jxl_cli/src/enc/pnm.rs
+++ b/jxl_cli/src/enc/pnm.rs
@@ -3,124 +3,46 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use jxl::{error::Result, image::Image};
+use color_eyre::eyre::{Result, ensure};
+use jxl::api::JxlColorType;
 use std::io::Write;
 
-pub trait ToU8ForWriting {
-    fn to_u8_for_writing(self) -> u8;
-}
+use crate::dec::{DecodeOutput, OutputDataType};
 
-impl ToU8ForWriting for u8 {
-    fn to_u8_for_writing(self) -> u8 {
-        self
+pub fn to_pgm<Writer: Write>(img: &DecodeOutput, writer: &mut Writer) -> Result<()> {
+    assert_eq!(img.data_type, OutputDataType::U8);
+    ensure!(
+        img.frames[0].color_type == JxlColorType::Grayscale,
+        "Writing to PPM only supports Grayscale"
+    );
+    if img.frames.len() > 1 {
+        eprintln!("Warning: More than one frame found, saving just the first one.");
     }
-}
-
-impl ToU8ForWriting for u16 {
-    fn to_u8_for_writing(self) -> u8 {
-        ((self as u32 * 0xff + 0x8000) / 0xffff) as u8
+    if img.frames[0].channels.len() > 1 {
+        eprintln!("Warning: Ignoring extra channels.");
     }
-}
-
-impl ToU8ForWriting for f32 {
-    fn to_u8_for_writing(self) -> u8 {
-        // + 0.5 instead of round is fine since we clamp to non-negative
-        ((self * 255.0).clamp(0.0, 255.0) + 0.5) as u8
-    }
-}
-
-impl ToU8ForWriting for u32 {
-    fn to_u8_for_writing(self) -> u8 {
-        ((self as u64 * 0xff + 0x80000000) / 0xffffffff) as u8
-    }
-}
-
-impl ToU8ForWriting for half::f16 {
-    fn to_u8_for_writing(self) -> u8 {
-        self.to_f32().to_u8_for_writing()
-    }
-}
-
-pub fn to_pgm_as_8bit<Writer: Write>(img: &Image<f32>, writer: &mut Writer) -> Result<()> {
-    write!(writer, "P5\n{} {}\n255\n", img.size().0, img.size().1)?;
-    for y in 0..img.size().1 {
-        for x in img.row(y).iter() {
-            writer.write_all(&[x.to_u8_for_writing()])?;
-        }
+    write!(writer, "P5\n{} {}\n255\n", img.size.0, img.size.1)?;
+    for y in 0..img.size.1 {
+        writer.write_all(img.frames[0].channels[0].row(y))?;
     }
     Ok(())
 }
 
-pub fn to_ppm_as_8bit<Writer: Write>(img: [&Image<f32>; 3], writer: &mut Writer) -> Result<()> {
-    assert_eq!(img[0].size(), img[1].size());
-    assert_eq!(img[0].size(), img[2].size());
-    write!(writer, "P6\n{} {}\n255\n", img[0].size().0, img[0].size().1)?;
-    for y in 0..img[0].size().1 {
-        for x in 0..img[0].size().0 {
-            for c in [0, 1, 2] {
-                writer.write_all(&[img[c].row(y)[x].to_u8_for_writing()])?;
-            }
-        }
+pub fn to_ppm<Writer: Write>(img: &DecodeOutput, writer: &mut Writer) -> Result<()> {
+    assert_eq!(img.data_type, OutputDataType::U8);
+    ensure!(
+        img.frames[0].color_type == JxlColorType::Rgb,
+        "Writing to PPM only supports RGB"
+    );
+    if img.frames.len() > 1 {
+        eprintln!("Warning: More than one frame found, saving just the first one.");
+    }
+    if img.frames[0].channels.len() > 1 {
+        eprintln!("Warning: Ignoring extra channels.");
+    }
+    write!(writer, "P6\n{} {}\n255\n", img.size.0, img.size.1)?;
+    for y in 0..img.size.1 {
+        writer.write_all(img.frames[0].channels[0].row(y))?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod test {
-    use super::{ToU8ForWriting, to_pgm_as_8bit};
-    use jxl::error::Result;
-    use jxl::image::Image;
-
-    #[test]
-    fn covert_to_pgm() -> Result<()> {
-        let image = Image::<f32>::new((32, 32))?;
-        let mut bytes = vec![];
-        to_pgm_as_8bit(&image, &mut bytes)?;
-        assert!(bytes.starts_with(b"P5\n32 32\n255\n"));
-        Ok(())
-    }
-
-    #[test]
-    fn u16_to_u8() {
-        let mut left_source_u16 = 0xffffu16 / 510;
-        for want_u8 in 0x00u8..0xffu8 {
-            assert_eq!(left_source_u16.to_u8_for_writing(), want_u8);
-            assert_eq!((left_source_u16 + 1).to_u8_for_writing(), want_u8 + 1);
-            // Since we have 256 u8 values, but 0x00 and 0xff only have half the
-            // range, we actually get whole ranges of size 0xffff / 255.
-            left_source_u16 = left_source_u16.wrapping_add(0xffff / 255);
-        }
-    }
-
-    #[test]
-    fn f32_to_u8() {
-        let epsilon = 1e-4f32;
-        for want_u8 in 0x00u8..0xffu8 {
-            let threshold = 1f32 / 510f32 + (1f32 / 255f32) * (want_u8 as f32);
-            assert_eq!((threshold - epsilon).to_u8_for_writing(), want_u8);
-            assert_eq!((threshold + epsilon).to_u8_for_writing(), want_u8 + 1);
-        }
-    }
-
-    #[test]
-    fn u32_to_u8() {
-        let mut left_source_u32 = 0xffffffffu32 / 510;
-        for want_u8 in 0x00u8..0xffu8 {
-            assert_eq!(left_source_u32.to_u8_for_writing(), want_u8);
-            assert_eq!((left_source_u32 + 1).to_u8_for_writing(), want_u8 + 1);
-            // Since we have 256 u8 values, but 0x00 and 0xff only have half the
-            // range, we actually get whole ranges of size 0xffffffff / 255.
-            left_source_u32 = left_source_u32.wrapping_add(0xffffffffu32 / 255);
-        }
-    }
-
-    #[test]
-    fn f16_to_u8() {
-        let epsilon = half::f16::from_f32(1e-3f32);
-        for want_u8 in 0x00u8..0xffu8 {
-            let threshold = half::f16::from_f32(1f32 / 510f32 + (1f32 / 255f32) * (want_u8 as f32));
-            assert_eq!((threshold - epsilon).to_u8_for_writing(), want_u8);
-            assert_eq!((threshold + epsilon).to_u8_for_writing(), want_u8 + 1);
-        }
-    }
 }


### PR DESCRIPTION
This avoids passing through f32, which drastically reduces time & memory usage, as well as significantly simplifying the code.