### PR TITLE
Progressive jxl_cli

### DIFF
--- a/jxl_cli/src/dec/mod.rs
+++ b/jxl_cli/src/dec/mod.rs
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file.
 
 use std::{
+    io::{Error, IoSliceMut},
+    path::Path,
     str::FromStr,
     time::{Duration, Instant},
 };
@@ -18,6 +20,61 @@ use jxl::{
     headers::extra_channels::ExtraChannel,
     image::{OwnedRawImage, Rect},
 };
+
+/// A wrapper around a byte slice that implements JxlBitstreamInput for streaming decoding.
+/// Unlike `&[u8]`, this reports only the "available" bytes we've fed so far, not the total buffer size.
+struct StreamingInput<'a> {
+    data: &'a [u8],
+    position: usize,
+    available_limit: usize, // How many bytes we're pretending to have available
+}
+
+impl<'a> StreamingInput<'a> {
+    fn new(data: &'a [u8], available_limit: usize) -> Self {
+        Self {
+            data,
+            position: 0,
+            available_limit,
+        }
+    }
+
+    fn set_available_limit(&mut self, new_limit: usize) {
+        self.available_limit = new_limit.min(self.data.len());
+    }
+}
+
+impl<'a> JxlBitstreamInput for StreamingInput<'a> {
+    fn available_bytes(&mut self) -> std::result::Result<usize, Error> {
+        // Report only up to available_limit, not the full data length
+        Ok(self.available_limit.saturating_sub(self.position))
+    }
+
+    fn read(&mut self, bufs: &mut [IoSliceMut]) -> std::result::Result<usize, Error> {
+        let available = self.available_limit.saturating_sub(self.position);
+        if available == 0 {
+            return Ok(0);
+        }
+
+        let mut total_read = 0;
+        for buf in bufs {
+            let to_read = buf.len().min(available - total_read);
+            if to_read == 0 {
+                break;
+            }
+            buf[..to_read].copy_from_slice(&self.data[self.position..self.position + to_read]);
+            self.position += to_read;
+            total_read += to_read;
+        }
+        Ok(total_read)
+    }
+
+    fn skip(&mut self, bytes: usize) -> std::result::Result<usize, Error> {
+        let available = self.available_limit.saturating_sub(self.position);
+        let to_skip = bytes.min(available);
+        self.position += to_skip;
+        Ok(to_skip)
+    }
+}
 
 pub struct ImageFrame {
     pub channels: Vec<OwnedRawImage>,
@@ -96,6 +153,16 @@ impl OutputDataType {
     pub fn bits_per_sample(&self) -> usize {
         self.to_data_format().bytes_per_sample() * 8
     }
+}
+
+/// Configuration for progressive decoding
+pub struct ProgressiveDecodeConfig<'a> {
+    pub override_bitdepth: Option<usize>,
+    pub data_type: Option<OutputDataType>,
+    pub supported_data_types: &'a [OutputDataType],
+    pub interleave_alpha: bool,
+    pub linear_output: bool,
+    pub allow_partial_files: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -256,4 +323,431 @@ pub fn decode_frames<In: JxlBitstreamInput>(
     }
 
     Ok((image_data, start.elapsed()))
+}
+
+/// Parse progressive step size from string (either bytes or percentage)
+fn parse_step_size(step_str: &str, total_size: usize) -> Result<usize> {
+    if let Some(percentage) = step_str.strip_suffix('%') {
+        let pct: f64 = percentage
+            .parse()
+            .map_err(|_| eyre!("Invalid percentage: {}", percentage))?;
+        if pct <= 0.0 || pct > 100.0 {
+            return Err(eyre!("Percentage must be between 0 and 100"));
+        }
+        Ok(((total_size as f64 * pct / 100.0) as usize).max(1))
+    } else {
+        step_str
+            .parse::<usize>()
+            .map_err(|_| eyre!("Invalid step size: {}", step_str))
+    }
+}
+
+// Progressive decode with single decoder instance (incremental data)
+// This is true streaming decoding: one decoder, feed data incrementally, flush at each step
+pub fn decode_frames_progressive<F>(
+    data: &[u8],
+    output_path: &Path,
+    step_size_str: &str,
+    make_decoder_options: F,
+    config: &ProgressiveDecodeConfig,
+) -> Result<(DecodeOutput, Duration)>
+where
+    F: Fn() -> JxlDecoderOptions,
+{
+    let step_size = parse_step_size(step_size_str, data.len())?;
+    let mut total_duration = Duration::new(0, 0);
+    let mut total_process_time = Duration::new(0, 0);
+    let mut total_flush_time = Duration::new(0, 0);
+    let mut total_write_time = Duration::new(0, 0);
+
+    println!(
+        "Progressive decoding (streaming) with step size: {} bytes ({:.1}% of {} total)",
+        step_size,
+        (step_size as f64 / data.len() as f64) * 100.0,
+        data.len()
+    );
+
+    // Prepare output filename components
+    let output_stem = output_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| eyre!("Invalid output filename"))?;
+    let output_ext = output_path
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("png");
+    let output_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
+
+    // Create a single decoder instance with streaming input
+    let start = Instant::now();
+    let mut position = step_size.min(data.len());
+    let mut streaming_input = StreamingInput::new(data, position);
+
+    println!("Step 1: Decoding header with {} bytes...", position);
+    let mut decoder_with_image_info = decode_header(&mut streaming_input, make_decoder_options())?;
+
+    // Get info and setup
+    let info = decoder_with_image_info.basic_info().clone();
+    let embedded_profile = decoder_with_image_info.embedded_color_profile().clone();
+
+    let output_type = if let Some(ot) = config.data_type
+        && config.supported_data_types.contains(&ot)
+    {
+        ot
+    } else {
+        if config.data_type.is_some() {
+            eprintln!("Warning: requested output type is not compatible with output format");
+        }
+        let bit_depth = config
+            .override_bitdepth
+            .unwrap_or(info.bit_depth.bits_per_sample() as usize);
+        *config
+            .supported_data_types
+            .iter()
+            .find(|x| x.bits_per_sample() >= bit_depth)
+            .unwrap_or(config.supported_data_types.last().unwrap())
+    };
+
+    let main_alpha_channel = info
+        .extra_channels
+        .iter()
+        .enumerate()
+        .find(|x| x.1.ec_type == ExtraChannel::Alpha)
+        .map(|x| x.0);
+
+    let interleave_alpha = config.interleave_alpha && main_alpha_channel.is_some();
+
+    // Set the pixel format
+    let current_format = decoder_with_image_info.current_pixel_format().clone();
+    let new_format = JxlPixelFormat {
+        color_type: if interleave_alpha {
+            current_format.color_type.add_alpha()
+        } else {
+            current_format.color_type
+        },
+        color_data_format: Some(output_type.to_data_format()),
+        extra_channel_format: current_format
+            .extra_channel_format
+            .iter()
+            .enumerate()
+            .map(|(c, f)| {
+                if interleave_alpha && Some(c) == main_alpha_channel {
+                    None
+                } else {
+                    f.as_ref().map(|_| output_type.to_data_format())
+                }
+            })
+            .collect(),
+    };
+    decoder_with_image_info.set_pixel_format(new_format);
+
+    // If linear output is requested, modify the output profile
+    if config.linear_output
+        && let JxlColorProfile::Simple(enc) = decoder_with_image_info.output_color_profile().clone()
+    {
+        decoder_with_image_info
+            .set_output_color_profile(JxlColorProfile::Simple(enc.with_linear_tf()))?;
+    }
+    let output_profile = decoder_with_image_info.output_color_profile().clone();
+
+    let extra_channels = info.extra_channels.len() - if interleave_alpha { 1 } else { 0 };
+    let pixel_format = decoder_with_image_info.current_pixel_format().clone();
+    let color_type = pixel_format.color_type;
+    let samples_per_pixel = pixel_format.color_type.samples_per_pixel();
+
+    let mut step_number = 1;
+    let mut frame_count = 0;
+
+    // Process frames progressively
+    loop {
+        // Try to get frame info - may need multiple attempts with more data
+        let decoder_with_frame_info = loop {
+            match decoder_with_image_info.process(&mut streaming_input)? {
+                ProcessingResult::Complete { result } => break result,
+                ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                    if position >= data.len() {
+                        println!("End of data reached during frame info");
+                        total_duration += start.elapsed();
+
+                        // Do final complete decode
+                        let mut full_data = data;
+                        let (final_output, _) = decode_frames(
+                            &mut full_data,
+                            make_decoder_options(),
+                            config.override_bitdepth,
+                            config.data_type,
+                            config.supported_data_types,
+                            config.interleave_alpha,
+                            config.linear_output,
+                            config.allow_partial_files,
+                        )?;
+                        return Ok((final_output, total_duration));
+                    }
+                    // Need more data for frame info
+                    println!(
+                        "  Need more data for frame {}, adding more...",
+                        frame_count + 1
+                    );
+                    decoder_with_image_info = fallback;
+                    step_number += 1;
+                    position = (position + step_size).min(data.len());
+                    streaming_input.set_available_limit(position);
+                }
+            }
+        };
+
+        let frame_header = decoder_with_frame_info.frame_header();
+        let frame_size = frame_header.size;
+        let frame_size = (
+            frame_size.0 * output_type.bits_per_sample() / 8,
+            frame_size.1,
+        );
+
+        // Create output buffers for this frame
+        let mut outputs = vec![OwnedRawImage::new((
+            frame_size.0 * samples_per_pixel,
+            frame_size.1,
+        ))?];
+
+        for _ in 0..extra_channels {
+            outputs.push(OwnedRawImage::new(frame_size)?);
+        }
+
+        let mut output_bufs: Vec<JxlOutputBuffer<'_>> = outputs
+            .iter_mut()
+            .map(|x| {
+                let rect = Rect {
+                    size: x.byte_size(),
+                    origin: (0, 0),
+                };
+                JxlOutputBuffer::from_image_rect_mut(x.get_rect_mut(rect))
+            })
+            .collect();
+
+        // Try to decode frame data, flushing progressively
+        let mut current_decoder = decoder_with_frame_info;
+        loop {
+            println!(
+                "Step {}: Decoding frame {} with {} bytes ({:.1}%)...",
+                step_number,
+                frame_count + 1,
+                position,
+                (position as f64 / data.len() as f64) * 100.0
+            );
+
+            let process_start = Instant::now();
+            match current_decoder.process(&mut streaming_input, &mut output_bufs)? {
+                ProcessingResult::Complete { result } => {
+                    // Frame fully decoded
+                    let process_time = process_start.elapsed();
+                    total_process_time += process_time;
+                    println!(
+                        "  Frame {} complete! (process: {:.3}ms)",
+                        frame_count + 1,
+                        process_time.as_secs_f64() * 1000.0
+                    );
+                    decoder_with_image_info = result;
+                    frame_count += 1;
+                    break;
+                }
+                ProcessingResult::NeedsMoreInput { mut fallback, .. } => {
+                    let process_time = process_start.elapsed();
+                    total_process_time += process_time;
+
+                    if position >= data.len() {
+                        // No more data, flush what we have
+                        println!(
+                            "  End of data, flushing frame {} (incomplete)...",
+                            frame_count + 1
+                        );
+                        let flush_start = Instant::now();
+                        fallback.flush_pixels(&mut output_bufs)?;
+                        let flush_time = flush_start.elapsed();
+                        total_flush_time += flush_time;
+                        println!(
+                            "  Times - process: {:.3}ms, flush: {:.3}ms",
+                            process_time.as_secs_f64() * 1000.0,
+                            flush_time.as_secs_f64() * 1000.0
+                        );
+                        drop(output_bufs); // Release borrow
+
+                        // Save final incomplete frame
+                        let intermediate_path = output_dir
+                            .join(format!("{}-{:03}.{}", output_stem, step_number, output_ext));
+                        println!(
+                            "Saving final incomplete frame to: {}",
+                            intermediate_path.display()
+                        );
+
+                        let write_start = Instant::now();
+                        let temp_output = DecodeOutput {
+                            size: info.size,
+                            frames: vec![ImageFrame {
+                                duration: frame_header.duration.unwrap_or(0.0),
+                                channels: outputs,
+                                color_type,
+                            }],
+                            data_type: output_type,
+                            original_bit_depth: info.bit_depth.clone(),
+                            output_profile: output_profile.clone(),
+                            embedded_profile: embedded_profile.clone(),
+                            jxl_animation: info.animation.clone(),
+                        };
+
+                        let output_format = crate::enc::OutputFormat::from_output_filename(
+                            &intermediate_path.to_string_lossy(),
+                        )?;
+                        output_format.save_image(&temp_output, &intermediate_path)?;
+                        total_write_time += write_start.elapsed();
+
+                        total_duration += start.elapsed();
+                        println!("\n=== Progressive Decode Summary ===");
+                        println!(
+                            "Total processing time: {:.3}ms",
+                            total_process_time.as_secs_f64() * 1000.0
+                        );
+                        println!(
+                            "Total flushing time:   {:.3}ms",
+                            total_flush_time.as_secs_f64() * 1000.0
+                        );
+                        println!(
+                            "Total write time:      {:.3}ms",
+                            total_write_time.as_secs_f64() * 1000.0
+                        );
+                        println!(
+                            "Total time:            {:.3}ms",
+                            total_duration.as_secs_f64() * 1000.0
+                        );
+                        return Ok((temp_output, total_duration));
+                    }
+
+                    // Flush intermediate result
+                    println!(
+                        "  Need more data for frame {}, flushing progressive preview...",
+                        frame_count + 1
+                    );
+                    let flush_start = Instant::now();
+                    fallback.flush_pixels(&mut output_bufs)?;
+                    let flush_time = flush_start.elapsed();
+                    total_flush_time += flush_time;
+                    println!(
+                        "  Times - process: {:.3}ms, flush: {:.3}ms",
+                        process_time.as_secs_f64() * 1000.0,
+                        flush_time.as_secs_f64() * 1000.0
+                    );
+                    drop(output_bufs); // Release borrow to allow cloning
+
+                    // Save intermediate result
+                    let intermediate_path = output_dir
+                        .join(format!("{}-{:03}.{}", output_stem, step_number, output_ext));
+                    println!(
+                        "  Saving intermediate result to: {}",
+                        intermediate_path.display()
+                    );
+
+                    let write_start = Instant::now();
+                    // Clone outputs for saving
+                    let cloned_outputs: Vec<OwnedRawImage> = outputs
+                        .iter()
+                        .map(|o| o.try_clone())
+                        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+                    let temp_output = DecodeOutput {
+                        size: info.size,
+                        frames: vec![ImageFrame {
+                            duration: frame_header.duration.unwrap_or(0.0),
+                            channels: cloned_outputs,
+                            color_type,
+                        }],
+                        data_type: output_type,
+                        original_bit_depth: info.bit_depth.clone(),
+                        output_profile: output_profile.clone(),
+                        embedded_profile: embedded_profile.clone(),
+                        jxl_animation: info.animation.clone(),
+                    };
+
+                    let output_format = crate::enc::OutputFormat::from_output_filename(
+                        &intermediate_path.to_string_lossy(),
+                    )?;
+                    output_format.save_image(&temp_output, &intermediate_path)?;
+                    total_write_time += write_start.elapsed();
+
+                    // Recreate output_bufs for next iteration
+                    output_bufs = outputs
+                        .iter_mut()
+                        .map(|x| {
+                            let rect = Rect {
+                                size: x.byte_size(),
+                                origin: (0, 0),
+                            };
+                            JxlOutputBuffer::from_image_rect_mut(x.get_rect_mut(rect))
+                        })
+                        .collect();
+
+                    // Feed more data and continue with same decoder
+                    step_number += 1;
+                    position = (position + step_size).min(data.len());
+                    streaming_input.set_available_limit(position);
+                    current_decoder = fallback;
+                }
+            }
+        }
+
+        if !decoder_with_image_info.has_more_frames() {
+            break;
+        }
+    }
+
+    total_duration += start.elapsed();
+
+    println!("\n=== Progressive Decode Summary ===");
+    println!(
+        "Total processing time: {:.3}ms",
+        total_process_time.as_secs_f64() * 1000.0
+    );
+    println!(
+        "Total flushing time:   {:.3}ms",
+        total_flush_time.as_secs_f64() * 1000.0
+    );
+    println!(
+        "Total write time:      {:.3}ms",
+        total_write_time.as_secs_f64() * 1000.0
+    );
+    println!(
+        "Total time:            {:.3}ms",
+        total_duration.as_secs_f64() * 1000.0
+    );
+
+    // Return final complete decode (we might not have this if we only got partial data)
+    // For now, do a fresh final decode to ensure completeness
+    println!("\n=== Single Full Decode (for comparison) ===");
+    let single_start = Instant::now();
+    let mut full_data = data;
+    let (final_output, _) = decode_frames(
+        &mut full_data,
+        make_decoder_options(),
+        config.override_bitdepth,
+        config.data_type,
+        config.supported_data_types,
+        config.interleave_alpha,
+        config.linear_output,
+        config.allow_partial_files,
+    )?;
+    let single_time = single_start.elapsed();
+    println!(
+        "Single decode time:    {:.3}ms",
+        single_time.as_secs_f64() * 1000.0
+    );
+    println!(
+        "Progressive overhead:  {:.3}ms ({:.1}%)",
+        (total_process_time.as_secs_f64() + total_flush_time.as_secs_f64()
+            - single_time.as_secs_f64())
+            * 1000.0,
+        ((total_process_time.as_secs_f64() + total_flush_time.as_secs_f64())
+            / single_time.as_secs_f64()
+            - 1.0)
+            * 100.0
+    );
+
+    Ok((final_output, total_duration))
 }

