### PR TITLE
Static lcms2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Google LLC <*@google.com>
 
 # Individuals:
 Caio <c410.f3r@gmail.com>
+Galaxy4594 <164440799+Galaxy4594@users.noreply.github.com>
 Ewout ter Hoeven <E.M.terHoeven@student.tudelft.nl>
 Helmut Januschka <helmut@januschka.com>
 Inflation <2375962+inflation@users.noreply.github.com>

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.5.18", features = ["derive"] }
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",
 ], optional = true }
-lcms2 = "6.1.0"
+lcms2 = { version = "6.1.0", features=["static"] }
 bytemuck = "1.14"
 half = "2.4.1"
 png = "0.18.0"


### PR DESCRIPTION
I expect rust builds to be static by default.