### PR TITLE
Fix index out of bounds in `decode_vardct_group`

### DIFF
--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -553,6 +553,10 @@ impl Histograms {
     pub fn num_histograms(&self) -> usize {
         *self.context_map.iter().max().unwrap() as usize + 1
     }
+
+    pub fn resize(&mut self, num_contexts: usize) {
+        self.context_map.resize(num_contexts, 0);
+    }
 }
 
 #[cfg(test)]

--- a/jxl/src/frame/block_context_map.rs
+++ b/jxl/src/frame/block_context_map.rs
@@ -12,7 +12,11 @@ use crate::{
 };
 
 pub const NON_ZERO_BUCKETS: usize = 37;
+
+// Supremum of zero_density_context(x, y) + 1, when x + y <= 64.
 pub const ZERO_DENSITY_CONTEXT_COUNT: usize = 458;
+// Supremum of zero_density_context(x, y) + 1.
+pub const ZERO_DENSITY_CONTEXT_LIMIT: usize = 474;
 
 pub const COEFF_FREQ_CONTEXT: [usize; 64] = [
     0xBAD, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19,

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -512,7 +512,7 @@ pub fn decode_vardct_group(
                 let permutation = &pass_info.coeff_orders[shape_id * 3 + c];
                 let current_coeffs = &mut coeffs[c][coeffs_offset..coeffs_offset + num_coeffs];
                 for k in num_blocks..num_coeffs {
-                    if nonzeros == 0 || nonzeros + k > num_coeffs {
+                    if nonzeros == 0 {
                         break;
                     }
                     let ctx =


### PR DESCRIPTION
Fixes https://github.com/libjxl/jxl-rs/actions/runs/21305626535

libjxl will pad the context map to `kZeroDensityContextLimit` https://github.com/libjxl/libjxl/blob/8ce9537c989cfc7adff034556c8a4b9469e874d6/lib/jxl/dec_frame.cc#L410
I'm not sure which way is better