### PR TITLE
Fix off-by-one in low-memory render pipeline.

### DIFF
--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -135,7 +135,7 @@ impl LowMemoryRenderPipeline {
                 return Ok(());
             }
             buf.ready_channels = 0;
-            *self.shared.group_chan_ready_passes[g].iter().min().unwrap()
+            *self.shared.group_chan_ready_passes[g].iter().min().unwrap() - 1
         };
 
         let (gx, gy) = self.shared.group_position(g);


### PR DESCRIPTION
This caused group borders to never get freed, and would potentially have caused crashes with images with the maximum number of passes.