### PR TITLE
SIMD-store_u8 and clean up safety comments.

### DIFF
--- a/jxl_simd/src/aarch64/neon.rs
+++ b/jxl_simd/src/aarch64/neon.rs
@@ -126,7 +126,7 @@ unsafe impl F32SimdVec for F32VecNeon {
     fn load(d: Self::Descriptor, mem: &[f32]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
-        // from the safety invariant on `d`.
+        // from the safety invariant on `d`. vld1q_f32 supports unaligned loads.
         Self(unsafe { vld1q_f32(mem.as_ptr()) }, d)
     }
 
@@ -134,7 +134,7 @@ unsafe impl F32SimdVec for F32VecNeon {
     fn store(&self, mem: &mut [f32]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
-        // from the safety invariant on `d`.
+        // from the safety invariant on `d`. vst1q_f32 supports unaligned stores.
         unsafe { vst1q_f32(mem.as_mut_ptr(), self.0) }
     }
 
@@ -142,9 +142,9 @@ unsafe impl F32SimdVec for F32VecNeon {
     fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<f32>]) {
         assert!(dest.len() >= 2 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst2q_f32 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut f32;
+            let dest_ptr = dest.as_mut_ptr().cast::<f32>();
             vst2q_f32(dest_ptr, float32x4x2_t(a.0, b.0));
         }
     }
@@ -152,9 +152,9 @@ unsafe impl F32SimdVec for F32VecNeon {
     #[inline(always)]
     fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<f32>]) {
         assert!(dest.len() >= 3 * Self::LEN);
-        // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
+        // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid. vst3q_f32 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut f32;
+            let dest_ptr = dest.as_mut_ptr().cast::<f32>();
             vst3q_f32(dest_ptr, float32x4x3_t(a.0, b.0, c.0));
         }
     }
@@ -169,9 +169,9 @@ unsafe impl F32SimdVec for F32VecNeon {
     ) {
         assert!(dest.len() >= 4 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst4q_f32 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut f32;
+            let dest_ptr = dest.as_mut_ptr().cast::<f32>();
             vst4q_f32(dest_ptr, float32x4x4_t(a.0, b.0, c.0, d.0));
         }
     }