--- a/tools/progressive_streaming_demo.sh
+++ b/tools/progressive_streaming_demo.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# Streaming progressive decode demo: uses jxl_cli's --progressive-step-size
+# to produce all preview frames in a single decoder run, simulating streaming decode.
+
+set -e
+
+INPUT="$1"
+OUTPUT_DIR="$2"
+STEP_SIZE="${3:-5%}"  # Default to 5% if not specified
+
+if [ -z "$INPUT" ] || [ -z "$OUTPUT_DIR" ]; then
+  echo "Usage: $0 <input_jxl> <output_dir> [step_size]"
+  echo ""
+  echo "Arguments:"
+  echo "  input_jxl   - Path to input JPEG XL file"
+  echo "  output_dir  - Directory for output frames and video"
+  echo "  step_size   - Progressive step size (default: 5%)"
+  echo "                Can be absolute (e.g. '1000' for bytes) or percentage (e.g. '5%')"
+  echo ""
+  echo "Example:"
+  echo "  $0 image.jxl output/ 5%"
+  exit 1
+fi
+
+echo "Building jxl_cli..."
+cargo build --bin jxl_cli --release
+
+BINARY="./target/release/jxl_cli"
+
+if [ ! -f "$BINARY" ]; then
+  echo "Error: Binary not found at $BINARY after build."
+  exit 1
+fi
+
+if [ ! -f "$INPUT" ]; then
+  echo "Error: Input file not found at $INPUT"
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+# Clean up previous runs
+rm -f "$OUTPUT_DIR"/*.png "$OUTPUT_DIR"/*.mp4
+
+# Get file size
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  FILE_SIZE=$(stat -f%z "$INPUT")
+else
+  FILE_SIZE=$(stat -c%s "$INPUT")
+fi
+
+echo "Input file: $INPUT"
+echo "File size: $FILE_SIZE bytes"
+echo "Output directory: $OUTPUT_DIR"
+echo "Step size: $STEP_SIZE"
+echo ""
+
+# Use a temporary output path - the actual frames will be named with frame numbers
+TEMP_OUTPUT="$OUTPUT_DIR/temp.png"
+
+echo "Running streaming progressive decode..."
+"$BINARY" "$INPUT" "$TEMP_OUTPUT" --progressive-step-size "$STEP_SIZE" --allow-partial-files
+
+# Remove the temp output if it exists (jxl_cli creates intermediate frames, not this one)
+rm -f "$TEMP_OUTPUT"
+
+echo ""
+echo "Creating video from frames..."
+VIDEO_OUTPUT="$OUTPUT_DIR/progressive_streaming.mp4"
+
+# Count frames
+FRAME_COUNT=$(ls -1 "$OUTPUT_DIR"/temp-*.png 2>/dev/null | wc -l)
+
+if [ "$FRAME_COUNT" -eq 0 ]; then
+  echo "Error: No frames were generated!"
+  exit 1
+fi
+
+echo "Found $FRAME_COUNT frames"
+
+# Flatten frames with checkerboard background (for alpha transparency)
+echo "Flattening frames with checkerboard background..."
+FLATTENED_DIR="$OUTPUT_DIR/flattened"
+mkdir -p "$FLATTENED_DIR"
+
+for frame in "$OUTPUT_DIR"/temp-*.png; do
+  if [ -f "$frame" ]; then
+    basename=$(basename "$frame")
+    output="$FLATTENED_DIR/$basename"
+    
+    # Get image dimensions
+    dimensions=$(identify -format "%wx%h" "$frame")
+    
+    # Use ImageMagick to composite frame over checkerboard pattern
+    # Create a 32x32 checkerboard tile (16x16 pixel squares, light gray and white)
+    # Background first, then frame on top with Over composite
+    convert -size 16x16 xc:white xc:'#d0d0d0' +append \
+            -write mpr:row1 +delete \
+            -size 16x16 xc:'#d0d0d0' xc:white +append \
+            -write mpr:row2 +delete \
+            mpr:row1 mpr:row2 -append -write mpr:tile +delete \
+            -size "$dimensions" tile:mpr:tile \
+            "$frame" -compose Over -composite "$output"
+  fi
+done
+
+echo "Flattened frames saved to: $FLATTENED_DIR/"
+
+# Create video from flattened frames (2 fps to see progression clearly)
+ffmpeg -y -framerate 2 -pattern_type glob -i "$FLATTENED_DIR/temp-*.png" \
+  -vf "scale='2*trunc(min(3840,iw)/2)':-2" \
+  -c:v libx264 -pix_fmt yuv420p "$VIDEO_OUTPUT"
+
+echo ""
+echo "Done!"
+echo "Frames saved to: $OUTPUT_DIR/temp-*.png"
+echo "Video saved to: $VIDEO_OUTPUT"
+echo ""
+echo "To view the video:"
+echo "  ffplay $VIDEO_OUTPUT"


### PR DESCRIPTION
Decoder changes for progressive modular: https://github.com/libjxl/jxl-rs/pull/680

This PR is now just the changes to jxl_cli to add an option `--progressive-step-size` that does streaming decode with regular flush_pixels().