### PR TITLE
Fix: `RowBuffer::new_filled` does not fill padding bytes, causing transparent seams (grid lines) when rendering alpha

### DIFF
--- a/jxl/src/render/low_memory_pipeline/row_buffers.rs
+++ b/jxl/src/render/low_memory_pipeline/row_buffers.rs
@@ -56,11 +56,13 @@ impl RowBuffer {
     pub fn new_filled(data_type: DataTypeTag, row_len: usize, fill_pattern: &[u8]) -> Result<Self> {
         let mut result = Self::new(data_type, 0, 0, row_len)?;
         let row_bytes: &mut [u8] = result.get_row_mut(0);
-        let start = Self::x0_offset::<u8>();
-        let end = start + row_len * fill_pattern.len();
-        for (i, byte) in row_bytes[start..end].iter_mut().enumerate() {
+
+        // Fill the *entire* allocated row, including the padding on both sides,
+        // so cross-group border sampling doesn't read zeros (transparent alpha).
+        for (i, byte) in row_bytes.iter_mut().enumerate() {
             *byte = fill_pattern[i % fill_pattern.len()];
         }
+
         Ok(result)
     }
 


### PR DESCRIPTION
I have signed the individual Google CLA for myself, "Cody Neiman".

---

When decoding an image without an alpha channel and requesting an output format that *does* contain alpha (e.g. `JxlPixelFormat::rgba8()`), the pipeline utilizes `fill_opaque_alpha` to synthesize an opaque alpha channel. 

However, `RowBuffer::new_filled` only fills the central `row_len` bytes and leaves the padding/border cachelines initialized to `0`. When stages overlap the group boundaries during stitching, they read `0` from the alpha channel padding. This results in fully transparent seams forming a grid at 256x256 group boundaries.

Therefore, in `jxl/src/render/low_memory_pipeline/row_buffers.rs`, `new_filled` should iterate over the entire allocated `row_bytes` slice, rather than restricting it to `[start..end]`.

---

Before:

<img width="842" height="630" alt="image" src="https://github.com/user-attachments/assets/4397716a-946a-42d2-9ffb-ee1e83681b04" />

After:

<img width="842" height="630" alt="image" src="https://github.com/user-attachments/assets/caa2ab23-2cfb-4a50-91e9-c19d5ef8969d" />