@@ -281,7 +281,7 @@ unsafe impl F32SimdVec for F32VecNeon {
     fn load_deinterleaved_2(d: Self::Descriptor, src: &[f32]) -> (Self, Self) {
         assert!(src.len() >= 2 * Self::LEN);
         // SAFETY: we just checked that `src` has enough space, and neon is available
-        // from the safety invariant on `d`.
+        // from the safety invariant on `d`. vld2q_f32 supports unaligned loads.
         let float32x4x2_t(a, b) = unsafe { vld2q_f32(src.as_ptr()) };
         (Self(a, d), Self(b, d))
     }
@@ -290,7 +290,7 @@ unsafe impl F32SimdVec for F32VecNeon {
     fn load_deinterleaved_3(d: Self::Descriptor, src: &[f32]) -> (Self, Self, Self) {
         assert!(src.len() >= 3 * Self::LEN);
         // SAFETY: we just checked that `src` has enough space, and neon is available
-        // from the safety invariant on `d`.
+        // from the safety invariant on `d`. vld3q_f32 supports unaligned loads.
         let float32x4x3_t(a, b, c) = unsafe { vld3q_f32(src.as_ptr()) };
         (Self(a, d), Self(b, d), Self(c, d))
     }
@@ -299,7 +299,7 @@ unsafe impl F32SimdVec for F32VecNeon {
     fn load_deinterleaved_4(d: Self::Descriptor, src: &[f32]) -> (Self, Self, Self, Self) {
         assert!(src.len() >= 4 * Self::LEN);
         // SAFETY: we just checked that `src` has enough space, and neon is available
-        // from the safety invariant on `d`.
+        // from the safety invariant on `d`. vld4q_f32 supports unaligned loads.
         let float32x4x4_t(a, b, c, e) = unsafe { vld4q_f32(src.as_ptr()) };
         (Self(a, d), Self(b, d), Self(c, d), Self(e, d))
     }
@@ -341,7 +341,7 @@ unsafe impl F32SimdVec for F32VecNeon {
             assert!(data.len() > 3);
 
             // Transposed load
-            // SAFETY: input is verified to be large enough for this pointer.
+            // SAFETY: input is verified to be large enough for this pointer. vld4q_f32 supports unaligned loads.
             let float32x4x4_t(p0, p1, p2, p3) = unsafe { vld4q_f32(data.as_ptr().cast()) };
 
             F32VecNeon(p0, d).store_array(&mut data[0]);
@@ -426,9 +426,9 @@ unsafe impl F32SimdVec for F32VecNeon {
             let u16s = vqmovun_s32(i32s);
             let u8s = vqmovn_u16(vcombine_u16(u16s, u16s));
             // Store lower 4 bytes
-            // SAFETY: we checked dest has enough space
+            // SAFETY: we checked dest has enough space. vst1_lane_u32 supports unaligned stores.
             unsafe {
-                vst1_lane_u32::<0>(dest.as_mut_ptr() as *mut u32, vreinterpret_u32_u8(u8s));
+                vst1_lane_u32::<0>(dest.as_mut_ptr().cast(), vreinterpret_u32_u8(u8s));
             }
         }
 
@@ -440,7 +440,7 @@ unsafe impl F32SimdVec for F32VecNeon {
             let i32s = vcvtq_s32_f32(rounded);
             let u16s = vqmovun_s32(i32s);
             // Store 4 u16s (8 bytes)
-            // SAFETY: we checked dest has enough space
+            // SAFETY: we checked dest has enough space. vst1_u16 supports unaligned stores.
             unsafe {
                 vst1_u16(dest.as_mut_ptr(), u16s);
             }
@@ -451,7 +451,8 @@ unsafe impl F32SimdVec for F32VecNeon {
             // Use inline asm because Rust stdarch incorrectly requires fp16 target feature
             // for vcvt_f16_f32 (fixed in https://github.com/rust-lang/stdarch/pull/1978)
             let f16_bits: uint16x4_t;
-            // SAFETY: NEON is available (guaranteed by descriptor), dest has enough space
+            // SAFETY: NEON is available (guaranteed by descriptor), dest has enough space,
+            // vst1_u16 supports unaligned stores.
             unsafe {
                 std::arch::asm!(
                     "fcvtn {out:v}.4h, {inp:v}.4s",
@@ -470,7 +471,8 @@ unsafe impl F32SimdVec for F32VecNeon {
         // Use inline asm because Rust stdarch incorrectly requires fp16 target feature
         // for vcvt_f32_f16 (fixed in https://github.com/rust-lang/stdarch/pull/1978)
         let result: float32x4_t;
-        // SAFETY: NEON is available (guaranteed by descriptor), mem has enough space
+        // SAFETY: NEON is available (guaranteed by descriptor), mem has enough space.
+        // vld1_u16 supports unaligned loads.
         unsafe {
             let f16_bits = vld1_u16(mem.as_ptr());
             std::arch::asm!(
@@ -491,7 +493,7 @@ unsafe impl F32SimdVec for F32VecNeon {
             // Convert f32 table to BF16 packed in 128 bits (16 bytes for 8 entries)
             // BF16 is the high 16 bits of f32
             // SAFETY: neon is available from target_feature, and `table` is large
-            // enough for the loads.
+            // enough for the loads. vld1q_f32 supports unaligned loads.
             let (table_lo, table_hi) =
                 unsafe { (vld1q_f32(table.as_ptr()), vld1q_f32(table.as_ptr().add(4))) };
 
@@ -699,11 +701,26 @@ impl I32SimdVec for I32VecNeon {
     fn store_u16(self, dest: &mut [u16]) {
         assert!(dest.len() >= Self::LEN);
         // SAFETY: We know neon is available from the safety invariant on `self.1`,
-        // and we just checked that `dest` has enough space.
+        // and we just checked that `dest` has enough space. vst1_u16 supports unaligned
+        // stores.
         unsafe {
             // vmovn narrows i32 to i16 by taking the lower 16 bits
             let narrowed = vmovn_s32(self.0);
             vst1_u16(dest.as_mut_ptr(), vreinterpret_u16_s16(narrowed));
+        }
+    }
+
+    #[inline(always)]
+    fn store_u8(self, dest: &mut [u8]) {
+        assert!(dest.len() >= Self::LEN);
+        // SAFETY: We know neon is available from the safety invariant on `self.1`,
+        // and we just checked that `dest` has enough space. vst1_lane_u32 supports unaligned stores.
+        unsafe {
+            // vmovn narrows i32 -> i16 -> i8
+            let narrowed_i16 = vmovn_s32(self.0);
+            let combined_i16 = vcombine_s16(narrowed_i16, narrowed_i16);
+            let narrowed_i8 = vmovn_s16(combined_i16);
+            vst1_lane_u32::<0>(dest.as_mut_ptr().cast(), vreinterpret_u32_s8(narrowed_i8));
         }
     }
 }
@@ -855,7 +872,7 @@ unsafe impl U8SimdVec for U8VecNeon {
     fn load(d: Self::Descriptor, mem: &[u8]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
-        // from the safety invariant on `d`.
+        // from the safety invariant on `d`. vld1q_u8 supports unaligned loads.
         Self(unsafe { vld1q_u8(mem.as_ptr()) }, d)
     }
 
@@ -869,7 +886,7 @@ unsafe impl U8SimdVec for U8VecNeon {
     fn store(&self, mem: &mut [u8]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
-        // from the safety invariant on `d`.
+        // from the safety invariant on `d`. vst1q_u8 supports unaligned stores.
         unsafe { vst1q_u8(mem.as_mut_ptr(), self.0) }
     }
 
@@ -877,9 +894,9 @@ unsafe impl U8SimdVec for U8VecNeon {
     fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<u8>]) {
         assert!(dest.len() >= 2 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst2q_u8 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut u8;
+            let dest_ptr = dest.as_mut_ptr().cast::<u8>();
             vst2q_u8(dest_ptr, uint8x16x2_t(a.0, b.0));
         }
     }
@@ -888,9 +905,9 @@ unsafe impl U8SimdVec for U8VecNeon {
     fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<u8>]) {
         assert!(dest.len() >= 3 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst3q_u8 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut u8;
+            let dest_ptr = dest.as_mut_ptr().cast::<u8>();
             vst3q_u8(dest_ptr, uint8x16x3_t(a.0, b.0, c.0));
         }
     }
@@ -905,9 +922,9 @@ unsafe impl U8SimdVec for U8VecNeon {
     ) {
         assert!(dest.len() >= 4 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst4q_u8 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut u8;
+            let dest_ptr = dest.as_mut_ptr().cast::<u8>();
             vst4q_u8(dest_ptr, uint8x16x4_t(a.0, b.0, c.0, d.0));
         }
     }
@@ -927,8 +944,8 @@ unsafe impl U16SimdVec for U16VecNeon {
     fn load(d: Self::Descriptor, mem: &[u16]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
-        // from the safety invariant on `d`.
-        Self(unsafe { vld1q_u16(mem.as_ptr()) }, d)
+        // from the safety invariant on `d`. vld1q_u16 supports unaligned loads.
+        Self(unsafe { vld1q_u16(mem.as_ptr().cast()) }, d)
     }
 
     #[inline(always)]
@@ -941,17 +958,17 @@ unsafe impl U16SimdVec for U16VecNeon {
     fn store(&self, mem: &mut [u16]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
-        // from the safety invariant on `d`.
-        unsafe { vst1q_u16(mem.as_mut_ptr(), self.0) }
+        // from the safety invariant on `d`. vst1q_u16 supports unaligned stores.
+        unsafe { vst1q_u16(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
     fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<u16>]) {
         assert!(dest.len() >= 2 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst2q_u16 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut u16;
+            let dest_ptr = dest.as_mut_ptr().cast::<u16>();
             vst2q_u16(dest_ptr, uint16x8x2_t(a.0, b.0));
         }
     }
@@ -960,9 +977,9 @@ unsafe impl U16SimdVec for U16VecNeon {
     fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<u16>]) {
         assert!(dest.len() >= 3 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst3q_u16 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut u16;
+            let dest_ptr = dest.as_mut_ptr().cast::<u16>();
             vst3q_u16(dest_ptr, uint16x8x3_t(a.0, b.0, c.0));
         }
     }
@@ -977,9 +994,9 @@ unsafe impl U16SimdVec for U16VecNeon {
     ) {
         assert!(dest.len() >= 4 * Self::LEN);
         // SAFETY: we just checked that `dest` has enough space, and neon is available
-        // from the safety invariant on the descriptor stored in `a`.
+        // from the safety invariant on the descriptor stored in `a`. vst4q_u16 supports unaligned stores.
         unsafe {
-            let dest_ptr = dest.as_mut_ptr() as *mut u16;
+            let dest_ptr = dest.as_mut_ptr().cast::<u16>();
             vst4q_u16(dest_ptr, uint16x8x4_t(a.0, b.0, c.0, d.0));
         }
     }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -128,7 +128,7 @@ pub unsafe trait F32SimdVec:
         // SAFETY: f32 and MaybeUninit<f32> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<f32>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<f32>>(), dest.len())
         };
         Self::store_interleaved_2_uninit(a, b, dest);
     }
@@ -140,7 +140,7 @@ pub unsafe trait F32SimdVec:
         // SAFETY: f32 and MaybeUninit<f32> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<f32>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<f32>>(), dest.len())
         };
         Self::store_interleaved_3_uninit(a, b, c, dest);
     }
@@ -152,7 +152,7 @@ pub unsafe trait F32SimdVec:
         // SAFETY: f32 and MaybeUninit<f32> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<f32>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<f32>>(), dest.len())
         };
         Self::store_interleaved_4_uninit(a, b, c, d, dest);
     }
@@ -348,6 +348,10 @@ pub trait I32SimdVec:
     /// Stores the lower 16 bits of each i32 lane as u16 values.
     /// Requires `dest.len() >= Self::LEN` or it will panic.
     fn store_u16(self, dest: &mut [u16]);
+
+    /// Stores the lower 8 bits of each i32 lane as u8 values.
+    /// Requires `dest.len() >= Self::LEN` or it will panic.
+    fn store_u8(self, dest: &mut [u8]);
 }
 
 pub trait U32SimdVec: Sized + Copy + Debug + Send + Sync {
@@ -381,7 +385,7 @@ pub unsafe trait U8SimdVec: Sized + Copy + Debug + Send + Sync {
         // SAFETY: u8 and MaybeUninit<u8> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<u8>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<u8>>(), dest.len())
         };
         Self::store_interleaved_2_uninit(a, b, dest);
     }
@@ -393,7 +397,7 @@ pub unsafe trait U8SimdVec: Sized + Copy + Debug + Send + Sync {
         // SAFETY: u8 and MaybeUninit<u8> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<u8>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<u8>>(), dest.len())
         };
         Self::store_interleaved_3_uninit(a, b, c, dest);
     }
@@ -405,7 +409,7 @@ pub unsafe trait U8SimdVec: Sized + Copy + Debug + Send + Sync {
         // SAFETY: u8 and MaybeUninit<u8> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<u8>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<u8>>(), dest.len())
         };
         Self::store_interleaved_4_uninit(a, b, c, d, dest);
     }
@@ -450,7 +454,7 @@ pub unsafe trait U16SimdVec: Sized + Copy + Debug + Send + Sync {
         // SAFETY: u16 and MaybeUninit<u16> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<u16>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<u16>>(), dest.len())
         };
         Self::store_interleaved_2_uninit(a, b, dest);
     }
@@ -462,7 +466,7 @@ pub unsafe trait U16SimdVec: Sized + Copy + Debug + Send + Sync {
         // SAFETY: u16 and MaybeUninit<u16> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<u16>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<u16>>(), dest.len())
         };
         Self::store_interleaved_3_uninit(a, b, c, dest);
     }
@@ -474,7 +478,7 @@ pub unsafe trait U16SimdVec: Sized + Copy + Debug + Send + Sync {
         // SAFETY: u16 and MaybeUninit<u16> have the same layout.
         // We are writing to initialized memory, so treating it as uninit for writing is fine.
         let dest = unsafe {
-            std::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut MaybeUninit<u16>, dest.len())
+            std::slice::from_raw_parts_mut(dest.as_mut_ptr().cast::<MaybeUninit<u16>>(), dest.len())
         };
         Self::store_interleaved_4_uninit(a, b, c, d, dest);
     }
@@ -1484,4 +1488,40 @@ mod test {
         }
     }
     test_all_instruction_sets!(test_store_interleaved_4_u16);
+
+    fn test_store_u8<D: SimdDescriptor>(d: D) {
+        let data = [
+            0xba_i32,
+            0x12345678_i32,
+            0xdeadbabeu32 as i32,
+            0x76543210_i32,
+            0x11111111_i32,
+            0x00000000_i32,
+            0xffffffffu32 as i32,
+            0x12345678_i32,
+            0x87654321u32 as i32,
+            0xabcdef01u32 as i32,
+            0x10203040_i32,
+            0x50607080_i32,
+            0x01020304_i32,
+            0x05060708_i32,
+            0x090a0b0c_i32,
+            0x0d0e0f00_i32,
+        ];
+        let mut output = [0u8; 16];
+        for i in (0..16).step_by(D::I32Vec::LEN) {
+            let vec = D::I32Vec::load(d, &data[i..]);
+            vec.store_u8(&mut output[i..]);
+        }
+
+        for i in 0..16 {
+            let expected = (data[i] & 0xff) as u8;
+            assert_eq!(
+                output[i], expected,
+                "store_u8 failed at index {}: expected 0x{:02x}, got 0x{:02x}",
+                i, expected, output[i]
+            );
+        }
+    }
+    test_all_instruction_sets!(test_store_u8);
 }

--- a/jxl_simd/src/scalar.rs
+++ b/jxl_simd/src/scalar.rs
@@ -312,6 +312,11 @@ impl I32SimdVec for Wrapping<i32> {
     fn store_u16(self, dest: &mut [u16]) {
         dest[0] = self.0 as u16;
     }
+
+    #[inline(always)]
+    fn store_u8(self, dest: &mut [u8]) {
+        dest[0] = self.0 as u8;
+    }
 }
 
 impl U32SimdVec for Wrapping<u32> {

--- a/jxl_simd/src/x86_64/avx.rs
+++ b/jxl_simd/src/x86_64/avx.rs
@@ -200,16 +200,16 @@ unsafe impl F32SimdVec for F32VecAvx {
     fn load(d: Self::Descriptor, mem: &[f32]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx is available
-        // from the safety invariant on `d`.
-        Self(unsafe { _mm256_loadu_ps(mem.as_ptr()) }, d)
+        // from the safety invariant on `d`. _mm256_loadu_ps supports unaligned loads.
+        Self(unsafe { _mm256_loadu_ps(mem.as_ptr().cast()) }, d)
     }
 
     #[inline(always)]
     fn store(&self, mem: &mut [f32]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx is available
-        // from the safety invariant on `self.1`.
-        unsafe { _mm256_storeu_ps(mem.as_mut_ptr(), self.0) }
+        // from the safety invariant on `self.1`. _mm256_storeu_ps supports unaligned stores.
+        unsafe { _mm256_storeu_ps(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
@@ -225,9 +225,9 @@ unsafe impl F32SimdVec for F32VecAvx {
             // Need to permute to get correct order
             let out0 = _mm256_permute2f128_ps::<0x20>(lo, hi); // lower halves: [a0,b0,a1,b1, a2,b2,a3,b3]
             let out1 = _mm256_permute2f128_ps::<0x31>(lo, hi); // upper halves: [a4,b4,a5,b5, a6,b6,a7,b7]
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid. _mm256_storeu_ps supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm256_storeu_ps(dest_ptr, out0);
                 _mm256_storeu_ps(dest_ptr.add(8), out1);
             }
@@ -276,9 +276,9 @@ unsafe impl F32SimdVec for F32VecAvx {
             let out2 = _mm256_blend_ps::<0b01001001>(a2, b2);
             let out2 = _mm256_blend_ps::<0b10010010>(out2, c2);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid. _mm256_storeu_ps supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm256_storeu_ps(dest_ptr, out0);
                 _mm256_storeu_ps(dest_ptr.add(8), out1);
                 _mm256_storeu_ps(dest_ptr.add(16), out2);
@@ -337,9 +337,9 @@ unsafe impl F32SimdVec for F32VecAvx {
             let out2 = _mm256_permute2f128_ps::<0x31>(abcd_0, abcd_1);
             let out3 = _mm256_permute2f128_ps::<0x31>(abcd_2, abcd_3);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid. _mm256_storeu_ps supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm256_storeu_ps(dest_ptr, out0);
                 _mm256_storeu_ps(dest_ptr.add(8), out1);
                 _mm256_storeu_ps(dest_ptr.add(16), out2);
@@ -638,9 +638,15 @@ unsafe impl F32SimdVec for F32VecAvx {
             // Pack 8 u16s to 8 u8s (use same vector twice, take lower half)
             let u8s = _mm_packus_epi16(u16s, u16s);
             // Store lower 8 bytes
-            // SAFETY: we checked dest has enough space
+            let val = _mm_cvtsi128_si64(u8s);
+            let bytes = val.to_ne_bytes();
+            // SAFETY:
+            // 1. `src` (bytes.as_ptr()) is valid for 8 bytes as it is a local [u8; 8].
+            // 2. `dst` (dest.as_mut_ptr()) is valid for 8 bytes because dest.len() >= 8.
+            // 3. `src` and `dst` are properly aligned for u8 (alignment 1).
+            // 4. `src` and `dst` do not overlap as `src` is a local stack array.
             unsafe {
-                _mm_storel_epi64(dest.as_mut_ptr() as *mut __m128i, u8s);
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest.as_mut_ptr().cast::<u8>(), 8);
             }
         }
         // SAFETY: avx2 is available from the safety invariant on the descriptor.
@@ -663,9 +669,9 @@ unsafe impl F32SimdVec for F32VecAvx {
             // Pack 4+4 i32s to 8 u16s
             let u16s = _mm_packus_epi32(lo, hi);
             // Store 8 u16s (16 bytes)
-            // SAFETY: we checked dest has enough space
+            // SAFETY: we checked dest has enough space. _mm_storeu_si128 supports unaligned stores.
             unsafe {
-                _mm_storeu_si128(dest.as_mut_ptr() as *mut __m128i, u16s);
+                _mm_storeu_si128(dest.as_mut_ptr().cast(), u16s);
             }
         }
         // SAFETY: avx2 is available from the safety invariant on the descriptor.
@@ -680,8 +686,8 @@ unsafe impl F32SimdVec for F32VecAvx {
         #[inline]
         fn load_f16_impl(d: AvxDescriptor, mem: &[u16]) -> F32VecAvx {
             assert!(mem.len() >= F32VecAvx::LEN);
-            // SAFETY: mem.len() >= 8 is checked above
-            let bits = unsafe { _mm_loadu_si128(mem.as_ptr() as *const __m128i) };
+            // SAFETY: mem.len() >= 8 is checked above. _mm_loadu_si128 supports unaligned loads.
+            let bits = unsafe { _mm_loadu_si128(mem.as_ptr().cast()) };
             F32VecAvx(_mm256_cvtph_ps(bits), d)
         }
         // SAFETY: avx2 and f16c are available from the safety invariant on the descriptor
@@ -695,8 +701,8 @@ unsafe impl F32SimdVec for F32VecAvx {
         fn store_f16_bits_impl(v: __m256, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx::LEN);
             let bits = _mm256_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
-            // SAFETY: dest.len() >= 8 is checked above
-            unsafe { _mm_storeu_si128(dest.as_mut_ptr() as *mut __m128i, bits) };
+            // SAFETY: dest.len() >= 8 is checked above. _mm_storeu_si128 supports unaligned stores.
+            unsafe { _mm_storeu_si128(dest.as_mut_ptr().cast(), bits) };
         }
         // SAFETY: avx2 and f16c are available from the safety invariant on the descriptor
         unsafe { store_f16_bits_impl(self.0, dest) }
@@ -802,8 +808,8 @@ impl I32SimdVec for I32VecAvx {
     fn load(d: Self::Descriptor, mem: &[i32]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx is available
-        // from the safety invariant on `d`.
-        Self(unsafe { _mm256_loadu_si256(mem.as_ptr() as *const _) }, d)
+        // from the safety invariant on `d`. _mm256_loadu_si256 supports unaligned loads.
+        Self(unsafe { _mm256_loadu_si256(mem.as_ptr().cast()) }, d)
     }
 
     #[inline(always)]
@@ -895,13 +901,45 @@ impl I32SimdVec for I32VecAvx {
                 ),
             );
             let tmp = _mm256_permute4x64_epi64(tmp, 0xD8);
-            // SAFETY: we just checked that `dest` has enough space.
+            // SAFETY: we just checked that `dest` has enough space. _mm_storeu_si128 supports unaligned stores.
             unsafe {
                 _mm_storeu_si128(dest.as_mut_ptr().cast(), _mm256_extracti128_si256::<0>(tmp))
             };
         }
         // SAFETY: avx2 is available from the safety invariant on the descriptor.
         unsafe { store_u16_impl(self.0, dest) }
+    }
+
+    #[inline(always)]
+    fn store_u8(self, dest: &mut [u8]) {
+        #[target_feature(enable = "avx2")]
+        #[inline]
+        fn store_u8_impl(v: __m256i, dest: &mut [u8]) {
+            assert!(dest.len() >= I32VecAvx::LEN);
+            let tmp = _mm256_shuffle_epi8(
+                v,
+                _mm256_setr_epi8(
+                    0, 4, 8, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //
+                    0, 4, 8, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                ),
+            );
+            let lo = _mm256_castsi256_si128(tmp);
+            let hi = _mm256_extracti128_si256::<1>(tmp);
+            let packed = _mm_unpacklo_epi32(lo, hi);
+            let val = _mm_cvtsi128_si64(packed);
+            let bytes = val.to_ne_bytes();
+            // SAFETY:
+            // 1. we just checked that `dest` has enough space (dest.len() >= 8).
+            // 2. `src` (bytes.as_ptr()) is valid for 8 bytes as it is a local [u8; 8].
+            // 3. `dst` (dest.as_mut_ptr()) is valid for 8 bytes because dest.len() >= 8.
+            // 4. `src` and `dst` are properly aligned for u8 (alignment 1).
+            // 5. `src` and `dst` do not overlap as `src` is a local stack array.
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest.as_mut_ptr().cast::<u8>(), 8);
+            }
+        }
+        // SAFETY: avx2 is available from the safety invariant on the descriptor.
+        unsafe { store_u8_impl(self.0, dest) }
     }
 }
 
@@ -1051,8 +1089,8 @@ unsafe impl U8SimdVec for U8VecAvx {
     fn load(d: Self::Descriptor, mem: &[u8]) -> Self {
         assert!(mem.len() >= U8VecAvx::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx2 is available
-        // from the safety invariant on `d`.
-        unsafe { Self(_mm256_loadu_si256(mem.as_ptr() as *const _), d) }
+        // from the safety invariant on `d`. _mm256_loadu_si256 supports unaligned loads.
+        unsafe { Self(_mm256_loadu_si256(mem.as_ptr().cast()), d) }
     }
 
     #[inline(always)]
@@ -1065,8 +1103,8 @@ unsafe impl U8SimdVec for U8VecAvx {
     fn store(&self, mem: &mut [u8]) {
         assert!(mem.len() >= U8VecAvx::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx2 is available
-        // from the safety invariant on `d`.
-        unsafe { _mm256_storeu_si256(mem.as_mut_ptr() as *mut _, self.0) }
+        // from the safety invariant on `d`. _mm256_storeu_si256 supports unaligned stores.
+        unsafe { _mm256_storeu_si256(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
@@ -1085,9 +1123,9 @@ unsafe impl U8SimdVec for U8VecAvx {
             // R1 = [A16 B16..A23 B23 | A24 B24..A31 B31]
             let out1 = _mm256_permute2x128_si256::<0x31>(lo, hi);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m256i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m256i` is valid. _mm256_storeu_si256 supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m256i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m256i>();
                 _mm256_storeu_si256(dest_ptr, out0);
                 _mm256_storeu_si256(dest_ptr.add(1), out1);
             }
@@ -1179,9 +1217,9 @@ unsafe impl U8SimdVec for U8VecAvx {
                 _mm256_shuffle_epi8(c_dup_hi, mask_c2),
             );
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m256i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m256i` is valid. _mm256_storeu_si256 supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m256i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m256i>();
                 _mm256_storeu_si256(dest_ptr, out0);
                 _mm256_storeu_si256(dest_ptr.add(1), out1);
                 _mm256_storeu_si256(dest_ptr.add(2), out2);
@@ -1227,9 +1265,9 @@ unsafe impl U8SimdVec for U8VecAvx {
             let out2 = _mm256_permute2x128_si256::<0x31>(out0_p, out1_p);
             let out3 = _mm256_permute2x128_si256::<0x31>(out2_p, out3_p);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m256i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m256i` is valid. _mm256_storeu_si256 supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m256i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m256i>();
                 _mm256_storeu_si256(dest_ptr, out0);
                 _mm256_storeu_si256(dest_ptr.add(1), out1);
                 _mm256_storeu_si256(dest_ptr.add(2), out2);
@@ -1255,8 +1293,8 @@ unsafe impl U16SimdVec for U16VecAvx {
     fn load(d: Self::Descriptor, mem: &[u16]) -> Self {
         assert!(mem.len() >= U16VecAvx::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx2 is available
-        // from the safety invariant on `d`.
-        unsafe { Self(_mm256_loadu_si256(mem.as_ptr() as *const _), d) }
+        // from the safety invariant on `d`. _mm256_loadu_si256 supports unaligned loads.
+        unsafe { Self(_mm256_loadu_si256(mem.as_ptr().cast()), d) }
     }
 
     #[inline(always)]
@@ -1269,8 +1307,8 @@ unsafe impl U16SimdVec for U16VecAvx {
     fn store(&self, mem: &mut [u16]) {
         assert!(mem.len() >= U16VecAvx::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx2 is available
-        // from the safety invariant on `d`.
-        unsafe { _mm256_storeu_si256(mem.as_mut_ptr() as *mut _, self.0) }
+        // from the safety invariant on `d`. _mm256_storeu_si256 supports unaligned stores.
+        unsafe { _mm256_storeu_si256(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
@@ -1289,9 +1327,9 @@ unsafe impl U16SimdVec for U16VecAvx {
             // R1 = [A8 B8..A15 B15]
             let out1 = _mm256_permute2x128_si256::<0x31>(lo, hi);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m256i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m256i` is valid. _mm256_storeu_si256 supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m256i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m256i>();
                 _mm256_storeu_si256(dest_ptr, out0);
                 _mm256_storeu_si256(dest_ptr.add(1), out1);
             }
@@ -1383,9 +1421,9 @@ unsafe impl U16SimdVec for U16VecAvx {
                 _mm256_shuffle_epi8(c_dup_hi, mask_c2),
             );
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m256i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m256i` is valid. _mm256_storeu_si256 supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m256i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m256i>();
                 _mm256_storeu_si256(dest_ptr, out0);
                 _mm256_storeu_si256(dest_ptr.add(1), out1);
                 _mm256_storeu_si256(dest_ptr.add(2), out2);
@@ -1431,9 +1469,9 @@ unsafe impl U16SimdVec for U16VecAvx {
             let out2 = _mm256_permute2x128_si256::<0x31>(out0_p, out1_p);
             let out3 = _mm256_permute2x128_si256::<0x31>(out2_p, out3_p);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m256i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m256i` is valid. _mm256_storeu_si256 supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m256i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m256i>();
                 _mm256_storeu_si256(dest_ptr, out0);
                 _mm256_storeu_si256(dest_ptr.add(1), out1);
                 _mm256_storeu_si256(dest_ptr.add(2), out2);

--- a/jxl_simd/src/x86_64/avx512.rs
+++ b/jxl_simd/src/x86_64/avx512.rs
@@ -153,9 +153,9 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             let out0 = _mm512_permutex2var_ps(lo, idx_lo, hi);
             let out1 = _mm512_permutex2var_ps(lo, idx_hi, hi);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid. _mm512_storeu_ps supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm512_storeu_ps(dest_ptr, out0);
                 _mm512_storeu_ps(dest_ptr.add(16), out1);
             }
@@ -196,9 +196,9 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             let out2 = _mm512_permutex2var_ps(a, idx_ab2, b);
             let out2 = _mm512_mask_permutexvar_ps(out2, 0b1001001001001001, idx_c2, c);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid. _mm512_storeu_ps supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm512_storeu_ps(dest_ptr, out0);
                 _mm512_storeu_ps(dest_ptr.add(16), out1);
                 _mm512_storeu_ps(dest_ptr.add(32), out2);
@@ -295,9 +295,9 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             let out1 = _mm512_permutex2var_ps(pair01_13, idx_0, pair23_13);
             let out3 = _mm512_permutex2var_ps(pair01_13, idx_1, pair23_13);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid. _mm512_storeu_ps supports unaligned stores.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm512_storeu_ps(dest_ptr, out0);
                 _mm512_storeu_ps(dest_ptr.add(16), out1);
                 _mm512_storeu_ps(dest_ptr.add(32), out2);
@@ -432,9 +432,9 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             let out6 = _mm512_permutex2var_ps(full_0_13, idx_hi, full_1_13);
             let out7 = _mm512_permutex2var_ps(full_2_13, idx_hi, full_3_13);
 
-            // SAFETY: we just checked that dest has enough space.
+            // SAFETY: we just checked that dest has enough space. _mm512_storeu_ps supports unaligned stores.
             unsafe {
-                let ptr = dest.as_mut_ptr();
+                let ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm512_storeu_ps(ptr, out0);
                 _mm512_storeu_ps(ptr.add(16), out1);
                 _mm512_storeu_ps(ptr.add(32), out2);
@@ -458,7 +458,7 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             assert!(src.len() >= 2 * F32VecAvx512::LEN);
             // Input: [a0,b0,a1,b1,...,a15,b15]
             // Output: a = [a0..a15], b = [b0..b15]
-            // SAFETY: we just checked that src has enough space.
+            // SAFETY: we just checked that src has enough space. _mm512_loadu_ps supports unaligned loads.
             let (in0, in1) = unsafe {
                 (
                     _mm512_loadu_ps(src.as_ptr()),
@@ -495,7 +495,7 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             // in2: [c10,a11,b11,c11,a12,b12,c12,a13,b13,c13,a14,b14,c14,a15,b15,c15]
             // Output: a = [a0..a15], b = [b0..b15], c = [c0..c15]
 
-            // SAFETY: we just checked that src has enough space.
+            // SAFETY: we just checked that src has enough space. _mm512_loadu_ps supports unaligned loads.
             let (in0, in1, in2) = unsafe {
                 (
                     _mm512_loadu_ps(src.as_ptr()),
@@ -548,7 +548,7 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             assert!(src.len() >= 4 * F32VecAvx512::LEN);
             // Input: [a0,b0,c0,d0,a1,b1,c1,d1,...] (64 floats)
             // Output: a = [a0..a15], b = [b0..b15], c = [c0..c15], d = [d0..d15]
-            // SAFETY: we just checked that src has enough space.
+            // SAFETY: we just checked that src has enough space. _mm512_loadu_ps supports unaligned loads.
             let (in0, in1, in2, in3) = unsafe {
                 (
                     _mm512_loadu_ps(src.as_ptr()),
@@ -704,7 +704,7 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             // Store 16 bytes
             // SAFETY: we checked dest has enough space
             unsafe {
-                _mm_storeu_si128(dest.as_mut_ptr() as *mut __m128i, u8s);
+                _mm_storeu_si128(dest.as_mut_ptr().cast(), u8s);
             }
         }
         // SAFETY: avx512f and avx512bw are available from the safety invariant on the descriptor.
@@ -726,7 +726,7 @@ unsafe impl F32SimdVec for F32VecAvx512 {
             // Store 16 u16s (32 bytes)
             // SAFETY: we checked dest has enough space
             unsafe {
-                _mm256_storeu_si256(dest.as_mut_ptr() as *mut __m256i, u16s);
+                _mm256_storeu_si256(dest.as_mut_ptr().cast(), u16s);
             }
         }
         // SAFETY: avx512f and avx512bw are available from the safety invariant on the descriptor.
@@ -742,8 +742,8 @@ unsafe impl F32SimdVec for F32VecAvx512 {
         #[inline]
         fn load_f16_impl(d: Avx512Descriptor, mem: &[u16]) -> F32VecAvx512 {
             assert!(mem.len() >= F32VecAvx512::LEN);
-            // SAFETY: mem.len() >= 16 is checked above
-            let bits = unsafe { _mm256_loadu_si256(mem.as_ptr() as *const __m256i) };
+            // SAFETY: mem.len() >= 16 is checked above.
+            let bits = unsafe { _mm256_loadu_si256(mem.as_ptr().cast()) };
             F32VecAvx512(_mm512_cvtph_ps(bits), d)
         }
         // SAFETY: avx512f is available from the safety invariant on the descriptor
@@ -758,8 +758,8 @@ unsafe impl F32SimdVec for F32VecAvx512 {
         fn store_f16_bits_impl(v: __m512, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx512::LEN);
             let bits = _mm512_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
-            // SAFETY: dest.len() >= 16 is checked above
-            unsafe { _mm256_storeu_si256(dest.as_mut_ptr() as *mut __m256i, bits) };
+            // SAFETY: dest.len() >= 16 is checked above.
+            unsafe { _mm256_storeu_si256(dest.as_mut_ptr().cast(), bits) };
         }
         // SAFETY: avx512f is available from the safety invariant on the descriptor
         unsafe { store_f16_bits_impl(self.0, dest) }
@@ -1074,6 +1074,22 @@ impl I32SimdVec for I32VecAvx512 {
         // SAFETY: avx512f is available from the safety invariant on the descriptor.
         unsafe { store_u16_impl(self.0, dest) }
     }
+
+    #[inline(always)]
+    fn store_u8(self, dest: &mut [u8]) {
+        #[target_feature(enable = "avx512f")]
+        #[inline]
+        fn store_u8_impl(v: __m512i, dest: &mut [u8]) {
+            assert!(dest.len() >= I32VecAvx512::LEN);
+            let tmp_vec = _mm512_cvtepi32_epi8(v);
+            // SAFETY: We just checked `dst` has enough space.
+            unsafe {
+                _mm_storeu_si128(dest.as_mut_ptr().cast(), tmp_vec);
+            }
+        }
+        // SAFETY: avx512f is available from the safety invariant on the descriptor.
+        unsafe { store_u8_impl(self.0, dest) }
+    }
 }
 
 impl Add<I32VecAvx512> for I32VecAvx512 {
@@ -1222,8 +1238,8 @@ unsafe impl U8SimdVec for U8VecAvx512 {
     fn load(d: Self::Descriptor, mem: &[u8]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available
-        // from the safety invariant on `d`.
-        unsafe { Self(_mm512_loadu_si512(mem.as_ptr() as *const _), d) }
+        // from the safety invariant on `d`. _mm512_loadu_si512 supports unaligned loads.
+        unsafe { Self(_mm512_loadu_si512(mem.as_ptr().cast()), d) }
     }
 
     #[inline(always)]
@@ -1236,8 +1252,8 @@ unsafe impl U8SimdVec for U8VecAvx512 {
     fn store(&self, mem: &mut [u8]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available
-        // from the safety invariant on `d`.
-        unsafe { _mm512_storeu_si512(mem.as_mut_ptr() as *mut _, self.0) }
+        // from the safety invariant on `d`. _mm512_storeu_si512 supports unaligned stores.
+        unsafe { _mm512_storeu_si512(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
@@ -1253,9 +1269,9 @@ unsafe impl U8SimdVec for U8VecAvx512 {
             let out0 = _mm512_permutex2var_epi64(lo, idx0, hi);
             let out1 = _mm512_permutex2var_epi64(lo, idx1, hi);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m512i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m512i` is valid. _mm512_storeu_si512 supports unaligned stores.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m512i;
+                let ptr = dest.as_mut_ptr().cast::<__m512i>();
                 _mm512_storeu_si512(ptr, out0);
                 _mm512_storeu_si512(ptr.add(1), out1);
             }
@@ -1335,9 +1351,9 @@ unsafe impl U8SimdVec for U8VecAvx512 {
             let idx_f2 = _mm512_setr_epi64(0, 1, 2, 3, 14, 15, 4, 5);
             let final2 = _mm512_permutex2var_epi64(part_a2, idx_f2, res1);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m512i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m512i` is valid. _mm512_storeu_si512 supports unaligned stores.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m512i;
+                let ptr = dest.as_mut_ptr().cast::<__m512i>();
                 _mm512_storeu_si512(ptr, final0);
                 _mm512_storeu_si512(ptr.add(1), final1);
                 _mm512_storeu_si512(ptr.add(2), final2);
@@ -1385,9 +1401,9 @@ unsafe impl U8SimdVec for U8VecAvx512 {
             let out2 = _mm512_permutex2var_epi64(pair01_13, idx_0, pair23_13);
             let out3 = _mm512_permutex2var_epi64(pair01_13, idx_1, pair23_13);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m512i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m512i` is valid. _mm512_storeu_si512 supports unaligned stores.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m512i;
+                let ptr = dest.as_mut_ptr().cast::<__m512i>();
                 _mm512_storeu_si512(ptr, out0);
                 _mm512_storeu_si512(ptr.add(1), out1);
                 _mm512_storeu_si512(ptr.add(2), out2);
@@ -1413,8 +1429,8 @@ unsafe impl U16SimdVec for U16VecAvx512 {
     fn load(d: Self::Descriptor, mem: &[u16]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available
-        // from the safety invariant on `d`.
-        unsafe { Self(_mm512_loadu_si512(mem.as_ptr() as *const _), d) }
+        // from the safety invariant on `d`. _mm512_loadu_si512 supports unaligned loads.
+        unsafe { Self(_mm512_loadu_si512(mem.as_ptr().cast()), d) }
     }
 
     #[inline(always)]
@@ -1427,8 +1443,8 @@ unsafe impl U16SimdVec for U16VecAvx512 {
     fn store(&self, mem: &mut [u16]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available
-        // from the safety invariant on `d`.
-        unsafe { _mm512_storeu_si512(mem.as_mut_ptr() as *mut _, self.0) }
+        // from the safety invariant on `d`. _mm512_storeu_si512 supports unaligned stores.
+        unsafe { _mm512_storeu_si512(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
@@ -1444,9 +1460,9 @@ unsafe impl U16SimdVec for U16VecAvx512 {
             let out0 = _mm512_permutex2var_epi64(lo, idx0, hi);
             let out1 = _mm512_permutex2var_epi64(lo, idx1, hi);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m512i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m512i` is valid. _mm512_storeu_si512 supports unaligned stores.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m512i;
+                let ptr = dest.as_mut_ptr().cast::<__m512i>();
                 _mm512_storeu_si512(ptr, out0);
                 _mm512_storeu_si512(ptr.add(1), out1);
             }
@@ -1529,9 +1545,9 @@ unsafe impl U16SimdVec for U16VecAvx512 {
             let idx_f2 = _mm512_setr_epi64(0, 1, 2, 3, 14, 15, 4, 5);
             let final2 = _mm512_permutex2var_epi64(part_a2, idx_f2, res1);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m512i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m512i` is valid. _mm512_storeu_si512 supports unaligned stores.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m512i;
+                let ptr = dest.as_mut_ptr().cast::<__m512i>();
                 _mm512_storeu_si512(ptr, final0);
                 _mm512_storeu_si512(ptr.add(1), final1);
                 _mm512_storeu_si512(ptr.add(2), final2);
@@ -1586,9 +1602,9 @@ unsafe impl U16SimdVec for U16VecAvx512 {
             let out2 = _mm512_permutex2var_epi64(pair01_13, idx_0, pair23_13);
             let out3 = _mm512_permutex2var_epi64(pair01_13, idx_1, pair23_13);
 
-            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m512i` is valid.
+            // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m512i` is valid. _mm512_storeu_si512 supports unaligned stores.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m512i;
+                let ptr = dest.as_mut_ptr().cast::<__m512i>();
                 _mm512_storeu_si512(ptr, out0);
                 _mm512_storeu_si512(ptr.add(1), out1);
                 _mm512_storeu_si512(ptr.add(2), out2);

--- a/jxl_simd/src/x86_64/sse42.rs
+++ b/jxl_simd/src/x86_64/sse42.rs
@@ -133,7 +133,7 @@ unsafe impl F32SimdVec for F32VecSse42 {
             let hi = _mm_unpackhi_ps(a, b);
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm_storeu_ps(dest_ptr, lo);
                 _mm_storeu_ps(dest_ptr.add(4), hi);
             }
@@ -186,7 +186,7 @@ unsafe impl F32SimdVec for F32VecSse42 {
             // Store the results
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm_storeu_ps(dest_ptr, out0);
                 _mm_storeu_ps(dest_ptr.add(4), out1);
                 _mm_storeu_ps(dest_ptr.add(8), out2);
@@ -229,7 +229,7 @@ unsafe impl F32SimdVec for F32VecSse42 {
 
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<f32>` through `*mut f32` is valid.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut f32;
+                let dest_ptr = dest.as_mut_ptr().cast::<f32>();
                 _mm_storeu_ps(dest_ptr, out0);
                 _mm_storeu_ps(dest_ptr.add(4), out1);
                 _mm_storeu_ps(dest_ptr.add(8), out2);
@@ -577,10 +577,15 @@ unsafe impl F32SimdVec for F32VecSse42 {
             let u16s = _mm_packus_epi32(i32s, i32s);
             let u8s = _mm_packus_epi16(u16s, u16s);
             // Store lower 4 bytes
-            // SAFETY: we checked dest has enough space
+            let val = _mm_cvtsi128_si32(u8s);
+            let bytes = val.to_ne_bytes();
+            // SAFETY:
+            // 1. `src` (bytes.as_ptr()) is valid for 4 bytes as it is a local [u8; 4].
+            // 2. `dst` (dest.as_mut_ptr()) is valid for 4 bytes because dest.len() >= 4.
+            // 3. `src` and `dst` are properly aligned for u8 (alignment 1).
+            // 4. `src` and `dst` do not overlap as `src` is a local stack array.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut i32;
-                *ptr = _mm_cvtsi128_si32(u8s);
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest.as_mut_ptr().cast::<u8>(), 4);
             }
         }
         // SAFETY: sse4.2 is available from the safety invariant on the descriptor.
@@ -600,9 +605,15 @@ unsafe impl F32SimdVec for F32VecSse42 {
             // Pack i32 -> u16 (use same vector twice, take lower half)
             let u16s = _mm_packus_epi32(i32s, i32s);
             // Store lower 8 bytes (4 u16s)
-            // SAFETY: we checked dest has enough space
+            let val = _mm_cvtsi128_si64(u16s);
+            let bytes = val.to_ne_bytes();
+            // SAFETY:
+            // 1. `src` (bytes.as_ptr()) is valid for 8 bytes as it is a local [u8; 8].
+            // 2. `dst` (dest.as_mut_ptr()) is valid for 8 bytes because dest.len() >= 4 and each element is 2 bytes.
+            // 3. `src` and `dst` are properly aligned for u8 (alignment 1).
+            // 4. `src` and `dst` do not overlap as `src` is a local stack array.
             unsafe {
-                _mm_storel_epi64(dest.as_mut_ptr() as *mut __m128i, u16s);
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest.as_mut_ptr().cast::<u8>(), 8);
             }
         }
         // SAFETY: sse4.2 is available from the safety invariant on the descriptor.
@@ -734,7 +745,7 @@ impl I32SimdVec for I32VecSse42 {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available
         // from the safety invariant on `d`.
-        Self(unsafe { _mm_loadu_si128(mem.as_ptr() as *const _) }, d)
+        Self(unsafe { _mm_loadu_si128(mem.as_ptr().cast()) }, d)
     }
 
     #[inline(always)]
@@ -822,16 +833,49 @@ impl I32SimdVec for I32VecSse42 {
         #[inline]
         fn store_u16_impl(v: __m128i, dest: &mut [u16]) {
             assert!(dest.len() >= I32VecSse42::LEN);
-            // Use scalar loop since _mm_packs_epi32 would saturate incorrectly for unsigned values
-            let mut tmp = [0i32; 4];
-            // SAFETY: tmp has 4 elements, matching LEN
-            unsafe { _mm_storeu_si128(tmp.as_mut_ptr() as *mut __m128i, v) };
-            for i in 0..4 {
-                dest[i] = tmp[i] as u16;
+            // Truncate i32 -> u16 using shuffle
+            let shuffle_mask =
+                _mm_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, -1, -1, -1, -1, -1, -1, -1, -1);
+            let u16s = _mm_shuffle_epi8(v, shuffle_mask);
+            let val = _mm_cvtsi128_si64(u16s);
+            let bytes = val.to_ne_bytes();
+            // SAFETY:
+            // 1. `src` (bytes.as_ptr()) is valid for 8 bytes as it is a local [u8; 8].
+            // 2. `dst` (dest.as_mut_ptr()) is valid for 8 bytes because dest.len() >= 4 and each element is 2 bytes.
+            // 3. `src` and `dst` are properly aligned for u8 (alignment 1).
+            // 4. `src` and `dst` do not overlap as `src` is a local stack array.
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest.as_mut_ptr().cast::<u8>(), 8);
             }
         }
         // SAFETY: sse4.2 is available from the safety invariant on the descriptor.
         unsafe { store_u16_impl(self.0, dest) }
+    }
+
+    #[inline(always)]
+    fn store_u8(self, dest: &mut [u8]) {
+        #[target_feature(enable = "sse4.2")]
+        #[inline]
+        fn store_u8_impl(v: __m128i, dest: &mut [u8]) {
+            assert!(dest.len() >= I32VecSse42::LEN);
+            // Truncate i32 -> u8 using shuffle
+            let shuffle_mask =
+                _mm_setr_epi8(0, 4, 8, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+            let u8s = _mm_shuffle_epi8(v, shuffle_mask);
+            // Store lower 4 bytes
+            let val = _mm_cvtsi128_si32(u8s);
+            let bytes = val.to_ne_bytes();
+            // SAFETY:
+            // 1. `src` (bytes.as_ptr()) is valid for 4 bytes as it is a local [u8; 4].
+            // 2. `dst` (dest.as_mut_ptr()) is valid for 4 bytes because dest.len() >= 4.
+            // 3. `src` and `dst` are properly aligned for u8 (alignment 1).
+            // 4. `src` and `dst` do not overlap as `src` is a local stack array.
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest.as_mut_ptr().cast::<u8>(), 4);
+            }
+        }
+        // SAFETY: sse4.2 is available from the safety invariant on the descriptor.
+        unsafe { store_u8_impl(self.0, dest) }
     }
 }
 
@@ -956,7 +1000,7 @@ unsafe impl U8SimdVec for U8VecSse42 {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available
         // from the safety invariant on `d`.
-        unsafe { Self(_mm_loadu_si128(mem.as_ptr() as *const _), d) }
+        unsafe { Self(_mm_loadu_si128(mem.as_ptr().cast()), d) }
     }
 
     #[inline(always)]
@@ -970,7 +1014,7 @@ unsafe impl U8SimdVec for U8VecSse42 {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available
         // from the safety invariant on `self.1`.
-        unsafe { _mm_storeu_si128(mem.as_mut_ptr() as *mut __m128i, self.0) }
+        unsafe { _mm_storeu_si128(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
@@ -983,7 +1027,7 @@ unsafe impl U8SimdVec for U8VecSse42 {
             let hi = _mm_unpackhi_epi8(a, b);
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m128i` is valid.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m128i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m128i>();
                 _mm_storeu_si128(dest_ptr, lo);
                 _mm_storeu_si128(dest_ptr.add(1), hi);
             }
@@ -1040,7 +1084,7 @@ unsafe impl U8SimdVec for U8VecSse42 {
 
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m128i` is valid.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m128i;
+                let ptr = dest.as_mut_ptr().cast::<__m128i>();
                 _mm_storeu_si128(ptr, out0);
                 _mm_storeu_si128(ptr.add(1), out1);
                 _mm_storeu_si128(ptr.add(2), out2);
@@ -1082,7 +1126,7 @@ unsafe impl U8SimdVec for U8VecSse42 {
 
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<u8>` through `*mut __m128i` is valid.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m128i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m128i>();
                 _mm_storeu_si128(dest_ptr, out0);
                 _mm_storeu_si128(dest_ptr.add(1), out1);
                 _mm_storeu_si128(dest_ptr.add(2), out2);
@@ -1109,7 +1153,7 @@ unsafe impl U16SimdVec for U16VecSse42 {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available
         // from the safety invariant on `d`.
-        unsafe { Self(_mm_loadu_si128(mem.as_ptr() as *const _), d) }
+        unsafe { Self(_mm_loadu_si128(mem.as_ptr().cast()), d) }
     }
 
     #[inline(always)]
@@ -1123,7 +1167,7 @@ unsafe impl U16SimdVec for U16VecSse42 {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available
         // from the safety invariant on `self.1`.
-        unsafe { _mm_storeu_si128(mem.as_mut_ptr() as *mut __m128i, self.0) }
+        unsafe { _mm_storeu_si128(mem.as_mut_ptr().cast(), self.0) }
     }
 
     #[inline(always)]
@@ -1136,7 +1180,7 @@ unsafe impl U16SimdVec for U16VecSse42 {
             let hi = _mm_unpackhi_epi16(a, b);
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m128i` is valid.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m128i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m128i>();
                 _mm_storeu_si128(dest_ptr, lo);
                 _mm_storeu_si128(dest_ptr.add(1), hi);
             }
@@ -1193,7 +1237,7 @@ unsafe impl U16SimdVec for U16VecSse42 {
 
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m128i` is valid.
             unsafe {
-                let ptr = dest.as_mut_ptr() as *mut __m128i;
+                let ptr = dest.as_mut_ptr().cast::<__m128i>();
                 _mm_storeu_si128(ptr, out0);
                 _mm_storeu_si128(ptr.add(1), out1);
                 _mm_storeu_si128(ptr.add(2), out2);
@@ -1235,7 +1279,7 @@ unsafe impl U16SimdVec for U16VecSse42 {
 
             // SAFETY: `dest` has enough space and writing to `MaybeUninit<u16>` through `*mut __m128i` is valid.
             unsafe {
-                let dest_ptr = dest.as_mut_ptr() as *mut __m128i;
+                let dest_ptr = dest.as_mut_ptr().cast::<__m128i>();
                 _mm_storeu_si128(dest_ptr, out0);
                 _mm_storeu_si128(dest_ptr.add(1), out1);
                 _mm_storeu_si128(dest_ptr.add(2), out2);


### PR DESCRIPTION
Also fixes some potential writes-through-unaligned-pointers, and consistently uses `.cast()` instead of `as *const` / `as *mut`.