### PR TITLE
feat: simd128 support for wasm32

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasip1]
+runner = "wasmtime"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.wasm32-wasip1]
-runner = "wasmtime --dir=. --dir=.."
+runner = "wasmtime --dir=. --dir=.. --env ARBTEST_BUDGET_MS"
 rustflags = ["-C", "target-feature=+simd128,+relaxed-simd"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.wasm32-wasip1]
-runner = "wasmtime"
+runner = "wasmtime --dir=."
 rustflags = ["-C", "target-feature=+simd128,+relaxed-simd"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.wasm32-wasip1]
-runner = "wasmtime --dir=."
+runner = "wasmtime --dir=. --dir=.."
 rustflags = ["-C", "target-feature=+simd128,+relaxed-simd"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [target.wasm32-wasip1]
 runner = "wasmtime"
+rustflags = ["-C", "target-feature=+simd128,+relaxed-simd"]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -100,6 +100,9 @@ jobs:
             simd: avx512
           - os: ubuntu-24.04-arm
             simd: neon
+          - os: ubuntu-latest
+            simd: simd128
+            target: wasm32-wasip1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -108,16 +111,25 @@ jobs:
 
       - name: Install latest rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install wasmtime
+        if: ${{ matrix.target == 'wasm32-wasip1' }}
+        uses: bytecodealliance/actions/wasmtime/setup@v1
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.8.0
         with:
           prefix-key: ${{ matrix.os }}-test-${{ matrix.simd }}
 
-
       - name: Tests with SIMD feature ${{ matrix.simd }}
-        if: ${{ matrix.simd != 'none' }}
+        if: ${{ matrix.simd != 'none' && !matrix.target }}
         run: cargo test --release --all --no-fail-fast --no-default-features --features ${{ matrix.simd }}
+
+      - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
+        if: ${{ matrix.target == 'wasm32-wasip1' }}
+        run: cargo test --release -p jxl_simd --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }}
 
       - name: Tests with no features
         if: ${{ matrix.simd == 'none' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -129,7 +129,11 @@ jobs:
 
       - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
         if: ${{ matrix.target == 'wasm32-wasip1' }}
-        run: cargo test --release -p jxl_simd --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }}
+        run: |
+          cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} --
+          --skip tirr_photo # 4GiB wasm32 memory limit
+          --skip huge_image # 4GiB wasm32 memory limit
+          --skip fuzzer_smallbuffer # only panic=abort is supported in stable toolchain
 
       - name: Tests with no features
         if: ${{ matrix.simd == 'none' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -103,6 +103,11 @@ jobs:
           - os: ubuntu-latest
             simd: simd128
             target: wasm32-wasip1
+            wasm_features: +simd128,+relaxed-simd
+          - os: ubuntu-latest
+            simd: simd128
+            target: wasm32-wasip1
+            wasm_features: +simd128
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -127,8 +132,10 @@ jobs:
         if: ${{ matrix.simd != 'none' && !matrix.target }}
         run: cargo test --release --all --no-fail-fast --no-default-features --features ${{ matrix.simd }}
 
-      - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
+      - name: Tests with SIMD feature ${{ matrix.simd }} (wasm ${{ matrix.wasm_features }})
         if: ${{ matrix.target == 'wasm32-wasip1' }}
+        env:
+          RUSTFLAGS: -C target-feature=${{ matrix.wasm_features }}
         run: |
           cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} -- \
             --skip tirr_photo \

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -130,10 +130,10 @@ jobs:
       - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
         if: ${{ matrix.target == 'wasm32-wasip1' }}
         run: |
-          cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} --
-          --skip tirr_photo # 4GiB wasm32 memory limit
-          --skip huge_image # 4GiB wasm32 memory limit
-          --skip fuzzer_smallbuffer # only panic=abort is supported in stable toolchain
+          cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} -- \
+            --skip tirr_photo \
+            --skip huge_image \
+            --skip fuzzer_smallbuffer
 
       - name: Tests with no features
         if: ${{ matrix.simd == 'none' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -139,7 +139,11 @@ jobs:
 
       - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
         if: ${{ matrix.target == 'wasm32-wasip1' }}
-        run: cargo test --release -p jxl_simd --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }}
+        run: |
+          cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} --
+          --skip tirr_photo # 4GiB wasm32 memory limit
+          --skip huge_image # 4GiB wasm32 memory limit
+          --skip fuzzer_smallbuffer # only panic=abort is supported in stable toolchain
 
       - name: Tests with no features
         if: ${{ matrix.simd == 'none' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -140,10 +140,10 @@ jobs:
       - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
         if: ${{ matrix.target == 'wasm32-wasip1' }}
         run: |
-          cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} --
-          --skip tirr_photo # 4GiB wasm32 memory limit
-          --skip huge_image # 4GiB wasm32 memory limit
-          --skip fuzzer_smallbuffer # only panic=abort is supported in stable toolchain
+          cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} -- \
+            --skip tirr_photo \
+            --skip huge_image \
+            --skip fuzzer_smallbuffer
 
       - name: Tests with no features
         if: ${{ matrix.simd == 'none' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,6 +109,9 @@ jobs:
             simd: avx512
           - os: ubuntu-24.04-arm
             simd: neon
+          - os: ubuntu-latest
+            simd: simd128
+            target: wasm32-wasip1
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -118,16 +121,25 @@ jobs:
 
       - name: Install latest rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install wasmtime
+        if: ${{ matrix.target == 'wasm32-wasip1' }}
+        uses: bytecodealliance/actions/wasmtime/setup@v1
 
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           prefix-key: ${{ matrix.os }}-test-${{ matrix.simd }}
 
-
       - name: Tests with SIMD feature ${{ matrix.simd }}
-        if: ${{ matrix.simd != 'none' }}
+        if: ${{ matrix.simd != 'none' && !matrix.target }}
         run: cargo test --release --all --no-fail-fast --no-default-features --features ${{ matrix.simd }}
+
+      - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
+        if: ${{ matrix.target == 'wasm32-wasip1' }}
+        run: cargo test --release -p jxl_simd --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }}
 
       - name: Tests with no features
         if: ${{ matrix.simd == 'none' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -112,6 +112,11 @@ jobs:
           - os: ubuntu-latest
             simd: simd128
             target: wasm32-wasip1
+            wasm_features: +simd128,+relaxed-simd
+          - os: ubuntu-latest
+            simd: simd128
+            target: wasm32-wasip1
+            wasm_features: +simd128
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -137,8 +142,10 @@ jobs:
         if: ${{ matrix.simd != 'none' && !matrix.target }}
         run: cargo test --release --all --no-fail-fast --no-default-features --features ${{ matrix.simd }}
 
-      - name: Tests with SIMD feature ${{ matrix.simd }} (wasm)
+      - name: Tests with SIMD feature ${{ matrix.simd }} (wasm ${{ matrix.wasm_features }})
         if: ${{ matrix.target == 'wasm32-wasip1' }}
+        env:
+          RUSTFLAGS: -C target-feature=${{ matrix.wasm_features }}
         run: |
           cargo test --release --workspace --exclude jxl_cli --exclude jxl_cms --no-fail-fast --no-default-features --features ${{ matrix.simd }} --target ${{ matrix.target }} -- \
             --skip tirr_photo \

--- a/jxl/Cargo.toml
+++ b/jxl/Cargo.toml
@@ -39,6 +39,7 @@ sse42 = ["jxl_simd/sse42"]
 avx = ["jxl_simd/avx"]
 avx512 = ["jxl_simd/avx512"]
 neon = ["jxl_simd/neon"]
+simd128 = ["jxl_simd/simd128"]
 
 [lints]
 workspace = true

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -36,6 +36,7 @@ sse42 = ["jxl/sse42"]
 avx = ["jxl/avx"]
 avx512 = ["jxl/avx512"]
 neon = ["jxl/neon"]
+simd128 = ["jxl/simd128"]
 
 [lints]
 workspace = true

--- a/jxl_macros/src/lib.rs
+++ b/jxl_macros/src/lib.rs
@@ -712,11 +712,10 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
     use syn::Ident;
 
     let fn_name = parse_macro_input!(input as Ident);
-    let root_test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+    let jxl_crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
-        .join("jxl")
-        .join("resources")
-        .join("test");
+        .join("jxl");
+    let root_test_dir = jxl_crate_dir.join("resources").join("test");
     let conformance_test_dir = root_test_dir.join("conformance_test_images");
 
     let mut tests = vec![];
@@ -726,7 +725,8 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
             let entry = entry.unwrap();
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "jxl") {
-                let pathname = path.to_string_lossy();
+                // Use relative path so tests work in WASM sandbox
+                let pathname = path.strip_prefix(&jxl_crate_dir).unwrap().to_string_lossy();
                 let relative_path = path
                     .strip_prefix(&test_dir)
                     .unwrap()

--- a/jxl_macros/src/lib.rs
+++ b/jxl_macros/src/lib.rs
@@ -712,10 +712,11 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
     use syn::Ident;
 
     let fn_name = parse_macro_input!(input as Ident);
-    let jxl_crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+    let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
-        .join("jxl");
-    let root_test_dir = jxl_crate_dir.join("resources").join("test");
+        .canonicalize()
+        .unwrap();
+    let root_test_dir = workspace_dir.join("jxl").join("resources").join("test");
     let conformance_test_dir = root_test_dir.join("conformance_test_images");
 
     let mut tests = vec![];
@@ -725,8 +726,6 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
             let entry = entry.unwrap();
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "jxl") {
-                // Use relative path so tests work in WASM sandbox
-                let pathname = path.strip_prefix(&jxl_crate_dir).unwrap().to_string_lossy();
                 let relative_path = path
                     .strip_prefix(&test_dir)
                     .unwrap()
@@ -738,10 +737,15 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
                     relative_path.strip_suffix(".jxl").unwrap()
                 );
                 let test_name = Ident::new(&test_name, fn_name.span());
+                // Path relative to workspace root.
+                let rel_path = Path::new("..")
+                    .join(path.strip_prefix(&workspace_dir).unwrap())
+                    .to_string_lossy()
+                    .into_owned();
                 tests.push(quote! {
                     #[test]
                     fn #test_name() {
-                        #fn_name(&Path::new(#pathname)).unwrap()
+                        #fn_name(&Path::new(#rel_path)).unwrap()
                     }
                 });
             }

--- a/jxl_macros/src/lib.rs
+++ b/jxl_macros/src/lib.rs
@@ -712,10 +712,11 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
     use syn::Ident;
 
     let fn_name = parse_macro_input!(input as Ident);
-    let jxl_crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+    let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
-        .join("jxl");
-    let root_test_dir = jxl_crate_dir.join("resources").join("test");
+        .canonicalize()
+        .unwrap();
+    let root_test_dir = workspace_dir.join("jxl").join("resources").join("test");
     let conformance_test_dir = root_test_dir.join("conformance_test_images");
 
     let mut tests = vec![];
@@ -725,8 +726,6 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
             let entry = entry.unwrap();
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "jxl") {
-                // Use relative path so tests work in WASM sandbox
-                let pathname = path.strip_prefix(&jxl_crate_dir).unwrap().to_string_lossy();
                 let relative_path = path
                     .strip_prefix(&test_dir)
                     .unwrap()
@@ -739,10 +738,15 @@ pub fn for_each_test_file(input: TokenStream) -> TokenStream {
                 )
                 .replace(|c: char| !c.is_alphanumeric() && c != '_', "_");
                 let test_name = Ident::new(&test_name, fn_name.span());
+                // Path relative to workspace root.
+                let rel_path = Path::new("..")
+                    .join(path.strip_prefix(&workspace_dir).unwrap())
+                    .to_string_lossy()
+                    .into_owned();
                 tests.push(quote! {
                     #[test]
                     fn #test_name() {
-                        #fn_name(&Path::new(#pathname)).unwrap()
+                        #fn_name(&Path::new(#rel_path)).unwrap()
                     }
                 });
             }

--- a/jxl_simd/Cargo.toml
+++ b/jxl_simd/Cargo.toml
@@ -17,11 +17,12 @@ arbtest = "0.3.2"
 paste = "1.0.15"
 
 [features]
-all-simd = ["sse42", "avx", "avx512", "neon"]
+all-simd = ["sse42", "avx", "avx512", "neon", "simd128"]
 sse42 = []
 avx = ["sse42"]
 avx512 = ["avx"]
 neon = []
+simd128 = []
 
 [lints]
 workspace = true

--- a/jxl_simd/src/float16.rs
+++ b/jxl_simd/src/float16.rs
@@ -105,7 +105,7 @@ impl f16 {
             } else if unbiased < -14 {
                 // Denormal f16
                 let shift = (-14 - unbiased) as u32;
-                let m = ((mant | 0x0080_0000) >> (shift + 14)) as u16;
+                let m = ((mant | 0x0080_0000) >> (shift + 13)) as u16;
                 (sign << 15) | m
             } else if unbiased > 15 {
                 // Overflow to infinity

--- a/jxl_simd/src/float16.rs
+++ b/jxl_simd/src/float16.rs
@@ -99,13 +99,22 @@ impl f16 {
         } else {
             let unbiased = exp - 127;
 
-            if unbiased < -24 {
+            if unbiased < -25 {
                 // Too small, underflow to zero
                 sign << 15
             } else if unbiased < -14 {
                 // Denormal f16
-                let shift = (-14 - unbiased) as u32;
-                let m = ((mant | 0x0080_0000) >> (shift + 13)) as u16;
+                let shift = (-14 - unbiased + 13) as u32;
+                let full = mant | 0x0080_0000;
+                let m = (full >> shift) as u16;
+                // Round to nearest, ties to even
+                let round_bit = (full >> (shift - 1)) & 1;
+                let sticky = full & ((1 << (shift - 1)) - 1);
+                let m = if round_bit == 1 && (sticky != 0 || (m & 1) == 1) {
+                    m + 1
+                } else {
+                    m
+                };
                 (sign << 15) | m
             } else if unbiased > 15 {
                 // Overflow to infinity
@@ -308,5 +317,13 @@ mod tests {
         let h = f16::from_bits(0x1234);
         assert_eq!(h.to_le_bytes(), [0x34, 0x12]);
         assert_eq!(h.to_be_bytes(), [0x12, 0x34]);
+    }
+
+    #[test]
+    fn test_subnormal_rounding_near_smallest() {
+        // 2^-25 + 1 ULP should round to the smallest subnormal, not flush to zero.
+        let v = f32::from_bits(0x33000001);
+        assert_eq!(f16::from_f32(v).to_bits(), 0x0001);
+        assert_eq!(f16::from_f32(-v).to_bits(), 0x8001);
     }
 }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -20,6 +20,9 @@ mod x86_64;
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 
+#[cfg(target_arch = "wasm32")]
+mod wasm32;
+
 pub mod float16;
 pub mod scalar;
 
@@ -34,6 +37,9 @@ pub use x86_64::sse42::Sse42Descriptor;
 
 #[cfg(all(target_arch = "aarch64", feature = "neon"))]
 pub use aarch64::neon::NeonDescriptor;
+
+#[cfg(all(target_arch = "wasm32", feature = "simd128"))]
+pub use wasm32::simd128::Simd128Descriptor;
 
 pub use scalar::ScalarDescriptor;
 

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -1530,4 +1530,153 @@ mod test {
         }
     }
     test_all_instruction_sets!(test_store_u8);
+
+    fn test_f16_load_roundtrip<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let values: &[f32] = &[0.0, 1.0, -1.0, 0.5, 100.0, -42.5, 65504.0, 0.001];
+        for chunk in values.chunks(len) {
+            let mut input = vec![0.0f32; len];
+            input[..chunk.len()].copy_from_slice(chunk);
+            let v = D::F32Vec::load(d, &input);
+            let mut f16_buf = vec![0u16; len];
+            v.store_f16_bits(&mut f16_buf);
+            let back = D::F32Vec::load_f16_bits(d, &f16_buf);
+            let mut output = vec![0.0f32; len];
+            back.store(&mut output);
+            for i in 0..chunk.len() {
+                let expected = input[i];
+                if expected == 0.0 {
+                    assert_eq!(
+                        output[i].to_bits() & 0x7FFF_FFFF,
+                        0,
+                        "zero not preserved at {i}"
+                    );
+                } else {
+                    let rel_err = ((expected - output[i]) / expected).abs();
+                    assert!(
+                        rel_err < 0.001,
+                        "roundtrip failed at {i}: {expected} -> {}",
+                        output[i]
+                    );
+                }
+            }
+        }
+    }
+    test_all_instruction_sets!(test_f16_load_roundtrip);
+
+    fn test_f16_load_special_values<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let cases: &[(u16, f32)] = &[
+            (0x0001, 5.960_464_5e-8),    // smallest positive subnormal
+            (0x03FF, 6.097_555e-5),      // largest positive subnormal
+            (0x8001, -5.960_464_5e-8),   // smallest negative subnormal
+            (0x7C00, f32::INFINITY),     // +inf
+            (0xFC00, f32::NEG_INFINITY), // -inf
+            (0x7C01, f32::NAN),          // NaN
+            (0x0000, 0.0),               // +zero
+        ];
+        for chunk in cases.chunks(len) {
+            let mut bits = vec![0u16; len];
+            for (i, &(b, _)) in chunk.iter().enumerate() {
+                bits[i] = b;
+            }
+            let v = D::F32Vec::load_f16_bits(d, &bits);
+            let mut output = vec![0.0f32; len];
+            v.store(&mut output);
+            for (i, &(_, expected)) in chunk.iter().enumerate() {
+                if expected.is_nan() {
+                    assert!(output[i].is_nan(), "expected NaN at {i}, got {}", output[i]);
+                } else if expected.is_infinite() {
+                    assert_eq!(output[i], expected, "inf mismatch at {i}");
+                } else if expected == 0.0 {
+                    assert_eq!(output[i], 0.0, "zero mismatch at {i}");
+                } else {
+                    assert!(
+                        (output[i] - expected).abs() < expected.abs() * 1e-3,
+                        "subnormal mismatch at {i}: expected {expected}, got {}",
+                        output[i],
+                    );
+                }
+            }
+        }
+    }
+    test_all_instruction_sets!(test_f16_load_special_values);
+
+    fn test_f16_store_roundtrip<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let known: &[(f32, u16)] = &[(1.0, 0x3C00), (-2.0, 0xC000), (0.5, 0x3800), (0.0, 0x0000)];
+        let mut input = vec![0.0f32; len];
+        let mut expected_bits = vec![0u16; len];
+        for i in 0..len.min(known.len()) {
+            input[i] = known[i].0;
+            expected_bits[i] = known[i].1;
+        }
+        let v = D::F32Vec::load(d, &input);
+        let mut output = vec![0u16; len];
+        v.store_f16_bits(&mut output);
+        for i in 0..len.min(known.len()) {
+            assert_eq!(
+                output[i], expected_bits[i],
+                "store_f16_bits wrong at {i}: input {}, expected 0x{:04X}, got 0x{:04X}",
+                input[i], expected_bits[i], output[i],
+            );
+        }
+    }
+    test_all_instruction_sets!(test_f16_store_roundtrip);
+
+    fn test_f16_store_special_values<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        // (f32 input, expected f16 bits)
+        let cases: &[(f32, u16)] = &[
+            (5.960_464_5e-8, 0x0001),    // smallest positive subnormal
+            (6.097_555e-5, 0x03FF),      // largest positive subnormal
+            (-5.960_464_5e-8, 0x8001),   // smallest negative subnormal
+            (f32::INFINITY, 0x7C00),     // +inf
+            (f32::NEG_INFINITY, 0xFC00), // -inf
+            (100000.0, 0x7C00),          // overflow to inf
+            (65504.0, 0x7BFF),           // max normal f16
+        ];
+        for chunk in cases.chunks(len) {
+            let mut input = vec![0.0f32; len];
+            for (i, &(v, _)) in chunk.iter().enumerate() {
+                input[i] = v;
+            }
+            let v = D::F32Vec::load(d, &input);
+            let mut output = vec![0u16; len];
+            v.store_f16_bits(&mut output);
+            for (i, &(inp, expected)) in chunk.iter().enumerate() {
+                assert_eq!(
+                    output[i], expected,
+                    "store_f16_bits special at {i}: input {inp}, expected 0x{expected:04X}, got 0x{:04X}",
+                    output[i],
+                );
+            }
+        }
+    }
+    test_all_instruction_sets!(test_f16_store_special_values);
+
+    fn test_f16_underflow_to_zero<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let mut input = vec![0.0f32; len];
+        input[0] = 1e-8;
+        if len > 1 {
+            input[1] = -1e-8;
+        }
+        if len > 2 {
+            input[2] = 1e-10;
+        }
+        let v = D::F32Vec::load(d, &input);
+        let mut f16_buf = vec![0u16; len];
+        v.store_f16_bits(&mut f16_buf);
+        // Magnitude bits should be zero (sign may be preserved)
+        for i in 0..3.min(len) {
+            assert_eq!(
+                f16_buf[i] & 0x7FFF,
+                0,
+                "underflow not flushed to zero at {i}: got 0x{:04X}",
+                f16_buf[i],
+            );
+        }
+    }
+    test_all_instruction_sets!(test_f16_underflow_to_zero);
 }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -1635,6 +1635,7 @@ mod test {
             (f32::NEG_INFINITY, 0xFC00), // -inf
             (100000.0, 0x7C00),          // overflow to inf
             (65504.0, 0x7BFF),           // max normal f16
+            (f32::NAN, 0x7E00),          // NaN preserved
         ];
         for chunk in cases.chunks(len) {
             let mut input = vec![0.0f32; len];
@@ -1678,4 +1679,59 @@ mod test {
         }
     }
     test_all_instruction_sets!(test_f16_underflow_to_zero);
+
+    fn compare_f16_bits(s: u16, m: u16) {
+        let (s_exp, m_exp) = ((s >> 10) & 0x1F, (m >> 10) & 0x1F);
+        if s_exp == 0x1F || m_exp == 0x1F {
+            assert_eq!(s_exp, m_exp, "inf/nan: scalar 0x{s:04X}, simd 0x{m:04X}");
+            return;
+        }
+        let (s_mag, m_mag) = (s & 0x7FFF, m & 0x7FFF);
+        let diff_mag = (s_mag as i32 - m_mag as i32).unsigned_abs();
+        assert!(diff_mag <= 1, "magnitude: scalar 0x{s:04X}, simd 0x{m:04X}");
+        if s_mag != 0 || m_mag != 0 {
+            let (s_sign, m_sign) = (s & 0x8000, m & 0x8000);
+            assert_eq!(s_sign, m_sign, "sign: scalar 0x{s:04X}, simd 0x{m:04X}");
+        }
+    }
+
+    fn test_f16_store_scalar_equivalent<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        arbtest::arbtest(|u| {
+            let mut input = vec![0.0f32; len];
+            for v in input.iter_mut() {
+                *v = f32::from_bits(u.arbitrary::<u32>()?);
+            }
+            let mut simd_bits = vec![0u16; len];
+            D::F32Vec::load(d, &input).store_f16_bits(&mut simd_bits);
+            for i in 0..len {
+                compare_f16_bits(crate::f16::from_f32(input[i]).to_bits(), simd_bits[i]);
+            }
+            Ok(())
+        });
+    }
+    test_all_instruction_sets!(test_f16_store_scalar_equivalent);
+
+    fn test_f16_load_scalar_equivalent<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        arbtest::arbtest(|u| {
+            let mut input = vec![0u16; len];
+            for v in input.iter_mut() {
+                *v = u.arbitrary::<u16>()?;
+            }
+            let mut simd_f32 = vec![0.0f32; len];
+            D::F32Vec::load_f16_bits(d, &input).store(&mut simd_f32);
+            for i in 0..len {
+                let (s, m) = (crate::f16::from_bits(input[i]).to_f32(), simd_f32[i]);
+                if s.is_nan() {
+                    assert!(m.is_nan(), "expected NaN for 0x{:04X}, got {m}", input[i]);
+                    continue;
+                }
+                let (s_b, m_b) = (s.to_bits(), m.to_bits());
+                assert_eq!(s_b, m_b, "load 0x{:04X}: scalar {s}, simd {m}", input[i]);
+            }
+            Ok(())
+        });
+    }
+    test_all_instruction_sets!(test_f16_load_scalar_equivalent);
 }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -1669,12 +1669,11 @@ mod test {
         let mut f16_buf = vec![0u16; len];
         v.store_f16_bits(&mut f16_buf);
         // Magnitude bits should be zero (sign may be preserved)
-        for i in 0..3.min(len) {
+        for (i, &bits) in f16_buf.iter().enumerate().take(3.min(len)) {
             assert_eq!(
-                f16_buf[i] & 0x7FFF,
+                bits & 0x7FFF,
                 0,
-                "underflow not flushed to zero at {i}: got 0x{:04X}",
-                f16_buf[i],
+                "underflow not flushed to zero at {i}: got 0x{bits:04X}",
             );
         }
     }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -19,6 +19,9 @@ mod x86_64;
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 
+#[cfg(target_arch = "wasm32")]
+mod wasm32;
+
 pub mod float16;
 pub mod scalar;
 
@@ -33,6 +36,9 @@ pub use x86_64::sse42::Sse42Descriptor;
 
 #[cfg(all(target_arch = "aarch64", feature = "neon"))]
 pub use aarch64::neon::NeonDescriptor;
+
+#[cfg(all(target_arch = "wasm32", feature = "simd128"))]
+pub use wasm32::simd128::Simd128Descriptor;
 
 pub use scalar::ScalarDescriptor;
 

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -1376,4 +1376,153 @@ mod test {
         }
     }
     test_all_instruction_sets!(test_store_u8);
+
+    fn test_f16_load_roundtrip<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let values: &[f32] = &[0.0, 1.0, -1.0, 0.5, 100.0, -42.5, 65504.0, 0.001];
+        for chunk in values.chunks(len) {
+            let mut input = vec![0.0f32; len];
+            input[..chunk.len()].copy_from_slice(chunk);
+            let v = D::F32Vec::load(d, &input);
+            let mut f16_buf = vec![0u16; len];
+            v.store_f16_bits(&mut f16_buf);
+            let back = D::F32Vec::load_f16_bits(d, &f16_buf);
+            let mut output = vec![0.0f32; len];
+            back.store(&mut output);
+            for i in 0..chunk.len() {
+                let expected = input[i];
+                if expected == 0.0 {
+                    assert_eq!(
+                        output[i].to_bits() & 0x7FFF_FFFF,
+                        0,
+                        "zero not preserved at {i}"
+                    );
+                } else {
+                    let rel_err = ((expected - output[i]) / expected).abs();
+                    assert!(
+                        rel_err < 0.001,
+                        "roundtrip failed at {i}: {expected} -> {}",
+                        output[i]
+                    );
+                }
+            }
+        }
+    }
+    test_all_instruction_sets!(test_f16_load_roundtrip);
+
+    fn test_f16_load_special_values<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let cases: &[(u16, f32)] = &[
+            (0x0001, 5.960_464_5e-8),    // smallest positive subnormal
+            (0x03FF, 6.097_555e-5),      // largest positive subnormal
+            (0x8001, -5.960_464_5e-8),   // smallest negative subnormal
+            (0x7C00, f32::INFINITY),     // +inf
+            (0xFC00, f32::NEG_INFINITY), // -inf
+            (0x7C01, f32::NAN),          // NaN
+            (0x0000, 0.0),               // +zero
+        ];
+        for chunk in cases.chunks(len) {
+            let mut bits = vec![0u16; len];
+            for (i, &(b, _)) in chunk.iter().enumerate() {
+                bits[i] = b;
+            }
+            let v = D::F32Vec::load_f16_bits(d, &bits);
+            let mut output = vec![0.0f32; len];
+            v.store(&mut output);
+            for (i, &(_, expected)) in chunk.iter().enumerate() {
+                if expected.is_nan() {
+                    assert!(output[i].is_nan(), "expected NaN at {i}, got {}", output[i]);
+                } else if expected.is_infinite() {
+                    assert_eq!(output[i], expected, "inf mismatch at {i}");
+                } else if expected == 0.0 {
+                    assert_eq!(output[i], 0.0, "zero mismatch at {i}");
+                } else {
+                    assert!(
+                        (output[i] - expected).abs() < expected.abs() * 1e-3,
+                        "subnormal mismatch at {i}: expected {expected}, got {}",
+                        output[i],
+                    );
+                }
+            }
+        }
+    }
+    test_all_instruction_sets!(test_f16_load_special_values);
+
+    fn test_f16_store_roundtrip<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let known: &[(f32, u16)] = &[(1.0, 0x3C00), (-2.0, 0xC000), (0.5, 0x3800), (0.0, 0x0000)];
+        let mut input = vec![0.0f32; len];
+        let mut expected_bits = vec![0u16; len];
+        for i in 0..len.min(known.len()) {
+            input[i] = known[i].0;
+            expected_bits[i] = known[i].1;
+        }
+        let v = D::F32Vec::load(d, &input);
+        let mut output = vec![0u16; len];
+        v.store_f16_bits(&mut output);
+        for i in 0..len.min(known.len()) {
+            assert_eq!(
+                output[i], expected_bits[i],
+                "store_f16_bits wrong at {i}: input {}, expected 0x{:04X}, got 0x{:04X}",
+                input[i], expected_bits[i], output[i],
+            );
+        }
+    }
+    test_all_instruction_sets!(test_f16_store_roundtrip);
+
+    fn test_f16_store_special_values<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        // (f32 input, expected f16 bits)
+        let cases: &[(f32, u16)] = &[
+            (5.960_464_5e-8, 0x0001),    // smallest positive subnormal
+            (6.097_555e-5, 0x03FF),      // largest positive subnormal
+            (-5.960_464_5e-8, 0x8001),   // smallest negative subnormal
+            (f32::INFINITY, 0x7C00),     // +inf
+            (f32::NEG_INFINITY, 0xFC00), // -inf
+            (100000.0, 0x7C00),          // overflow to inf
+            (65504.0, 0x7BFF),           // max normal f16
+        ];
+        for chunk in cases.chunks(len) {
+            let mut input = vec![0.0f32; len];
+            for (i, &(v, _)) in chunk.iter().enumerate() {
+                input[i] = v;
+            }
+            let v = D::F32Vec::load(d, &input);
+            let mut output = vec![0u16; len];
+            v.store_f16_bits(&mut output);
+            for (i, &(inp, expected)) in chunk.iter().enumerate() {
+                assert_eq!(
+                    output[i], expected,
+                    "store_f16_bits special at {i}: input {inp}, expected 0x{expected:04X}, got 0x{:04X}",
+                    output[i],
+                );
+            }
+        }
+    }
+    test_all_instruction_sets!(test_f16_store_special_values);
+
+    fn test_f16_underflow_to_zero<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        let mut input = vec![0.0f32; len];
+        input[0] = 1e-8;
+        if len > 1 {
+            input[1] = -1e-8;
+        }
+        if len > 2 {
+            input[2] = 1e-10;
+        }
+        let v = D::F32Vec::load(d, &input);
+        let mut f16_buf = vec![0u16; len];
+        v.store_f16_bits(&mut f16_buf);
+        // Magnitude bits should be zero (sign may be preserved)
+        for i in 0..3.min(len) {
+            assert_eq!(
+                f16_buf[i] & 0x7FFF,
+                0,
+                "underflow not flushed to zero at {i}: got 0x{:04X}",
+                f16_buf[i],
+            );
+        }
+    }
+    test_all_instruction_sets!(test_f16_underflow_to_zero);
 }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -1481,6 +1481,7 @@ mod test {
             (f32::NEG_INFINITY, 0xFC00), // -inf
             (100000.0, 0x7C00),          // overflow to inf
             (65504.0, 0x7BFF),           // max normal f16
+            (f32::NAN, 0x7E00),          // NaN preserved
         ];
         for chunk in cases.chunks(len) {
             let mut input = vec![0.0f32; len];
@@ -1524,4 +1525,59 @@ mod test {
         }
     }
     test_all_instruction_sets!(test_f16_underflow_to_zero);
+
+    fn compare_f16_bits(s: u16, m: u16) {
+        let (s_exp, m_exp) = ((s >> 10) & 0x1F, (m >> 10) & 0x1F);
+        if s_exp == 0x1F || m_exp == 0x1F {
+            assert_eq!(s_exp, m_exp, "inf/nan: scalar 0x{s:04X}, simd 0x{m:04X}");
+            return;
+        }
+        let (s_mag, m_mag) = (s & 0x7FFF, m & 0x7FFF);
+        let diff_mag = (s_mag as i32 - m_mag as i32).unsigned_abs();
+        assert!(diff_mag <= 1, "magnitude: scalar 0x{s:04X}, simd 0x{m:04X}");
+        if s_mag != 0 || m_mag != 0 {
+            let (s_sign, m_sign) = (s & 0x8000, m & 0x8000);
+            assert_eq!(s_sign, m_sign, "sign: scalar 0x{s:04X}, simd 0x{m:04X}");
+        }
+    }
+
+    fn test_f16_store_scalar_equivalent<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        arbtest::arbtest(|u| {
+            let mut input = vec![0.0f32; len];
+            for v in input.iter_mut() {
+                *v = f32::from_bits(u.arbitrary::<u32>()?);
+            }
+            let mut simd_bits = vec![0u16; len];
+            D::F32Vec::load(d, &input).store_f16_bits(&mut simd_bits);
+            for i in 0..len {
+                compare_f16_bits(crate::f16::from_f32(input[i]).to_bits(), simd_bits[i]);
+            }
+            Ok(())
+        });
+    }
+    test_all_instruction_sets!(test_f16_store_scalar_equivalent);
+
+    fn test_f16_load_scalar_equivalent<D: SimdDescriptor>(d: D) {
+        let len = D::F32Vec::LEN;
+        arbtest::arbtest(|u| {
+            let mut input = vec![0u16; len];
+            for v in input.iter_mut() {
+                *v = u.arbitrary::<u16>()?;
+            }
+            let mut simd_f32 = vec![0.0f32; len];
+            D::F32Vec::load_f16_bits(d, &input).store(&mut simd_f32);
+            for i in 0..len {
+                let (s, m) = (crate::f16::from_bits(input[i]).to_f32(), simd_f32[i]);
+                if s.is_nan() {
+                    assert!(m.is_nan(), "expected NaN for 0x{:04X}, got {m}", input[i]);
+                    continue;
+                }
+                let (s_b, m_b) = (s.to_bits(), m.to_bits());
+                assert_eq!(s_b, m_b, "load 0x{:04X}: scalar {s}, simd {m}", input[i]);
+            }
+            Ok(())
+        });
+    }
+    test_all_instruction_sets!(test_f16_load_scalar_equivalent);
 }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -1515,12 +1515,11 @@ mod test {
         let mut f16_buf = vec![0u16; len];
         v.store_f16_bits(&mut f16_buf);
         // Magnitude bits should be zero (sign may be preserved)
-        for i in 0..3.min(len) {
+        for (i, &bits) in f16_buf.iter().enumerate().take(3.min(len)) {
             assert_eq!(
-                f16_buf[i] & 0x7FFF,
+                bits & 0x7FFF,
                 0,
-                "underflow not flushed to zero at {i}: got 0x{:04X}",
-                f16_buf[i],
+                "underflow not flushed to zero at {i}: got 0x{bits:04X}",
             );
         }
     }

--- a/jxl_simd/src/scalar.rs
+++ b/jxl_simd/src/scalar.rs
@@ -462,7 +462,11 @@ impl SimdMask for bool {
     }
 }
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
 #[macro_export]
 macro_rules! simd_function {
     (
@@ -481,7 +485,11 @@ macro_rules! simd_function {
     };
 }
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
 #[macro_export]
 macro_rules! test_all_instruction_sets {
     (
@@ -497,7 +505,11 @@ macro_rules! test_all_instruction_sets {
     };
 }
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
 #[macro_export]
 macro_rules! bench_all_instruction_sets {
     (

--- a/jxl_simd/src/scalar.rs
+++ b/jxl_simd/src/scalar.rs
@@ -437,7 +437,11 @@ impl SimdMask for bool {
     }
 }
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
 #[macro_export]
 macro_rules! simd_function {
     (
@@ -456,7 +460,11 @@ macro_rules! simd_function {
     };
 }
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
 #[macro_export]
 macro_rules! test_all_instruction_sets {
     (
@@ -472,7 +480,11 @@ macro_rules! test_all_instruction_sets {
     };
 }
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
 #[macro_export]
 macro_rules! bench_all_instruction_sets {
     (

--- a/jxl_simd/src/wasm32/mod.rs
+++ b/jxl_simd/src/wasm32/mod.rs
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-
 #[cfg(feature = "simd128")]
 pub(super) mod simd128;
 

--- a/jxl_simd/src/wasm32/mod.rs
+++ b/jxl_simd/src/wasm32/mod.rs
@@ -21,28 +21,12 @@ macro_rules! simd_function {
         $pub fn $dname($($arg: $ty),*) $(-> $ret)? {
             #[allow(unused)]
             use $crate::SimdDescriptor;
-            $crate::simd_function_body_simd128!($name($($arg: $ty),*) $(-> $ret)?; ($($arg),*));
-            $name($crate::ScalarDescriptor::new().unwrap(), $($arg),*)
+            #[cfg(all(feature = "simd128", target_feature = "simd128"))]
+            { $name($crate::Simd128Descriptor::new().unwrap(), $($arg),*) }
+            #[cfg(not(all(feature = "simd128", target_feature = "simd128")))]
+            { $name($crate::ScalarDescriptor::new().unwrap(), $($arg),*) }
         }
     };
-}
-
-#[cfg(feature = "simd128")]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! simd_function_body_simd128 {
-    ($name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty )?; ($($val:expr),* $(,)?)) => {
-        if let Some(d) = $crate::Simd128Descriptor::new() {
-            return $name(d, $($val),*);
-        }
-    };
-}
-
-#[cfg(not(feature = "simd128"))]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! simd_function_body_simd128 {
-    ($($ignore:tt)*) => {};
 }
 
 #[macro_export]
@@ -92,13 +76,13 @@ macro_rules! bench_all_instruction_sets {
         $criterion:ident
     ) => {
         use $crate::SimdDescriptor;
-        // `simd_function_body_*` does early return; wrap it with an immediately-invoked closure
-        (|| {
-            $crate::simd_function_body_simd128!(
-                $name($criterion: &mut ::criterion::BenchmarkGroup<'_, impl ::criterion::measurement::Measurement>);
-                ($criterion, "simd128")
-            );
-        })();
+        #[cfg(all(feature = "simd128", target_feature = "simd128"))]
+        $name(
+            $crate::Simd128Descriptor::new().unwrap(),
+            $criterion,
+            "simd128",
+        );
+        #[cfg(not(all(feature = "simd128", target_feature = "simd128")))]
         $name(
             $crate::ScalarDescriptor::new().unwrap(),
             $criterion,

--- a/jxl_simd/src/wasm32/mod.rs
+++ b/jxl_simd/src/wasm32/mod.rs
@@ -21,12 +21,28 @@ macro_rules! simd_function {
         $pub fn $dname($($arg: $ty),*) $(-> $ret)? {
             #[allow(unused)]
             use $crate::SimdDescriptor;
-            #[cfg(all(feature = "simd128", target_feature = "simd128"))]
-            { $name($crate::Simd128Descriptor::new().unwrap(), $($arg),*) }
-            #[cfg(not(all(feature = "simd128", target_feature = "simd128")))]
-            { $name($crate::ScalarDescriptor::new().unwrap(), $($arg),*) }
+            $crate::simd_function_body_simd128!($name($($arg: $ty),*) $(-> $ret)?; ($($arg),*));
+            $name($crate::ScalarDescriptor::new().unwrap(), $($arg),*)
         }
     };
+}
+
+#[cfg(feature = "simd128")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! simd_function_body_simd128 {
+    ($name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty )?; ($($val:expr),* $(,)?)) => {
+        if let Some(d) = $crate::Simd128Descriptor::new() {
+            return $name(d, $($val),*);
+        }
+    };
+}
+
+#[cfg(not(feature = "simd128"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! simd_function_body_simd128 {
+    ($($ignore:tt)*) => {};
 }
 
 #[macro_export]
@@ -76,13 +92,12 @@ macro_rules! bench_all_instruction_sets {
         $criterion:ident
     ) => {
         use $crate::SimdDescriptor;
-        #[cfg(all(feature = "simd128", target_feature = "simd128"))]
-        $name(
-            $crate::Simd128Descriptor::new().unwrap(),
-            $criterion,
-            "simd128",
-        );
-        #[cfg(not(all(feature = "simd128", target_feature = "simd128")))]
+        (|| {
+            $crate::simd_function_body_simd128!(
+                $name($criterion: &mut ::criterion::BenchmarkGroup<'_, impl ::criterion::measurement::Measurement>);
+                ($criterion, "simd128")
+            );
+        })();
         $name(
             $crate::ScalarDescriptor::new().unwrap(),
             $criterion,

--- a/jxl_simd/src/wasm32/mod.rs
+++ b/jxl_simd/src/wasm32/mod.rs
@@ -1,0 +1,109 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+
+#[cfg(feature = "simd128")]
+pub(super) mod simd128;
+
+#[macro_export]
+macro_rules! simd_function {
+    (
+        $dname:ident,
+        $descr:ident: $descr_ty:ident,
+        $(#[$($attr:meta)*])*
+        $pub:vis fn $name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty )? $body: block
+    ) => {
+        #[inline(always)]
+        $(#[$($attr)*])*
+        $pub fn $name<$descr_ty: $crate::SimdDescriptor>($descr: $descr_ty, $($arg: $ty),*) $(-> $ret)? $body
+        $(#[$($attr)*])*
+        $pub fn $dname($($arg: $ty),*) $(-> $ret)? {
+            #[allow(unused)]
+            use $crate::SimdDescriptor;
+            $crate::simd_function_body_simd128!($name($($arg: $ty),*) $(-> $ret)?; ($($arg),*));
+            $name($crate::ScalarDescriptor::new().unwrap(), $($arg),*)
+        }
+    };
+}
+
+#[cfg(feature = "simd128")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! simd_function_body_simd128 {
+    ($name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty )?; ($($val:expr),* $(,)?)) => {
+        if let Some(d) = $crate::Simd128Descriptor::new() {
+            return $name(d, $($val),*);
+        }
+    };
+}
+
+#[cfg(not(feature = "simd128"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! simd_function_body_simd128 {
+    ($($ignore:tt)*) => {};
+}
+
+#[macro_export]
+macro_rules! test_all_instruction_sets {
+    (
+        $name:ident
+    ) => {
+        paste::paste! {
+            #[test]
+            fn [<$name _scalar>]() {
+                use $crate::SimdDescriptor;
+                $name($crate::ScalarDescriptor::new().unwrap())
+            }
+        }
+
+        $crate::test_simd128!($name);
+    };
+}
+
+#[cfg(feature = "simd128")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! test_simd128 {
+    ($name:ident) => {
+        paste::paste! {
+            #[test]
+            fn [<$name _simd128>]() {
+                use $crate::SimdDescriptor;
+                let Some(d) = $crate::Simd128Descriptor::new() else { return; };
+                $name(d)
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "simd128"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! test_simd128 {
+    ($name:ident) => {};
+}
+
+#[macro_export]
+macro_rules! bench_all_instruction_sets {
+    (
+        $name:ident,
+        $criterion:ident
+    ) => {
+        use $crate::SimdDescriptor;
+        // `simd_function_body_*` does early return; wrap it with an immediately-invoked closure
+        (|| {
+            $crate::simd_function_body_simd128!(
+                $name($criterion: &mut ::criterion::BenchmarkGroup<'_, impl ::criterion::measurement::Measurement>);
+                ($criterion, "simd128")
+            );
+        })();
+        $name(
+            $crate::ScalarDescriptor::new().unwrap(),
+            $criterion,
+            "scalar",
+        );
+    };
+}

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -63,20 +63,6 @@ impl SimdDescriptor for Simd128Descriptor {
     }
 }
 
-macro_rules! fn_simd128 {
-    {} => {};
-    {$(
-        fn $name:ident($this:ident: $self_ty:ty $(, $arg:ident: $ty:ty)* $(,)?) $(-> $ret:ty )?
-        $body: block
-    )*} => {$(
-        #[inline(always)]
-        fn $name(self: $self_ty, $($arg: $ty),*) $(-> $ret)? {
-            let $this = self;
-            $body
-        }
-    )*};
-}
-
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
 pub struct F32VecSimd128(v128, Simd128Descriptor);
@@ -349,111 +335,128 @@ unsafe impl F32SimdVec for F32VecSimd128 {
 
     crate::impl_f32_array_interface!();
 
-    fn_simd128! {
-        fn mul_add(this: F32VecSimd128, mul: F32VecSimd128, add: F32VecSimd128) -> F32VecSimd128 {
-            #[cfg(target_feature = "relaxed-simd")]
-            { F32VecSimd128(f32x4_relaxed_madd(this.0, mul.0, add.0), this.1) }
-            #[cfg(not(target_feature = "relaxed-simd"))]
-            { F32VecSimd128(f32x4_add(f32x4_mul(this.0, mul.0), add.0), this.1) }
+    #[inline(always)]
+    fn mul_add(self, mul: F32VecSimd128, add: F32VecSimd128) -> F32VecSimd128 {
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            F32VecSimd128(f32x4_relaxed_madd(self.0, mul.0, add.0), self.1)
         }
-
-        fn neg_mul_add(this: F32VecSimd128, mul: F32VecSimd128, add: F32VecSimd128) -> F32VecSimd128 {
-            #[cfg(target_feature = "relaxed-simd")]
-            { F32VecSimd128(f32x4_relaxed_nmadd(this.0, mul.0, add.0), this.1) }
-            #[cfg(not(target_feature = "relaxed-simd"))]
-            { F32VecSimd128(f32x4_sub(add.0, f32x4_mul(this.0, mul.0)), this.1) }
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            F32VecSimd128(f32x4_add(f32x4_mul(self.0, mul.0), add.0), self.1)
         }
+    }
 
-        fn abs(this: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_abs(this.0), this.1)
+    #[inline(always)]
+    fn neg_mul_add(self, mul: F32VecSimd128, add: F32VecSimd128) -> F32VecSimd128 {
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            F32VecSimd128(f32x4_relaxed_nmadd(self.0, mul.0, add.0), self.1)
         }
-
-        fn floor(this: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_floor(this.0), this.1)
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            F32VecSimd128(f32x4_sub(add.0, f32x4_mul(self.0, mul.0)), self.1)
         }
+    }
 
-        fn sqrt(this: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_sqrt(this.0), this.1)
+    #[inline(always)]
+    fn abs(self) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_abs(self.0), self.1)
+    }
+
+    #[inline(always)]
+    fn floor(self) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_floor(self.0), self.1)
+    }
+
+    #[inline(always)]
+    fn sqrt(self) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_sqrt(self.0), self.1)
+    }
+
+    #[inline(always)]
+    fn neg(self) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_neg(self.0), self.1)
+    }
+
+    #[inline(always)]
+    fn copysign(self, sign: F32VecSimd128) -> F32VecSimd128 {
+        // Select sign bit from `sign`, magnitude from `self`
+        let sign_mask = u32x4_splat(0x8000_0000);
+        F32VecSimd128(v128_bitselect(sign.0, self.0, sign_mask), self.1)
+    }
+
+    #[inline(always)]
+    fn max(self, other: F32VecSimd128) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_max(self.0, other.0), self.1)
+    }
+
+    #[inline(always)]
+    fn min(self, other: F32VecSimd128) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_min(self.0, other.0), self.1)
+    }
+
+    #[inline(always)]
+    fn gt(self, other: F32VecSimd128) -> MaskSimd128 {
+        MaskSimd128(f32x4_gt(self.0, other.0), self.1)
+    }
+
+    #[inline(always)]
+    fn as_i32(self) -> I32VecSimd128 {
+        I32VecSimd128(i32x4_trunc_sat_f32x4(self.0), self.1)
+    }
+
+    #[inline(always)]
+    fn bitcast_to_i32(self) -> I32VecSimd128 {
+        // v128 is untyped; no conversion needed, just reinterpret.
+        I32VecSimd128(self.0, self.1)
+    }
+
+    #[inline(always)]
+    fn round_store_u8(self, dest: &mut [u8]) {
+        assert!(dest.len() >= F32VecSimd128::LEN);
+        let rounded = f32x4_nearest(self.0);
+        let i32s = i32x4_trunc_sat_f32x4(rounded);
+        // Saturate i32 -> i16 (signed narrow, preserving sign for next stage)
+        let i16s = i16x8_narrow_i32x4(i32s, i32s);
+        // Saturate i16 -> u8 (signed-to-unsigned narrow, clamping to [0, 255])
+        let u8s = u8x16_narrow_i16x8(i16s, i16s);
+        // Store lower 4 bytes
+        let val = u32x4_extract_lane::<0>(u8s);
+        // SAFETY: we checked dest has enough space.
+        unsafe {
+            std::ptr::copy_nonoverlapping(&val as *const u32 as *const u8, dest.as_mut_ptr(), 4);
         }
+    }
 
-        fn neg(this: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_neg(this.0), this.1)
+    #[inline(always)]
+    fn round_store_u16(self, dest: &mut [u16]) {
+        assert!(dest.len() >= F32VecSimd128::LEN);
+        let rounded = f32x4_nearest(self.0);
+        let i32s = i32x4_trunc_sat_f32x4(rounded);
+        // Saturate i32 -> u16 (narrow to 16-bit)
+        let u16s = u16x8_narrow_i32x4(i32s, i32s);
+        // Store lower 8 bytes (4 u16s)
+        let lo = i64x2_extract_lane::<0>(u16s);
+        // SAFETY: we checked dest has enough space.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                &lo as *const i64 as *const u8,
+                dest.as_mut_ptr().cast::<u8>(),
+                8,
+            );
         }
+    }
 
-        fn copysign(this: F32VecSimd128, sign: F32VecSimd128) -> F32VecSimd128 {
-            // Select sign bit from `sign`, magnitude from `this`
-            let sign_mask = u32x4_splat(0x8000_0000);
-            F32VecSimd128(v128_bitselect(sign.0, this.0, sign_mask), this.1)
-        }
-
-        fn max(this: F32VecSimd128, other: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_max(this.0, other.0), this.1)
-        }
-
-        fn min(this: F32VecSimd128, other: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_min(this.0, other.0), this.1)
-        }
-
-        fn gt(this: F32VecSimd128, other: F32VecSimd128) -> MaskSimd128 {
-            MaskSimd128(f32x4_gt(this.0, other.0), this.1)
-        }
-
-        fn as_i32(this: F32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(i32x4_trunc_sat_f32x4(this.0), this.1)
-        }
-
-        fn bitcast_to_i32(this: F32VecSimd128) -> I32VecSimd128 {
-            // v128 is untyped; no conversion needed, just reinterpret.
-            I32VecSimd128(this.0, this.1)
-        }
-
-        fn round_store_u8(this: F32VecSimd128, dest: &mut [u8]) {
-            assert!(dest.len() >= F32VecSimd128::LEN);
-            let rounded = f32x4_nearest(this.0);
-            let i32s = i32x4_trunc_sat_f32x4(rounded);
-            // Saturate i32 -> i16 (signed narrow, preserving sign for next stage)
-            let i16s = i16x8_narrow_i32x4(i32s, i32s);
-            // Saturate i16 -> u8 (signed-to-unsigned narrow, clamping to [0, 255])
-            let u8s = u8x16_narrow_i16x8(i16s, i16s);
-            // Store lower 4 bytes
-            let val = u32x4_extract_lane::<0>(u8s);
-            // SAFETY: we checked dest has enough space.
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    &val as *const u32 as *const u8,
-                    dest.as_mut_ptr(),
-                    4,
-                );
-            }
-        }
-
-        fn round_store_u16(this: F32VecSimd128, dest: &mut [u16]) {
-            assert!(dest.len() >= F32VecSimd128::LEN);
-            let rounded = f32x4_nearest(this.0);
-            let i32s = i32x4_trunc_sat_f32x4(rounded);
-            // Saturate i32 -> u16 (narrow to 16-bit)
-            let u16s = u16x8_narrow_i32x4(i32s, i32s);
-            // Store lower 8 bytes (4 u16s)
-            let lo = i64x2_extract_lane::<0>(u16s);
-            // SAFETY: we checked dest has enough space.
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    &lo as *const i64 as *const u8,
-                    dest.as_mut_ptr().cast::<u8>(),
-                    8,
-                );
-            }
-        }
-
-        fn store_f16_bits(this: F32VecSimd128, dest: &mut [u16]) {
-            assert!(dest.len() >= F32VecSimd128::LEN);
-            // WASM SIMD128 has no hardware f16 conversion; use scalar fallback.
-            let mut tmp = [0.0f32; 4];
-            // SAFETY: tmp is large enough.
-            unsafe { v128_store(tmp.as_mut_ptr().cast(), this.0) };
-            for i in 0..4 {
-                dest[i] = crate::f16::from_f32(tmp[i]).to_bits();
-            }
+    #[inline(always)]
+    fn store_f16_bits(self, dest: &mut [u16]) {
+        assert!(dest.len() >= F32VecSimd128::LEN);
+        // WASM SIMD128 has no hardware f16 conversion; use scalar fallback.
+        let mut tmp = [0.0f32; 4];
+        // SAFETY: tmp is large enough.
+        unsafe { v128_store(tmp.as_mut_ptr().cast(), self.0) };
+        for i in 0..4 {
+            dest[i] = crate::f16::from_f32(tmp[i]).to_bits();
         }
     }
 
@@ -510,69 +513,61 @@ unsafe impl F32SimdVec for F32VecSimd128 {
 
 impl Add<F32VecSimd128> for F32VecSimd128 {
     type Output = Self;
-    fn_simd128! {
-        fn add(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_add(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn add(self, rhs: F32VecSimd128) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_add(self.0, rhs.0), self.1)
     }
 }
 
 impl Sub<F32VecSimd128> for F32VecSimd128 {
     type Output = Self;
-    fn_simd128! {
-        fn sub(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_sub(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn sub(self, rhs: F32VecSimd128) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_sub(self.0, rhs.0), self.1)
     }
 }
 
 impl Mul<F32VecSimd128> for F32VecSimd128 {
     type Output = Self;
-    fn_simd128! {
-        fn mul(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_mul(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn mul(self, rhs: F32VecSimd128) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_mul(self.0, rhs.0), self.1)
     }
 }
 
 impl Div<F32VecSimd128> for F32VecSimd128 {
     type Output = Self;
-    fn_simd128! {
-        fn div(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_div(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn div(self, rhs: F32VecSimd128) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_div(self.0, rhs.0), self.1)
     }
 }
 
 impl AddAssign<F32VecSimd128> for F32VecSimd128 {
-    fn_simd128! {
-        fn add_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
-            this.0 = f32x4_add(this.0, rhs.0);
-        }
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: F32VecSimd128) {
+        self.0 = f32x4_add(self.0, rhs.0);
     }
 }
 
 impl SubAssign<F32VecSimd128> for F32VecSimd128 {
-    fn_simd128! {
-        fn sub_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
-            this.0 = f32x4_sub(this.0, rhs.0);
-        }
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: F32VecSimd128) {
+        self.0 = f32x4_sub(self.0, rhs.0);
     }
 }
 
 impl MulAssign<F32VecSimd128> for F32VecSimd128 {
-    fn_simd128! {
-        fn mul_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
-            this.0 = f32x4_mul(this.0, rhs.0);
-        }
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: F32VecSimd128) {
+        self.0 = f32x4_mul(self.0, rhs.0);
     }
 }
 
 impl DivAssign<F32VecSimd128> for F32VecSimd128 {
-    fn_simd128! {
-        fn div_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
-            this.0 = f32x4_div(this.0, rhs.0);
-        }
+    #[inline(always)]
+    fn div_assign(&mut self, rhs: F32VecSimd128) {
+        self.0 = f32x4_div(self.0, rhs.0);
     }
 }
 
@@ -604,55 +599,62 @@ impl I32SimdVec for I32VecSimd128 {
         unsafe { v128_store(mem.as_mut_ptr().cast(), self.0) }
     }
 
-    fn_simd128! {
-        fn abs(this: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(i32x4_abs(this.0), this.1)
-        }
+    #[inline(always)]
+    fn abs(self) -> I32VecSimd128 {
+        I32VecSimd128(i32x4_abs(self.0), self.1)
+    }
 
-        fn as_f32(this: I32VecSimd128) -> F32VecSimd128 {
-            F32VecSimd128(f32x4_convert_i32x4(this.0), this.1)
-        }
+    #[inline(always)]
+    fn as_f32(self) -> F32VecSimd128 {
+        F32VecSimd128(f32x4_convert_i32x4(self.0), self.1)
+    }
 
-        fn bitcast_to_f32(this: I32VecSimd128) -> F32VecSimd128 {
-            // v128 is untyped; no conversion needed.
-            F32VecSimd128(this.0, this.1)
-        }
+    #[inline(always)]
+    fn bitcast_to_f32(self) -> F32VecSimd128 {
+        // v128 is untyped; no conversion needed.
+        F32VecSimd128(self.0, self.1)
+    }
 
-        fn bitcast_to_u32(this: I32VecSimd128) -> U32VecSimd128 {
-            // v128 is untyped; no conversion needed.
-            U32VecSimd128(this.0, this.1)
-        }
+    #[inline(always)]
+    fn bitcast_to_u32(self) -> U32VecSimd128 {
+        // v128 is untyped; no conversion needed.
+        U32VecSimd128(self.0, self.1)
+    }
 
-        fn gt(this: I32VecSimd128, other: I32VecSimd128) -> MaskSimd128 {
-            MaskSimd128(i32x4_gt(this.0, other.0), this.1)
-        }
+    #[inline(always)]
+    fn gt(self, other: I32VecSimd128) -> MaskSimd128 {
+        MaskSimd128(i32x4_gt(self.0, other.0), self.1)
+    }
 
-        fn lt_zero(this: I32VecSimd128) -> MaskSimd128 {
-            MaskSimd128(i32x4_lt(this.0, i32x4_splat(0)), this.1)
-        }
+    #[inline(always)]
+    fn lt_zero(self) -> MaskSimd128 {
+        MaskSimd128(i32x4_lt(self.0, i32x4_splat(0)), self.1)
+    }
 
-        fn eq(this: I32VecSimd128, other: I32VecSimd128) -> MaskSimd128 {
-            MaskSimd128(i32x4_eq(this.0, other.0), this.1)
-        }
+    #[inline(always)]
+    fn eq(self, other: I32VecSimd128) -> MaskSimd128 {
+        MaskSimd128(i32x4_eq(self.0, other.0), self.1)
+    }
 
-        fn eq_zero(this: I32VecSimd128) -> MaskSimd128 {
-            MaskSimd128(i32x4_eq(this.0, i32x4_splat(0)), this.1)
-        }
+    #[inline(always)]
+    fn eq_zero(self) -> MaskSimd128 {
+        MaskSimd128(i32x4_eq(self.0, i32x4_splat(0)), self.1)
+    }
 
-        fn mul_wide_take_high(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
-            // Multiply pairs and take the high 32 bits of each 64-bit result
-            let lo = i64x2_extmul_low_i32x4(this.0, rhs.0); // [a0*b0, a1*b1] as i64
-            let hi = i64x2_extmul_high_i32x4(this.0, rhs.0); // [a2*b2, a3*b3] as i64
-            // Extract high 32 bits: shift right by 32, then shuffle to pack
-            // After shift: lo = [hi(a0*b0), 0, hi(a1*b1), 0] as i32 view
-            // We want: [hi(a0*b0), hi(a1*b1), hi(a2*b2), hi(a3*b3)]
-            let lo_shifted = i64x2_shr(lo, 32);
-            let hi_shifted = i64x2_shr(hi, 32);
-            // Pack: take lanes 0,2 from lo_shifted and 0,2 from hi_shifted
-            // lo_shifted as i32x4: [hi0, 0, hi1, 0]
-            // hi_shifted as i32x4: [hi2, 0, hi3, 0]
-            I32VecSimd128(i32x4_shuffle::<0, 2, 4, 6>(lo_shifted, hi_shifted), this.1)
-        }
+    #[inline(always)]
+    fn mul_wide_take_high(self, rhs: I32VecSimd128) -> I32VecSimd128 {
+        // Multiply pairs and take the high 32 bits of each 64-bit result
+        let lo = i64x2_extmul_low_i32x4(self.0, rhs.0); // [a0*b0, a1*b1] as i64
+        let hi = i64x2_extmul_high_i32x4(self.0, rhs.0); // [a2*b2, a3*b3] as i64
+        // Extract high 32 bits: shift right by 32, then shuffle to pack
+        // After shift: lo = [hi(a0*b0), 0, hi(a1*b1), 0] as i32 view
+        // We want: [hi(a0*b0), hi(a1*b1), hi(a2*b2), hi(a3*b3)]
+        let lo_shifted = i64x2_shr(lo, 32);
+        let hi_shifted = i64x2_shr(hi, 32);
+        // Pack: take lanes 0,2 from lo_shifted and 0,2 from hi_shifted
+        // lo_shifted as i32x4: [hi0, 0, hi1, 0]
+        // hi_shifted as i32x4: [hi2, 0, hi3, 0]
+        I32VecSimd128(i32x4_shuffle::<0, 2, 4, 6>(lo_shifted, hi_shifted), self.1)
     }
 
     #[inline(always)]
@@ -702,112 +704,99 @@ impl I32SimdVec for I32VecSimd128 {
 
 impl Add<I32VecSimd128> for I32VecSimd128 {
     type Output = I32VecSimd128;
-    fn_simd128! {
-        fn add(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(i32x4_add(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn add(self, rhs: I32VecSimd128) -> I32VecSimd128 {
+        I32VecSimd128(i32x4_add(self.0, rhs.0), self.1)
     }
 }
 
 impl Sub<I32VecSimd128> for I32VecSimd128 {
     type Output = I32VecSimd128;
-    fn_simd128! {
-        fn sub(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(i32x4_sub(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn sub(self, rhs: I32VecSimd128) -> I32VecSimd128 {
+        I32VecSimd128(i32x4_sub(self.0, rhs.0), self.1)
     }
 }
 
 impl Mul<I32VecSimd128> for I32VecSimd128 {
     type Output = I32VecSimd128;
-    fn_simd128! {
-        fn mul(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(i32x4_mul(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn mul(self, rhs: I32VecSimd128) -> I32VecSimd128 {
+        I32VecSimd128(i32x4_mul(self.0, rhs.0), self.1)
     }
 }
 
 impl Neg for I32VecSimd128 {
     type Output = I32VecSimd128;
-    fn_simd128! {
-        fn neg(this: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(i32x4_neg(this.0), this.1)
-        }
+    #[inline(always)]
+    fn neg(self) -> I32VecSimd128 {
+        I32VecSimd128(i32x4_neg(self.0), self.1)
     }
 }
 
 impl BitAnd<I32VecSimd128> for I32VecSimd128 {
     type Output = I32VecSimd128;
-    fn_simd128! {
-        fn bitand(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(v128_and(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn bitand(self, rhs: I32VecSimd128) -> I32VecSimd128 {
+        I32VecSimd128(v128_and(self.0, rhs.0), self.1)
     }
 }
 
 impl BitOr<I32VecSimd128> for I32VecSimd128 {
     type Output = I32VecSimd128;
-    fn_simd128! {
-        fn bitor(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(v128_or(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn bitor(self, rhs: I32VecSimd128) -> I32VecSimd128 {
+        I32VecSimd128(v128_or(self.0, rhs.0), self.1)
     }
 }
 
 impl BitXor<I32VecSimd128> for I32VecSimd128 {
     type Output = I32VecSimd128;
-    fn_simd128! {
-        fn bitxor(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
-            I32VecSimd128(v128_xor(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn bitxor(self, rhs: I32VecSimd128) -> I32VecSimd128 {
+        I32VecSimd128(v128_xor(self.0, rhs.0), self.1)
     }
 }
 
 impl AddAssign<I32VecSimd128> for I32VecSimd128 {
-    fn_simd128! {
-        fn add_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
-            this.0 = i32x4_add(this.0, rhs.0)
-        }
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: I32VecSimd128) {
+        self.0 = i32x4_add(self.0, rhs.0)
     }
 }
 
 impl SubAssign<I32VecSimd128> for I32VecSimd128 {
-    fn_simd128! {
-        fn sub_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
-            this.0 = i32x4_sub(this.0, rhs.0)
-        }
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: I32VecSimd128) {
+        self.0 = i32x4_sub(self.0, rhs.0)
     }
 }
 
 impl MulAssign<I32VecSimd128> for I32VecSimd128 {
-    fn_simd128! {
-        fn mul_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
-            this.0 = i32x4_mul(this.0, rhs.0)
-        }
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: I32VecSimd128) {
+        self.0 = i32x4_mul(self.0, rhs.0)
     }
 }
 
 impl BitAndAssign<I32VecSimd128> for I32VecSimd128 {
-    fn_simd128! {
-        fn bitand_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
-            this.0 = v128_and(this.0, rhs.0);
-        }
+    #[inline(always)]
+    fn bitand_assign(&mut self, rhs: I32VecSimd128) {
+        self.0 = v128_and(self.0, rhs.0);
     }
 }
 
 impl BitOrAssign<I32VecSimd128> for I32VecSimd128 {
-    fn_simd128! {
-        fn bitor_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
-            this.0 = v128_or(this.0, rhs.0);
-        }
+    #[inline(always)]
+    fn bitor_assign(&mut self, rhs: I32VecSimd128) {
+        self.0 = v128_or(self.0, rhs.0);
     }
 }
 
 impl BitXorAssign<I32VecSimd128> for I32VecSimd128 {
-    fn_simd128! {
-        fn bitxor_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
-            this.0 = v128_xor(this.0, rhs.0);
-        }
+    #[inline(always)]
+    fn bitxor_assign(&mut self, rhs: I32VecSimd128) {
+        self.0 = v128_xor(self.0, rhs.0);
     }
 }
 
@@ -820,11 +809,10 @@ impl U32SimdVec for U32VecSimd128 {
 
     const LEN: usize = 4;
 
-    fn_simd128! {
-        fn bitcast_to_i32(this: U32VecSimd128) -> I32VecSimd128 {
-            // v128 is untyped; no conversion needed.
-            I32VecSimd128(this.0, this.1)
-        }
+    #[inline(always)]
+    fn bitcast_to_i32(self) -> I32VecSimd128 {
+        // v128 is untyped; no conversion needed.
+        I32VecSimd128(self.0, self.1)
     }
 
     #[inline(always)]
@@ -1047,59 +1035,66 @@ pub struct MaskSimd128(v128, Simd128Descriptor);
 impl SimdMask for MaskSimd128 {
     type Descriptor = Simd128Descriptor;
 
-    fn_simd128! {
-        fn if_then_else_f32(
-            this: MaskSimd128,
-            if_true: F32VecSimd128,
-            if_false: F32VecSimd128,
-        ) -> F32VecSimd128 {
-            #[cfg(target_feature = "relaxed-simd")]
-            { F32VecSimd128(i32x4_relaxed_laneselect(if_true.0, if_false.0, this.0), this.1) }
-            #[cfg(not(target_feature = "relaxed-simd"))]
-            { F32VecSimd128(v128_bitselect(if_true.0, if_false.0, this.0), this.1) }
+    #[inline(always)]
+    fn if_then_else_f32(self, if_true: F32VecSimd128, if_false: F32VecSimd128) -> F32VecSimd128 {
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            F32VecSimd128(
+                i32x4_relaxed_laneselect(if_true.0, if_false.0, self.0),
+                self.1,
+            )
         }
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            F32VecSimd128(v128_bitselect(if_true.0, if_false.0, self.0), self.1)
+        }
+    }
 
-        fn if_then_else_i32(
-            this: MaskSimd128,
-            if_true: I32VecSimd128,
-            if_false: I32VecSimd128,
-        ) -> I32VecSimd128 {
-            #[cfg(target_feature = "relaxed-simd")]
-            { I32VecSimd128(i32x4_relaxed_laneselect(if_true.0, if_false.0, this.0), this.1) }
-            #[cfg(not(target_feature = "relaxed-simd"))]
-            { I32VecSimd128(v128_bitselect(if_true.0, if_false.0, this.0), this.1) }
+    #[inline(always)]
+    fn if_then_else_i32(self, if_true: I32VecSimd128, if_false: I32VecSimd128) -> I32VecSimd128 {
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            I32VecSimd128(
+                i32x4_relaxed_laneselect(if_true.0, if_false.0, self.0),
+                self.1,
+            )
         }
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            I32VecSimd128(v128_bitselect(if_true.0, if_false.0, self.0), self.1)
+        }
+    }
 
-        fn maskz_i32(this: MaskSimd128, v: I32VecSimd128) -> I32VecSimd128 {
-            // Zero out lanes where mask is true: v AND NOT mask
-            I32VecSimd128(v128_andnot(v.0, this.0), this.1)
-        }
+    #[inline(always)]
+    fn maskz_i32(self, v: I32VecSimd128) -> I32VecSimd128 {
+        // Zero out lanes where mask is true: v AND NOT mask
+        I32VecSimd128(v128_andnot(v.0, self.0), self.1)
+    }
 
-        fn andnot(this: MaskSimd128, rhs: MaskSimd128) -> MaskSimd128 {
-            // !this & rhs
-            MaskSimd128(v128_andnot(rhs.0, this.0), this.1)
-        }
+    #[inline(always)]
+    fn andnot(self, rhs: MaskSimd128) -> MaskSimd128 {
+        // !self & rhs
+        MaskSimd128(v128_andnot(rhs.0, self.0), self.1)
+    }
 
-        fn all(this: MaskSimd128) -> bool {
-            u32x4_all_true(this.0)
-        }
+    #[inline(always)]
+    fn all(self) -> bool {
+        u32x4_all_true(self.0)
     }
 }
 
 impl BitAnd<MaskSimd128> for MaskSimd128 {
     type Output = MaskSimd128;
-    fn_simd128! {
-        fn bitand(this: MaskSimd128, rhs: MaskSimd128) -> MaskSimd128 {
-            MaskSimd128(v128_and(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn bitand(self, rhs: MaskSimd128) -> MaskSimd128 {
+        MaskSimd128(v128_and(self.0, rhs.0), self.1)
     }
 }
 
 impl BitOr<MaskSimd128> for MaskSimd128 {
     type Output = MaskSimd128;
-    fn_simd128! {
-        fn bitor(this: MaskSimd128, rhs: MaskSimd128) -> MaskSimd128 {
-            MaskSimd128(v128_or(this.0, rhs.0), this.1)
-        }
+    #[inline(always)]
+    fn bitor(self, rhs: MaskSimd128) -> MaskSimd128 {
+        MaskSimd128(v128_or(self.0, rhs.0), self.1)
     }
 }

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -431,25 +431,72 @@ unsafe impl F32SimdVec for F32VecSimd128 {
 
     #[inline(always)]
     fn store_f16_bits(self, dest: &mut [u16]) {
-        assert!(dest.len() >= F32VecSimd128::LEN);
-        // WASM SIMD128 has no hardware f16 conversion; use scalar fallback.
-        let mut tmp = [0.0f32; 4];
-        // SAFETY: tmp is large enough.
-        unsafe { v128_store(tmp.as_mut_ptr().cast(), self.0) };
-        for i in 0..4 {
-            dest[i] = crate::f16::from_f32(tmp[i]).to_bits();
+        assert!(dest.len() >= Self::LEN);
+        let abs = f32x4_abs(self.0);
+        let sign = v128_and(u32x4_shr(self.0, 16), u32x4_splat(0x8000));
+        let abs_shifted = u32x4_shr(abs, 13);
+
+        // Normal: shift exp+mant into f16 position, rebias, clamp to max f16
+        let normal = i32x4_min(
+            i32x4_sub(abs_shifted, u32x4_splat(112 << 10)),
+            i32x4_splat(0x7C00),
+        );
+
+        // Subnormal (|x| < 2^-14): magic number trick to denormalize
+        // Adding 2^-14 normalizes the mantissa via float rounding,
+        // then integer-subtract the bias and shift to get the 10-bit mantissa.
+        let magic = u32x4_splat(113 << 23);
+        let subnorm = u32x4_shr(i32x4_sub(f32x4_add(abs, magic), magic), 13);
+
+        // Inf/NaN (exp==255): set f16 exp=31, keep top 10 mantissa bits
+        let infnan = v128_or(
+            u32x4_splat(0x7C00),
+            v128_and(abs_shifted, u32x4_splat(0x03FF)),
+        );
+
+        let is_subnorm = i32x4_lt(abs, u32x4_splat(0x38800000));
+        let is_infnan = i32x4_gt(abs, u32x4_splat(0x7F7FFFFF));
+        let result = v128_bitselect(subnorm, normal, is_subnorm);
+        let result = v128_bitselect(infnan, result, is_infnan);
+        let h = v128_or(sign, result);
+
+        // Narrow u32->u16 and store
+        let packed = i8x16_shuffle::<0, 1, 4, 5, 8, 9, 12, 13, 0, 0, 0, 0, 0, 0, 0, 0>(h, h);
+        // SAFETY: we checked dest has enough space.
+        unsafe {
+            v128_store64_lane::<0>(packed, dest.as_mut_ptr().cast::<u64>());
         }
     }
 
     #[inline(always)]
     fn load_f16_bits(d: Self::Descriptor, mem: &[u16]) -> Self {
         assert!(mem.len() >= Self::LEN);
-        // WASM SIMD128 has no hardware f16 conversion; use scalar fallback.
-        let mut result = [0.0f32; 4];
-        for i in 0..4 {
-            result[i] = crate::f16::from_bits(mem[i]).to_f32();
-        }
-        Self::load(d, &result)
+        let lo = unsafe { v128_load64_splat(mem.as_ptr().cast()) };
+        let zero = i32x4_splat(0);
+        let wide =
+            i8x16_shuffle::<0, 1, 16, 16, 2, 3, 16, 16, 4, 5, 16, 16, 6, 7, 16, 16>(lo, zero);
+        let sign = i32x4_shl(v128_and(wide, u32x4_splat(0x8000)), 16);
+        let mag = v128_and(wide, u32x4_splat(0x7FFF));
+        let mag_shifted = i32x4_shl(mag, 13);
+
+        // Normal: shift exp+mant into f32 position, rebias exponent (+112)
+        let normal = i32x4_add(mag_shifted, u32x4_splat(112 << 23));
+
+        // Subnormal (exp==0): magic number trick to normalize
+        // Construct 2^(-14) * (1 + mant/1024) then subtract 2^(-14)
+        let magic = u32x4_splat(113 << 23);
+        let mant_shifted = v128_and(mag_shifted, u32x4_splat(0x7FE000));
+        let subnorm = f32x4_sub(v128_or(magic, mant_shifted), magic);
+
+        // Inf/NaN (exp==31): normal path gives f32 exp=143, need 255; add 112<<23
+        let infnan = i32x4_add(normal, u32x4_splat(112 << 23));
+
+        let is_subnorm = i32x4_lt(mag, u32x4_splat(0x0400));
+        let is_infnan = i32x4_gt(mag, u32x4_splat(0x7BFF));
+        let result = v128_bitselect(subnorm, normal, is_subnorm);
+        let result = v128_bitselect(infnan, result, is_infnan);
+
+        Self(v128_or(sign, result), d)
     }
 
     #[inline(always)]

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -296,41 +296,22 @@ unsafe impl F32SimdVec for F32VecSimd128 {
 
     #[inline(always)]
     fn transpose_square(d: Simd128Descriptor, data: &mut [[f32; 4]], stride: usize) {
-        if stride == 1 {
-            assert!(data.len() > 3);
-            // SAFETY: input is verified to be large enough. v128_load supports unaligned loads.
-            let v0 = unsafe { v128_load(data.as_ptr().cast()) };
-            let v1 = unsafe { v128_load(data.as_ptr().add(1).cast()) };
-            let v2 = unsafe { v128_load(data.as_ptr().add(2).cast()) };
-            let v3 = unsafe { v128_load(data.as_ptr().add(3).cast()) };
+        assert!(data.len() > 3 * stride);
 
-            let ac02 = i32x4_shuffle::<0, 4, 2, 6>(v0, v1);
-            let bd02 = i32x4_shuffle::<1, 5, 3, 7>(v0, v1);
-            let ac13 = i32x4_shuffle::<0, 4, 2, 6>(v2, v3);
-            let bd13 = i32x4_shuffle::<1, 5, 3, 7>(v2, v3);
+        let p0 = F32VecSimd128::load_array(d, &data[0]).0;
+        let p1 = F32VecSimd128::load_array(d, &data[1 * stride]).0;
+        let p2 = F32VecSimd128::load_array(d, &data[2 * stride]).0;
+        let p3 = F32VecSimd128::load_array(d, &data[3 * stride]).0;
 
-            F32VecSimd128(i64x2_shuffle::<0, 2>(ac02, ac13), d).store_array(&mut data[0]);
-            F32VecSimd128(i64x2_shuffle::<0, 2>(bd02, bd13), d).store_array(&mut data[1]);
-            F32VecSimd128(i64x2_shuffle::<1, 3>(ac02, ac13), d).store_array(&mut data[2]);
-            F32VecSimd128(i64x2_shuffle::<1, 3>(bd02, bd13), d).store_array(&mut data[3]);
-        } else {
-            assert!(data.len() > 3 * stride);
+        let tr0 = i32x4_shuffle::<0, 4, 1, 5>(p0, p1);
+        let tr1 = i32x4_shuffle::<2, 6, 3, 7>(p0, p1);
+        let tr2 = i32x4_shuffle::<0, 4, 1, 5>(p2, p3);
+        let tr3 = i32x4_shuffle::<2, 6, 3, 7>(p2, p3);
 
-            let p0 = F32VecSimd128::load_array(d, &data[0]).0;
-            let p1 = F32VecSimd128::load_array(d, &data[1 * stride]).0;
-            let p2 = F32VecSimd128::load_array(d, &data[2 * stride]).0;
-            let p3 = F32VecSimd128::load_array(d, &data[3 * stride]).0;
-
-            let tr0 = i32x4_shuffle::<0, 4, 1, 5>(p0, p1);
-            let tr1 = i32x4_shuffle::<2, 6, 3, 7>(p0, p1);
-            let tr2 = i32x4_shuffle::<0, 4, 1, 5>(p2, p3);
-            let tr3 = i32x4_shuffle::<2, 6, 3, 7>(p2, p3);
-
-            F32VecSimd128(i64x2_shuffle::<0, 2>(tr0, tr2), d).store_array(&mut data[0]);
-            F32VecSimd128(i64x2_shuffle::<1, 3>(tr0, tr2), d).store_array(&mut data[1 * stride]);
-            F32VecSimd128(i64x2_shuffle::<0, 2>(tr1, tr3), d).store_array(&mut data[2 * stride]);
-            F32VecSimd128(i64x2_shuffle::<1, 3>(tr1, tr3), d).store_array(&mut data[3 * stride]);
-        }
+        F32VecSimd128(i64x2_shuffle::<0, 2>(tr0, tr2), d).store_array(&mut data[0]);
+        F32VecSimd128(i64x2_shuffle::<1, 3>(tr0, tr2), d).store_array(&mut data[1 * stride]);
+        F32VecSimd128(i64x2_shuffle::<0, 2>(tr1, tr3), d).store_array(&mut data[2 * stride]);
+        F32VecSimd128(i64x2_shuffle::<1, 3>(tr1, tr3), d).store_array(&mut data[3 * stride]);
     }
 
     crate::impl_f32_array_interface!();

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -434,11 +434,15 @@ unsafe impl F32SimdVec for F32VecSimd128 {
         assert!(dest.len() >= Self::LEN);
         let abs = f32x4_abs(self.0);
         let sign = v128_and(u32x4_shr(self.0, 16), u32x4_splat(0x8000));
-        let abs_shifted = u32x4_shr(abs, 13);
 
-        // Normal: shift exp+mant into f16 position, rebias, clamp to max f16
+        // Round to nearest even
+        let abs_shifted = u32x4_shr(abs, 13);
+        let lsb = v128_and(abs_shifted, u32x4_splat(1));
+        let rounded = i32x4_add(abs, i32x4_add(lsb, u32x4_splat(0x0FFF)));
+
+        // Normal: shift exp+mant into f16 position, rebias, clamp to inf (0x7C00)
         let normal = i32x4_min(
-            i32x4_sub(abs_shifted, u32x4_splat(112 << 10)),
+            i32x4_sub(u32x4_shr(rounded, 13), u32x4_splat(112 << 10)),
             i32x4_splat(0x7C00),
         );
 
@@ -483,10 +487,8 @@ unsafe impl F32SimdVec for F32VecSimd128 {
         let normal = i32x4_add(mag_shifted, u32x4_splat(112 << 23));
 
         // Subnormal (exp==0): magic number trick to normalize
-        // Construct 2^(-14) * (1 + mant/1024) then subtract 2^(-14)
         let magic = u32x4_splat(113 << 23);
-        let mant_shifted = v128_and(mag_shifted, u32x4_splat(0x7FE000));
-        let subnorm = f32x4_sub(v128_or(magic, mant_shifted), magic);
+        let subnorm = f32x4_sub(v128_or(magic, mag_shifted), magic);
 
         // Inf/NaN (exp==31): normal path gives f32 exp=143, need 255; add 112<<23
         let infnan = i32x4_add(normal, u32x4_splat(112 << 23));

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -1,0 +1,1105 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use std::{
+    arch::wasm32::*,
+    mem::MaybeUninit,
+    ops::{
+        Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
+        DivAssign, Mul, MulAssign, Neg, Sub, SubAssign,
+    },
+};
+
+use crate::U32SimdVec;
+
+use super::super::{F32SimdVec, I32SimdVec, SimdDescriptor, SimdMask, U8SimdVec, U16SimdVec};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Simd128Descriptor(());
+
+/// Prepared 8-entry BF16 lookup table for WASM SIMD128.
+/// Contains 8 BF16 values packed into 16 bytes (v128).
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct Bf16Table8Simd128(v128);
+
+impl SimdDescriptor for Simd128Descriptor {
+    type F32Vec = F32VecSimd128;
+
+    type I32Vec = I32VecSimd128;
+
+    type U32Vec = U32VecSimd128;
+
+    type U16Vec = U16VecSimd128;
+
+    type U8Vec = U8VecSimd128;
+
+    type Mask = MaskSimd128;
+    type Bf16Table8 = Bf16Table8Simd128;
+
+    type Descriptor256 = Self;
+    type Descriptor128 = Self;
+
+    fn new() -> Option<Self> {
+        if cfg!(target_feature = "simd128") {
+            Some(Self(()))
+        } else {
+            None
+        }
+    }
+
+    fn maybe_downgrade_256bit(self) -> Self {
+        self
+    }
+
+    fn maybe_downgrade_128bit(self) -> Self {
+        self
+    }
+
+    fn call<R>(self, f: impl FnOnce(Self) -> R) -> R {
+        f(self)
+    }
+}
+
+macro_rules! fn_simd128 {
+    {} => {};
+    {$(
+        fn $name:ident($this:ident: $self_ty:ty $(, $arg:ident: $ty:ty)* $(,)?) $(-> $ret:ty )?
+        $body: block
+    )*} => {$(
+        #[inline(always)]
+        fn $name(self: $self_ty, $($arg: $ty),*) $(-> $ret)? {
+            let $this = self;
+            $body
+        }
+    )*};
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct F32VecSimd128(v128, Simd128Descriptor);
+
+// SAFETY: The methods in this implementation that write to `MaybeUninit` (store_interleaved_*)
+// ensure that they write valid data to the output slice without reading uninitialized memory.
+unsafe impl F32SimdVec for F32VecSimd128 {
+    type Descriptor = Simd128Descriptor;
+
+    const LEN: usize = 4;
+
+    #[inline(always)]
+    fn splat(d: Self::Descriptor, v: f32) -> Self {
+        Self(f32x4_splat(v), d)
+    }
+
+    #[inline(always)]
+    fn zero(d: Self::Descriptor) -> Self {
+        Self(f32x4_splat(0.0), d)
+    }
+
+    #[inline(always)]
+    fn load(d: Self::Descriptor, mem: &[f32]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        Self(unsafe { v128_load(mem.as_ptr().cast()) }, d)
+    }
+
+    #[inline(always)]
+    fn store(&self, mem: &mut [f32]) {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        unsafe { v128_store(mem.as_mut_ptr().cast(), self.0) }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<f32>]) {
+        assert!(dest.len() >= 2 * Self::LEN);
+        // a = [a0, a1, a2, a3], b = [b0, b1, b2, b3]
+        // out0 = [a0, b0, a1, b1], out1 = [a2, b2, a3, b3]
+        let lo = i32x4_shuffle::<0, 4, 1, 5>(a.0, b.0);
+        let hi = i32x4_shuffle::<2, 6, 3, 7>(a.0, b.0);
+        // SAFETY: dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, lo);
+            v128_store(ptr.add(1), hi);
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<f32>]) {
+        assert!(dest.len() >= 3 * Self::LEN);
+        // a = [a0, a1, a2, a3], b = [b0, b1, b2, b3], c = [c0, c1, c2, c3]
+        // out0 = [a0, b0, c0, a1], out1 = [b1, c1, a2, b2], out2 = [c2, a3, b3, c3]
+        let ab01 = i32x4_shuffle::<0, 4, 0, 0>(a.0, b.0); // [a0, b0, ?, ?]
+        let ca01 = i32x4_shuffle::<0, 5, 0, 0>(c.0, a.0); // [c0, a1, ?, ?]
+        let out0 = i64x2_shuffle::<0, 2>(ab01, ca01); // [a0, b0, c0, a1]
+
+        let bc1 = i32x4_shuffle::<1, 5, 0, 0>(b.0, c.0); // [b1, c1, ?, ?]
+        let ab2 = i32x4_shuffle::<2, 6, 0, 0>(a.0, b.0); // [a2, b2, ?, ?]
+        let out1 = i64x2_shuffle::<0, 2>(bc1, ab2); // [b1, c1, a2, b2]
+
+        let ca2 = i32x4_shuffle::<2, 7, 0, 0>(c.0, a.0); // [c2, a3, ?, ?]
+        let bc3 = i32x4_shuffle::<3, 7, 0, 0>(b.0, c.0); // [b3, c3, ?, ?]
+        let out2 = i64x2_shuffle::<0, 2>(ca2, bc3); // [c2, a3, b3, c3]
+
+        // SAFETY: dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, out0);
+            v128_store(ptr.add(1), out1);
+            v128_store(ptr.add(2), out2);
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_4_uninit(
+        a: Self,
+        b: Self,
+        c: Self,
+        d: Self,
+        dest: &mut [MaybeUninit<f32>],
+    ) {
+        assert!(dest.len() >= 4 * Self::LEN);
+        // a = [a0,a1,a2,a3], b = [b0,b1,b2,b3], c = [c0,c1,c2,c3], d = [d0,d1,d2,d3]
+        // out = [a0,b0,c0,d0, a1,b1,c1,d1, a2,b2,c2,d2, a3,b3,c3,d3]
+        // Stage 1: interleave pairs
+        let ab_lo = i32x4_shuffle::<0, 4, 1, 5>(a.0, b.0); // [a0, b0, a1, b1]
+        let ab_hi = i32x4_shuffle::<2, 6, 3, 7>(a.0, b.0); // [a2, b2, a3, b3]
+        let cd_lo = i32x4_shuffle::<0, 4, 1, 5>(c.0, d.0); // [c0, d0, c1, d1]
+        let cd_hi = i32x4_shuffle::<2, 6, 3, 7>(c.0, d.0); // [c2, d2, c3, d3]
+
+        // Stage 2: interleave pairs of pairs (using 64-bit granularity)
+        let out0 = i64x2_shuffle::<0, 2>(ab_lo, cd_lo); // [a0, b0, c0, d0]
+        let out1 = i64x2_shuffle::<1, 3>(ab_lo, cd_lo); // [a1, b1, c1, d1]
+        let out2 = i64x2_shuffle::<0, 2>(ab_hi, cd_hi); // [a2, b2, c2, d2]
+        let out3 = i64x2_shuffle::<1, 3>(ab_hi, cd_hi); // [a3, b3, c3, d3]
+
+        // SAFETY: dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, out0);
+            v128_store(ptr.add(1), out1);
+            v128_store(ptr.add(2), out2);
+            v128_store(ptr.add(3), out3);
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_8(
+        a: Self,
+        b: Self,
+        c: Self,
+        d: Self,
+        e: Self,
+        f: Self,
+        g: Self,
+        h: Self,
+        dest: &mut [f32],
+    ) {
+        assert!(dest.len() >= 8 * Self::LEN);
+
+        // Use zip to interleave pairs
+        let ae_lo = i32x4_shuffle::<0, 4, 1, 5>(a.0, e.0);
+        let ae_hi = i32x4_shuffle::<2, 6, 3, 7>(a.0, e.0);
+        let bf_lo = i32x4_shuffle::<0, 4, 1, 5>(b.0, f.0);
+        let bf_hi = i32x4_shuffle::<2, 6, 3, 7>(b.0, f.0);
+        let cg_lo = i32x4_shuffle::<0, 4, 1, 5>(c.0, g.0);
+        let cg_hi = i32x4_shuffle::<2, 6, 3, 7>(c.0, g.0);
+        let dh_lo = i32x4_shuffle::<0, 4, 1, 5>(d.0, h.0);
+        let dh_hi = i32x4_shuffle::<2, 6, 3, 7>(d.0, h.0);
+
+        // Now interleave ae with bf, and cg with dh
+        let aebf_0 = i32x4_shuffle::<0, 4, 1, 5>(ae_lo, bf_lo);
+        let aebf_1 = i32x4_shuffle::<2, 6, 3, 7>(ae_lo, bf_lo);
+        let aebf_2 = i32x4_shuffle::<0, 4, 1, 5>(ae_hi, bf_hi);
+        let aebf_3 = i32x4_shuffle::<2, 6, 3, 7>(ae_hi, bf_hi);
+        let cgdh_0 = i32x4_shuffle::<0, 4, 1, 5>(cg_lo, dh_lo);
+        let cgdh_1 = i32x4_shuffle::<2, 6, 3, 7>(cg_lo, dh_lo);
+        let cgdh_2 = i32x4_shuffle::<0, 4, 1, 5>(cg_hi, dh_hi);
+        let cgdh_3 = i32x4_shuffle::<2, 6, 3, 7>(cg_hi, dh_hi);
+
+        // Final interleave using 64-bit shuffles
+        let out0 = i64x2_shuffle::<0, 2>(aebf_0, cgdh_0);
+        let out1 = i64x2_shuffle::<1, 3>(aebf_0, cgdh_0);
+        let out2 = i64x2_shuffle::<0, 2>(aebf_1, cgdh_1);
+        let out3 = i64x2_shuffle::<1, 3>(aebf_1, cgdh_1);
+        let out4 = i64x2_shuffle::<0, 2>(aebf_2, cgdh_2);
+        let out5 = i64x2_shuffle::<1, 3>(aebf_2, cgdh_2);
+        let out6 = i64x2_shuffle::<0, 2>(aebf_3, cgdh_3);
+        let out7 = i64x2_shuffle::<1, 3>(aebf_3, cgdh_3);
+
+        // SAFETY: we just checked that dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, out0);
+            v128_store(ptr.add(1), out1);
+            v128_store(ptr.add(2), out2);
+            v128_store(ptr.add(3), out3);
+            v128_store(ptr.add(4), out4);
+            v128_store(ptr.add(5), out5);
+            v128_store(ptr.add(6), out6);
+            v128_store(ptr.add(7), out7);
+        }
+    }
+
+    #[inline(always)]
+    fn load_deinterleaved_2(d: Self::Descriptor, src: &[f32]) -> (Self, Self) {
+        assert!(src.len() >= 2 * Self::LEN);
+        // src = [a0, b0, a1, b1, a2, b2, a3, b3]
+        // SAFETY: we just checked that `src` has enough space.
+        let lo = unsafe { v128_load(src.as_ptr().cast()) }; // [a0, b0, a1, b1]
+        let hi = unsafe { v128_load(src.as_ptr().add(4).cast()) }; // [a2, b2, a3, b3]
+        let a = i32x4_shuffle::<0, 2, 4, 6>(lo, hi); // [a0, a1, a2, a3]
+        let b = i32x4_shuffle::<1, 3, 5, 7>(lo, hi); // [b0, b1, b2, b3]
+        (Self(a, d), Self(b, d))
+    }
+
+    #[inline(always)]
+    fn load_deinterleaved_3(d: Self::Descriptor, src: &[f32]) -> (Self, Self, Self) {
+        assert!(src.len() >= 3 * Self::LEN);
+        // src = [a0,b0,c0, a1,b1,c1, a2,b2,c2, a3,b3,c3]
+        // v0 = [a0, b0, c0, a1], v1 = [b1, c1, a2, b2], v2 = [c2, a3, b3, c3]
+        // SAFETY: we just checked that `src` has enough space.
+        let v0 = unsafe { v128_load(src.as_ptr().cast()) };
+        let v1 = unsafe { v128_load(src.as_ptr().add(4).cast()) };
+        let v2 = unsafe { v128_load(src.as_ptr().add(8).cast()) };
+
+        // a = [a0, a1, a2, a3] = v0[0], v0[3], v1[2], v2[1]
+        let a01 = i32x4_shuffle::<0, 3, 0, 0>(v0, v0); // [a0, a1, ?, ?]
+        let a23 = i32x4_shuffle::<2, 5, 0, 0>(v1, v2); // [a2, a3, ?, ?]
+        let a = i64x2_shuffle::<0, 2>(a01, a23);
+
+        // b = [b0, b1, b2, b3] = v0[1], v1[0], v1[3], v2[2]
+        let b01 = i32x4_shuffle::<1, 4, 0, 0>(v0, v1); // [b0, b1, ?, ?]
+        let b23 = i32x4_shuffle::<3, 6, 0, 0>(v1, v2); // [b2, b3, ?, ?]
+        let b = i64x2_shuffle::<0, 2>(b01, b23);
+
+        // c = [c0, c1, c2, c3] = v0[2], v1[1], v2[0], v2[3]
+        let c01 = i32x4_shuffle::<2, 5, 0, 0>(v0, v1); // [c0, c1, ?, ?]
+        let c23 = i32x4_shuffle::<0, 3, 0, 0>(v2, v2); // [c2, c3, ?, ?]
+        let c = i64x2_shuffle::<0, 2>(c01, c23);
+
+        (Self(a, d), Self(b, d), Self(c, d))
+    }
+
+    #[inline(always)]
+    fn load_deinterleaved_4(d: Self::Descriptor, src: &[f32]) -> (Self, Self, Self, Self) {
+        assert!(src.len() >= 4 * Self::LEN);
+        // src = [a0,b0,c0,d0, a1,b1,c1,d1, a2,b2,c2,d2, a3,b3,c3,d3]
+        // SAFETY: we just checked that `src` has enough space.
+        let v0 = unsafe { v128_load(src.as_ptr().cast()) }; // [a0, b0, c0, d0]
+        let v1 = unsafe { v128_load(src.as_ptr().add(4).cast()) }; // [a1, b1, c1, d1]
+        let v2 = unsafe { v128_load(src.as_ptr().add(8).cast()) }; // [a2, b2, c2, d2]
+        let v3 = unsafe { v128_load(src.as_ptr().add(12).cast()) }; // [a3, b3, c3, d3]
+
+        // Stage 1: interleave pairs
+        let ac02 = i32x4_shuffle::<0, 4, 2, 6>(v0, v1); // [a0, a1, c0, c1]
+        let bd02 = i32x4_shuffle::<1, 5, 3, 7>(v0, v1); // [b0, b1, d0, d1]
+        let ac13 = i32x4_shuffle::<0, 4, 2, 6>(v2, v3); // [a2, a3, c2, c3]
+        let bd13 = i32x4_shuffle::<1, 5, 3, 7>(v2, v3); // [b2, b3, d2, d3]
+
+        // Stage 2: combine
+        let a = i64x2_shuffle::<0, 2>(ac02, ac13); // [a0, a1, a2, a3]
+        let b = i64x2_shuffle::<0, 2>(bd02, bd13); // [b0, b1, b2, b3]
+        let c = i64x2_shuffle::<1, 3>(ac02, ac13); // [c0, c1, c2, c3]
+        let dd = i64x2_shuffle::<1, 3>(bd02, bd13); // [d0, d1, d2, d3]
+        (Self(a, d), Self(b, d), Self(c, d), Self(dd, d))
+    }
+
+    #[inline(always)]
+    fn transpose_square(d: Simd128Descriptor, data: &mut [[f32; 4]], stride: usize) {
+        if stride == 1 {
+            assert!(data.len() > 3);
+            // SAFETY: input is verified to be large enough. v128_load supports unaligned loads.
+            let v0 = unsafe { v128_load(data.as_ptr().cast()) };
+            let v1 = unsafe { v128_load(data.as_ptr().add(1).cast()) };
+            let v2 = unsafe { v128_load(data.as_ptr().add(2).cast()) };
+            let v3 = unsafe { v128_load(data.as_ptr().add(3).cast()) };
+
+            let ac02 = i32x4_shuffle::<0, 4, 2, 6>(v0, v1);
+            let bd02 = i32x4_shuffle::<1, 5, 3, 7>(v0, v1);
+            let ac13 = i32x4_shuffle::<0, 4, 2, 6>(v2, v3);
+            let bd13 = i32x4_shuffle::<1, 5, 3, 7>(v2, v3);
+
+            F32VecSimd128(i64x2_shuffle::<0, 2>(ac02, ac13), d).store_array(&mut data[0]);
+            F32VecSimd128(i64x2_shuffle::<0, 2>(bd02, bd13), d).store_array(&mut data[1]);
+            F32VecSimd128(i64x2_shuffle::<1, 3>(ac02, ac13), d).store_array(&mut data[2]);
+            F32VecSimd128(i64x2_shuffle::<1, 3>(bd02, bd13), d).store_array(&mut data[3]);
+        } else {
+            assert!(data.len() > 3 * stride);
+
+            let p0 = F32VecSimd128::load_array(d, &data[0]).0;
+            let p1 = F32VecSimd128::load_array(d, &data[1 * stride]).0;
+            let p2 = F32VecSimd128::load_array(d, &data[2 * stride]).0;
+            let p3 = F32VecSimd128::load_array(d, &data[3 * stride]).0;
+
+            let tr0 = i32x4_shuffle::<0, 4, 1, 5>(p0, p1);
+            let tr1 = i32x4_shuffle::<2, 6, 3, 7>(p0, p1);
+            let tr2 = i32x4_shuffle::<0, 4, 1, 5>(p2, p3);
+            let tr3 = i32x4_shuffle::<2, 6, 3, 7>(p2, p3);
+
+            F32VecSimd128(i64x2_shuffle::<0, 2>(tr0, tr2), d).store_array(&mut data[0]);
+            F32VecSimd128(i64x2_shuffle::<1, 3>(tr0, tr2), d).store_array(&mut data[1 * stride]);
+            F32VecSimd128(i64x2_shuffle::<0, 2>(tr1, tr3), d).store_array(&mut data[2 * stride]);
+            F32VecSimd128(i64x2_shuffle::<1, 3>(tr1, tr3), d).store_array(&mut data[3 * stride]);
+        }
+    }
+
+    crate::impl_f32_array_interface!();
+
+    fn_simd128! {
+        fn mul_add(this: F32VecSimd128, mul: F32VecSimd128, add: F32VecSimd128) -> F32VecSimd128 {
+            #[cfg(target_feature = "relaxed-simd")]
+            { F32VecSimd128(f32x4_relaxed_madd(this.0, mul.0, add.0), this.1) }
+            #[cfg(not(target_feature = "relaxed-simd"))]
+            { F32VecSimd128(f32x4_add(f32x4_mul(this.0, mul.0), add.0), this.1) }
+        }
+
+        fn neg_mul_add(this: F32VecSimd128, mul: F32VecSimd128, add: F32VecSimd128) -> F32VecSimd128 {
+            #[cfg(target_feature = "relaxed-simd")]
+            { F32VecSimd128(f32x4_relaxed_nmadd(this.0, mul.0, add.0), this.1) }
+            #[cfg(not(target_feature = "relaxed-simd"))]
+            { F32VecSimd128(f32x4_sub(add.0, f32x4_mul(this.0, mul.0)), this.1) }
+        }
+
+        fn abs(this: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_abs(this.0), this.1)
+        }
+
+        fn floor(this: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_floor(this.0), this.1)
+        }
+
+        fn sqrt(this: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_sqrt(this.0), this.1)
+        }
+
+        fn neg(this: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_neg(this.0), this.1)
+        }
+
+        fn copysign(this: F32VecSimd128, sign: F32VecSimd128) -> F32VecSimd128 {
+            // Select sign bit from `sign`, magnitude from `this`
+            let sign_mask = u32x4_splat(0x8000_0000);
+            F32VecSimd128(v128_bitselect(sign.0, this.0, sign_mask), this.1)
+        }
+
+        fn max(this: F32VecSimd128, other: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_max(this.0, other.0), this.1)
+        }
+
+        fn min(this: F32VecSimd128, other: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_min(this.0, other.0), this.1)
+        }
+
+        fn gt(this: F32VecSimd128, other: F32VecSimd128) -> MaskSimd128 {
+            MaskSimd128(f32x4_gt(this.0, other.0), this.1)
+        }
+
+        fn as_i32(this: F32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(i32x4_trunc_sat_f32x4(this.0), this.1)
+        }
+
+        fn bitcast_to_i32(this: F32VecSimd128) -> I32VecSimd128 {
+            // v128 is untyped; no conversion needed, just reinterpret.
+            I32VecSimd128(this.0, this.1)
+        }
+
+        fn round_store_u8(this: F32VecSimd128, dest: &mut [u8]) {
+            assert!(dest.len() >= F32VecSimd128::LEN);
+            let rounded = f32x4_nearest(this.0);
+            let i32s = i32x4_trunc_sat_f32x4(rounded);
+            // Saturate i32 -> i16 (signed narrow, preserving sign for next stage)
+            let i16s = i16x8_narrow_i32x4(i32s, i32s);
+            // Saturate i16 -> u8 (signed-to-unsigned narrow, clamping to [0, 255])
+            let u8s = u8x16_narrow_i16x8(i16s, i16s);
+            // Store lower 4 bytes
+            let val = u32x4_extract_lane::<0>(u8s);
+            // SAFETY: we checked dest has enough space.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    &val as *const u32 as *const u8,
+                    dest.as_mut_ptr(),
+                    4,
+                );
+            }
+        }
+
+        fn round_store_u16(this: F32VecSimd128, dest: &mut [u16]) {
+            assert!(dest.len() >= F32VecSimd128::LEN);
+            let rounded = f32x4_nearest(this.0);
+            let i32s = i32x4_trunc_sat_f32x4(rounded);
+            // Saturate i32 -> u16 (narrow to 16-bit)
+            let u16s = u16x8_narrow_i32x4(i32s, i32s);
+            // Store lower 8 bytes (4 u16s)
+            let lo = i64x2_extract_lane::<0>(u16s);
+            // SAFETY: we checked dest has enough space.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    &lo as *const i64 as *const u8,
+                    dest.as_mut_ptr().cast::<u8>(),
+                    8,
+                );
+            }
+        }
+
+        fn store_f16_bits(this: F32VecSimd128, dest: &mut [u16]) {
+            assert!(dest.len() >= F32VecSimd128::LEN);
+            // WASM SIMD128 has no hardware f16 conversion; use scalar fallback.
+            let mut tmp = [0.0f32; 4];
+            // SAFETY: tmp is large enough.
+            unsafe { v128_store(tmp.as_mut_ptr().cast(), this.0) };
+            for i in 0..4 {
+                dest[i] = crate::f16::from_f32(tmp[i]).to_bits();
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn load_f16_bits(d: Self::Descriptor, mem: &[u16]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // WASM SIMD128 has no hardware f16 conversion; use scalar fallback.
+        let mut result = [0.0f32; 4];
+        for i in 0..4 {
+            result[i] = crate::f16::from_bits(mem[i]).to_f32();
+        }
+        Self::load(d, &result)
+    }
+
+    #[inline(always)]
+    fn prepare_table_bf16_8(_d: Simd128Descriptor, table: &[f32; 8]) -> Bf16Table8Simd128 {
+        // Convert f32 table to BF16 packed in 128 bits (16 bytes for 8 entries)
+        // BF16 is the high 16 bits of f32
+        // SAFETY: `table` has 8 elements, so both loads are in bounds.
+        let table_lo = unsafe { v128_load(table.as_ptr().cast()) };
+        let table_hi = unsafe { v128_load(table.as_ptr().add(4).cast()) };
+
+        // Shift right by 16 to get BF16 values, then narrow to 16-bit
+        let lo_shifted = u32x4_shr(table_lo, 16);
+        let hi_shifted = u32x4_shr(table_hi, 16);
+
+        // Narrow u32 -> u16, packing both halves
+        Bf16Table8Simd128(u16x8_narrow_i32x4(lo_shifted, hi_shifted))
+    }
+
+    #[inline(always)]
+    fn table_lookup_bf16_8(
+        d: Simd128Descriptor,
+        table: Bf16Table8Simd128,
+        indices: I32VecSimd128,
+    ) -> Self {
+        // Build shuffle mask efficiently using arithmetic on 32-bit indices.
+        // For each index i (0-7), we need to select bytes [2*i, 2*i+1] from bf16_table
+        // and place them in the high 16 bits of each 32-bit f32 lane (bytes 2,3),
+        // with bytes 0,1 set to zero (using out-of-range index which gives 0 in swizzle).
+        //
+        // Output byte pattern per lane (little-endian): [0x80, 0x80, 2*i, 2*i+1]
+        // As a 32-bit value: 0x80 | (0x80 << 8) | (2*i << 16) | ((2*i+1) << 24)
+        //                  = (i << 17) | (i << 25) | 0x01008080
+        let shl17 = i32x4_shl(indices.0, 17);
+        let shl25 = i32x4_shl(indices.0, 25);
+        let base = u32x4_splat(0x01008080);
+        let shuffle_mask = v128_or(v128_or(shl17, shl25), base);
+
+        // Perform the table lookup (out of range indices give 0)
+        F32VecSimd128(i8x16_swizzle(table.0, shuffle_mask), d)
+    }
+}
+
+impl Add<F32VecSimd128> for F32VecSimd128 {
+    type Output = Self;
+    fn_simd128! {
+        fn add(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_add(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl Sub<F32VecSimd128> for F32VecSimd128 {
+    type Output = Self;
+    fn_simd128! {
+        fn sub(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_sub(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl Mul<F32VecSimd128> for F32VecSimd128 {
+    type Output = Self;
+    fn_simd128! {
+        fn mul(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_mul(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl Div<F32VecSimd128> for F32VecSimd128 {
+    type Output = Self;
+    fn_simd128! {
+        fn div(this: F32VecSimd128, rhs: F32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_div(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl AddAssign<F32VecSimd128> for F32VecSimd128 {
+    fn_simd128! {
+        fn add_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
+            this.0 = f32x4_add(this.0, rhs.0);
+        }
+    }
+}
+
+impl SubAssign<F32VecSimd128> for F32VecSimd128 {
+    fn_simd128! {
+        fn sub_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
+            this.0 = f32x4_sub(this.0, rhs.0);
+        }
+    }
+}
+
+impl MulAssign<F32VecSimd128> for F32VecSimd128 {
+    fn_simd128! {
+        fn mul_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
+            this.0 = f32x4_mul(this.0, rhs.0);
+        }
+    }
+}
+
+impl DivAssign<F32VecSimd128> for F32VecSimd128 {
+    fn_simd128! {
+        fn div_assign(this: &mut F32VecSimd128, rhs: F32VecSimd128) {
+            this.0 = f32x4_div(this.0, rhs.0);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct I32VecSimd128(v128, Simd128Descriptor);
+
+impl I32SimdVec for I32VecSimd128 {
+    type Descriptor = Simd128Descriptor;
+
+    const LEN: usize = 4;
+
+    #[inline(always)]
+    fn splat(d: Self::Descriptor, v: i32) -> Self {
+        Self(i32x4_splat(v), d)
+    }
+
+    #[inline(always)]
+    fn load(d: Self::Descriptor, mem: &[i32]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        Self(unsafe { v128_load(mem.as_ptr().cast()) }, d)
+    }
+
+    #[inline(always)]
+    fn store(&self, mem: &mut [i32]) {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        unsafe { v128_store(mem.as_mut_ptr().cast(), self.0) }
+    }
+
+    fn_simd128! {
+        fn abs(this: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(i32x4_abs(this.0), this.1)
+        }
+
+        fn as_f32(this: I32VecSimd128) -> F32VecSimd128 {
+            F32VecSimd128(f32x4_convert_i32x4(this.0), this.1)
+        }
+
+        fn bitcast_to_f32(this: I32VecSimd128) -> F32VecSimd128 {
+            // v128 is untyped; no conversion needed.
+            F32VecSimd128(this.0, this.1)
+        }
+
+        fn bitcast_to_u32(this: I32VecSimd128) -> U32VecSimd128 {
+            // v128 is untyped; no conversion needed.
+            U32VecSimd128(this.0, this.1)
+        }
+
+        fn gt(this: I32VecSimd128, other: I32VecSimd128) -> MaskSimd128 {
+            MaskSimd128(i32x4_gt(this.0, other.0), this.1)
+        }
+
+        fn lt_zero(this: I32VecSimd128) -> MaskSimd128 {
+            MaskSimd128(i32x4_lt(this.0, i32x4_splat(0)), this.1)
+        }
+
+        fn eq(this: I32VecSimd128, other: I32VecSimd128) -> MaskSimd128 {
+            MaskSimd128(i32x4_eq(this.0, other.0), this.1)
+        }
+
+        fn eq_zero(this: I32VecSimd128) -> MaskSimd128 {
+            MaskSimd128(i32x4_eq(this.0, i32x4_splat(0)), this.1)
+        }
+
+        fn mul_wide_take_high(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
+            // Multiply pairs and take the high 32 bits of each 64-bit result
+            let lo = i64x2_extmul_low_i32x4(this.0, rhs.0); // [a0*b0, a1*b1] as i64
+            let hi = i64x2_extmul_high_i32x4(this.0, rhs.0); // [a2*b2, a3*b3] as i64
+            // Extract high 32 bits: shift right by 32, then shuffle to pack
+            // After shift: lo = [hi(a0*b0), 0, hi(a1*b1), 0] as i32 view
+            // We want: [hi(a0*b0), hi(a1*b1), hi(a2*b2), hi(a3*b3)]
+            let lo_shifted = i64x2_shr(lo, 32);
+            let hi_shifted = i64x2_shr(hi, 32);
+            // Pack: take lanes 0,2 from lo_shifted and 0,2 from hi_shifted
+            // lo_shifted as i32x4: [hi0, 0, hi1, 0]
+            // hi_shifted as i32x4: [hi2, 0, hi3, 0]
+            I32VecSimd128(i32x4_shuffle::<0, 2, 4, 6>(lo_shifted, hi_shifted), this.1)
+        }
+    }
+
+    #[inline(always)]
+    fn shl<const AMOUNT_U: u32, const AMOUNT_I: i32>(self) -> Self {
+        Self(i32x4_shl(self.0, AMOUNT_U), self.1)
+    }
+
+    #[inline(always)]
+    fn shr<const AMOUNT_U: u32, const AMOUNT_I: i32>(self) -> Self {
+        Self(i32x4_shr(self.0, AMOUNT_U), self.1)
+    }
+
+    #[inline(always)]
+    fn store_u16(self, dest: &mut [u16]) {
+        assert!(dest.len() >= Self::LEN);
+        // Truncating narrow: take the lower 16 bits of each 32-bit lane via shuffle.
+        // Input bytes: [l0,l1,h0,h1, l2,l3,h2,h3, l4,l5,h4,h5, l6,l7,h6,h7]
+        // Output bytes (lower 8): [l0,l1,l2,l3,l4,l5,l6,l7]
+        let packed =
+            i8x16_shuffle::<0, 1, 4, 5, 8, 9, 12, 13, 0, 0, 0, 0, 0, 0, 0, 0>(self.0, self.0);
+        let lo = i64x2_extract_lane::<0>(packed);
+        // SAFETY: we checked that `dest` has enough space.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                &lo as *const i64 as *const u8,
+                dest.as_mut_ptr().cast::<u8>(),
+                8,
+            );
+        }
+    }
+
+    #[inline(always)]
+    fn store_u8(self, dest: &mut [u8]) {
+        assert!(dest.len() >= Self::LEN);
+        // Truncating narrow i32 -> u8: take the lowest byte of each 32-bit lane.
+        // Input bytes: [b0,_,_,_, b1,_,_,_, b2,_,_,_, b3,_,_,_]
+        // Output bytes (lower 4): [b0, b1, b2, b3]
+        let packed =
+            i8x16_shuffle::<0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>(self.0, self.0);
+        let val = u32x4_extract_lane::<0>(packed);
+        // SAFETY: we checked that `dest` has enough space.
+        unsafe {
+            std::ptr::copy_nonoverlapping(&val as *const u32 as *const u8, dest.as_mut_ptr(), 4);
+        }
+    }
+}
+
+impl Add<I32VecSimd128> for I32VecSimd128 {
+    type Output = I32VecSimd128;
+    fn_simd128! {
+        fn add(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(i32x4_add(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl Sub<I32VecSimd128> for I32VecSimd128 {
+    type Output = I32VecSimd128;
+    fn_simd128! {
+        fn sub(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(i32x4_sub(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl Mul<I32VecSimd128> for I32VecSimd128 {
+    type Output = I32VecSimd128;
+    fn_simd128! {
+        fn mul(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(i32x4_mul(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl Neg for I32VecSimd128 {
+    type Output = I32VecSimd128;
+    fn_simd128! {
+        fn neg(this: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(i32x4_neg(this.0), this.1)
+        }
+    }
+}
+
+impl BitAnd<I32VecSimd128> for I32VecSimd128 {
+    type Output = I32VecSimd128;
+    fn_simd128! {
+        fn bitand(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(v128_and(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl BitOr<I32VecSimd128> for I32VecSimd128 {
+    type Output = I32VecSimd128;
+    fn_simd128! {
+        fn bitor(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(v128_or(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl BitXor<I32VecSimd128> for I32VecSimd128 {
+    type Output = I32VecSimd128;
+    fn_simd128! {
+        fn bitxor(this: I32VecSimd128, rhs: I32VecSimd128) -> I32VecSimd128 {
+            I32VecSimd128(v128_xor(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl AddAssign<I32VecSimd128> for I32VecSimd128 {
+    fn_simd128! {
+        fn add_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
+            this.0 = i32x4_add(this.0, rhs.0)
+        }
+    }
+}
+
+impl SubAssign<I32VecSimd128> for I32VecSimd128 {
+    fn_simd128! {
+        fn sub_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
+            this.0 = i32x4_sub(this.0, rhs.0)
+        }
+    }
+}
+
+impl MulAssign<I32VecSimd128> for I32VecSimd128 {
+    fn_simd128! {
+        fn mul_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
+            this.0 = i32x4_mul(this.0, rhs.0)
+        }
+    }
+}
+
+impl BitAndAssign<I32VecSimd128> for I32VecSimd128 {
+    fn_simd128! {
+        fn bitand_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
+            this.0 = v128_and(this.0, rhs.0);
+        }
+    }
+}
+
+impl BitOrAssign<I32VecSimd128> for I32VecSimd128 {
+    fn_simd128! {
+        fn bitor_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
+            this.0 = v128_or(this.0, rhs.0);
+        }
+    }
+}
+
+impl BitXorAssign<I32VecSimd128> for I32VecSimd128 {
+    fn_simd128! {
+        fn bitxor_assign(this: &mut I32VecSimd128, rhs: I32VecSimd128) {
+            this.0 = v128_xor(this.0, rhs.0);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct U32VecSimd128(v128, Simd128Descriptor);
+
+impl U32SimdVec for U32VecSimd128 {
+    type Descriptor = Simd128Descriptor;
+
+    const LEN: usize = 4;
+
+    fn_simd128! {
+        fn bitcast_to_i32(this: U32VecSimd128) -> I32VecSimd128 {
+            // v128 is untyped; no conversion needed.
+            I32VecSimd128(this.0, this.1)
+        }
+    }
+
+    #[inline(always)]
+    fn shr<const AMOUNT_U: u32, const AMOUNT_I: i32>(self) -> Self {
+        Self(u32x4_shr(self.0, AMOUNT_U), self.1)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct U8VecSimd128(v128, Simd128Descriptor);
+
+// SAFETY: The methods in this implementation that write to `MaybeUninit` (store_interleaved_*)
+// ensure that they write valid data to the output slice without reading uninitialized memory.
+unsafe impl U8SimdVec for U8VecSimd128 {
+    type Descriptor = Simd128Descriptor;
+    const LEN: usize = 16;
+
+    #[inline(always)]
+    fn load(d: Self::Descriptor, mem: &[u8]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        Self(unsafe { v128_load(mem.as_ptr().cast()) }, d)
+    }
+
+    #[inline(always)]
+    fn splat(d: Self::Descriptor, v: u8) -> Self {
+        Self(u8x16_splat(v), d)
+    }
+
+    #[inline(always)]
+    fn store(&self, mem: &mut [u8]) {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        unsafe { v128_store(mem.as_mut_ptr().cast(), self.0) }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<u8>]) {
+        assert!(dest.len() >= 2 * Self::LEN);
+        let lo = i8x16_shuffle::<0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23>(a.0, b.0);
+        let hi =
+            i8x16_shuffle::<8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31>(a.0, b.0);
+        // SAFETY: dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, lo);
+            v128_store(ptr.add(1), hi);
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<u8>]) {
+        assert!(dest.len() >= 3 * Self::LEN);
+        // 3-way byte interleave using 2 shuffles per output vector.
+        let ab0 = i8x16_shuffle::<0, 16, 0, 1, 17, 0, 2, 18, 0, 3, 19, 0, 4, 20, 0, 5>(a.0, b.0);
+        let out0 =
+            i8x16_shuffle::<0, 1, 16, 3, 4, 17, 6, 7, 18, 9, 10, 19, 12, 13, 20, 15>(ab0, c.0);
+
+        let ab1 = i8x16_shuffle::<21, 0, 6, 22, 0, 7, 23, 0, 8, 24, 0, 9, 25, 0, 10, 26>(a.0, b.0);
+        let out1 =
+            i8x16_shuffle::<0, 21, 2, 3, 22, 5, 6, 23, 8, 9, 24, 11, 12, 25, 14, 15>(ab1, c.0);
+
+        let ab2 =
+            i8x16_shuffle::<0, 11, 27, 0, 12, 28, 0, 13, 29, 0, 14, 30, 0, 15, 31, 0>(a.0, b.0);
+        let out2 =
+            i8x16_shuffle::<26, 1, 2, 27, 4, 5, 28, 7, 8, 29, 10, 11, 30, 13, 14, 31>(ab2, c.0);
+
+        // SAFETY: dest has 3*16 = 48 bytes.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, out0);
+            v128_store(ptr.add(1), out1);
+            v128_store(ptr.add(2), out2);
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_4_uninit(
+        a: Self,
+        b: Self,
+        c: Self,
+        d: Self,
+        dest: &mut [MaybeUninit<u8>],
+    ) {
+        assert!(dest.len() >= 4 * Self::LEN);
+        // Stage 1: interleave a,b and c,d
+        let ab_lo =
+            i8x16_shuffle::<0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23>(a.0, b.0);
+        let ab_hi =
+            i8x16_shuffle::<8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31>(a.0, b.0);
+        let cd_lo =
+            i8x16_shuffle::<0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23>(c.0, d.0);
+        let cd_hi =
+            i8x16_shuffle::<8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31>(c.0, d.0);
+
+        // Stage 2: interleave ab and cd at 16-bit granularity
+        let out0 =
+            i8x16_shuffle::<0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23>(ab_lo, cd_lo);
+        let out1 = i8x16_shuffle::<8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31>(
+            ab_lo, cd_lo,
+        );
+        let out2 =
+            i8x16_shuffle::<0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23>(ab_hi, cd_hi);
+        let out3 = i8x16_shuffle::<8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31>(
+            ab_hi, cd_hi,
+        );
+
+        // SAFETY: dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, out0);
+            v128_store(ptr.add(1), out1);
+            v128_store(ptr.add(2), out2);
+            v128_store(ptr.add(3), out3);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct U16VecSimd128(v128, Simd128Descriptor);
+
+// SAFETY: The methods in this implementation that write to `MaybeUninit` (store_interleaved_*)
+// ensure that they write valid data to the output slice without reading uninitialized memory.
+unsafe impl U16SimdVec for U16VecSimd128 {
+    type Descriptor = Simd128Descriptor;
+    const LEN: usize = 8;
+
+    #[inline(always)]
+    fn load(d: Self::Descriptor, mem: &[u16]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        Self(unsafe { v128_load(mem.as_ptr().cast()) }, d)
+    }
+
+    #[inline(always)]
+    fn splat(d: Self::Descriptor, v: u16) -> Self {
+        Self(u16x8_splat(v), d)
+    }
+
+    #[inline(always)]
+    fn store(&self, mem: &mut [u16]) {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
+        unsafe { v128_store(mem.as_mut_ptr().cast(), self.0) }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<u16>]) {
+        assert!(dest.len() >= 2 * Self::LEN);
+        let lo = i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(a.0, b.0);
+        let hi = i16x8_shuffle::<4, 12, 5, 13, 6, 14, 7, 15>(a.0, b.0);
+        // SAFETY: dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, lo);
+            v128_store(ptr.add(1), hi);
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<u16>]) {
+        assert!(dest.len() >= 3 * Self::LEN);
+        // 3-way u16 interleave using 2 shuffles per output vector.
+        let ab0 = i16x8_shuffle::<0, 8, 0, 1, 9, 0, 2, 10>(a.0, b.0);
+        let out0 = i16x8_shuffle::<0, 1, 8, 3, 4, 9, 6, 7>(ab0, c.0);
+
+        let ab1 = i16x8_shuffle::<0, 3, 11, 0, 4, 12, 0, 5>(a.0, b.0);
+        let out1 = i16x8_shuffle::<10, 1, 2, 11, 4, 5, 12, 7>(ab1, c.0);
+
+        let ab2 = i16x8_shuffle::<13, 0, 6, 14, 0, 7, 15, 0>(a.0, b.0);
+        let out2 = i16x8_shuffle::<0, 13, 2, 3, 14, 5, 6, 15>(ab2, c.0);
+
+        // SAFETY: dest has 3*8 = 24 u16 elements.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, out0);
+            v128_store(ptr.add(1), out1);
+            v128_store(ptr.add(2), out2);
+        }
+    }
+
+    #[inline(always)]
+    fn store_interleaved_4_uninit(
+        a: Self,
+        b: Self,
+        c: Self,
+        d: Self,
+        dest: &mut [MaybeUninit<u16>],
+    ) {
+        assert!(dest.len() >= 4 * Self::LEN);
+        // Stage 1: interleave a,b and c,d at 16-bit level
+        let ab_lo = i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(a.0, b.0);
+        let ab_hi = i16x8_shuffle::<4, 12, 5, 13, 6, 14, 7, 15>(a.0, b.0);
+        let cd_lo = i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(c.0, d.0);
+        let cd_hi = i16x8_shuffle::<4, 12, 5, 13, 6, 14, 7, 15>(c.0, d.0);
+
+        // Stage 2: interleave at 32-bit level
+        let out0 = i32x4_shuffle::<0, 4, 1, 5>(ab_lo, cd_lo);
+        let out1 = i32x4_shuffle::<2, 6, 3, 7>(ab_lo, cd_lo);
+        let out2 = i32x4_shuffle::<0, 4, 1, 5>(ab_hi, cd_hi);
+        let out3 = i32x4_shuffle::<2, 6, 3, 7>(ab_hi, cd_hi);
+
+        // SAFETY: dest has enough space.
+        unsafe {
+            let ptr = dest.as_mut_ptr().cast::<v128>();
+            v128_store(ptr, out0);
+            v128_store(ptr.add(1), out1);
+            v128_store(ptr.add(2), out2);
+            v128_store(ptr.add(3), out3);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct MaskSimd128(v128, Simd128Descriptor);
+
+impl SimdMask for MaskSimd128 {
+    type Descriptor = Simd128Descriptor;
+
+    fn_simd128! {
+        fn if_then_else_f32(
+            this: MaskSimd128,
+            if_true: F32VecSimd128,
+            if_false: F32VecSimd128,
+        ) -> F32VecSimd128 {
+            #[cfg(target_feature = "relaxed-simd")]
+            { F32VecSimd128(i32x4_relaxed_laneselect(if_true.0, if_false.0, this.0), this.1) }
+            #[cfg(not(target_feature = "relaxed-simd"))]
+            { F32VecSimd128(v128_bitselect(if_true.0, if_false.0, this.0), this.1) }
+        }
+
+        fn if_then_else_i32(
+            this: MaskSimd128,
+            if_true: I32VecSimd128,
+            if_false: I32VecSimd128,
+        ) -> I32VecSimd128 {
+            #[cfg(target_feature = "relaxed-simd")]
+            { I32VecSimd128(i32x4_relaxed_laneselect(if_true.0, if_false.0, this.0), this.1) }
+            #[cfg(not(target_feature = "relaxed-simd"))]
+            { I32VecSimd128(v128_bitselect(if_true.0, if_false.0, this.0), this.1) }
+        }
+
+        fn maskz_i32(this: MaskSimd128, v: I32VecSimd128) -> I32VecSimd128 {
+            // Zero out lanes where mask is true: v AND NOT mask
+            I32VecSimd128(v128_andnot(v.0, this.0), this.1)
+        }
+
+        fn andnot(this: MaskSimd128, rhs: MaskSimd128) -> MaskSimd128 {
+            // !this & rhs
+            MaskSimd128(v128_andnot(rhs.0, this.0), this.1)
+        }
+
+        fn all(this: MaskSimd128) -> bool {
+            u32x4_all_true(this.0)
+        }
+    }
+}
+
+impl BitAnd<MaskSimd128> for MaskSimd128 {
+    type Output = MaskSimd128;
+    fn_simd128! {
+        fn bitand(this: MaskSimd128, rhs: MaskSimd128) -> MaskSimd128 {
+            MaskSimd128(v128_and(this.0, rhs.0), this.1)
+        }
+    }
+}
+
+impl BitOr<MaskSimd128> for MaskSimd128 {
+    type Output = MaskSimd128;
+    fn_simd128! {
+        fn bitor(this: MaskSimd128, rhs: MaskSimd128) -> MaskSimd128 {
+            MaskSimd128(v128_or(this.0, rhs.0), this.1)
+        }
+    }
+}

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -118,17 +118,12 @@ unsafe impl F32SimdVec for F32VecSimd128 {
         assert!(dest.len() >= 3 * Self::LEN);
         // a = [a0, a1, a2, a3], b = [b0, b1, b2, b3], c = [c0, c1, c2, c3]
         // out0 = [a0, b0, c0, a1], out1 = [b1, c1, a2, b2], out2 = [c2, a3, b3, c3]
-        let ab01 = i32x4_shuffle::<0, 4, 0, 0>(a.0, b.0); // [a0, b0, ?, ?]
-        let ca01 = i32x4_shuffle::<0, 5, 0, 0>(c.0, a.0); // [c0, a1, ?, ?]
-        let out0 = i64x2_shuffle::<0, 2>(ab01, ca01); // [a0, b0, c0, a1]
-
-        let bc1 = i32x4_shuffle::<1, 5, 0, 0>(b.0, c.0); // [b1, c1, ?, ?]
-        let ab2 = i32x4_shuffle::<2, 6, 0, 0>(a.0, b.0); // [a2, b2, ?, ?]
-        let out1 = i64x2_shuffle::<0, 2>(bc1, ab2); // [b1, c1, a2, b2]
-
-        let ca2 = i32x4_shuffle::<2, 7, 0, 0>(c.0, a.0); // [c2, a3, ?, ?]
-        let bc3 = i32x4_shuffle::<3, 7, 0, 0>(b.0, c.0); // [b3, c3, ?, ?]
-        let out2 = i64x2_shuffle::<0, 2>(ca2, bc3); // [c2, a3, b3, c3]
+        let ab_lo = i32x4_shuffle::<0, 4, 1, 5>(a.0, b.0); // [a0, b0, a1, b1]
+        let ab_hi = i32x4_shuffle::<2, 6, 3, 7>(a.0, b.0); // [a2, b2, a3, b3]
+        let out0 = i32x4_shuffle::<0, 1, 4, 2>(ab_lo, c.0); // [a0, b0, c0, a1]
+        let tmp1 = i32x4_shuffle::<3, 5, 0, 0>(ab_lo, c.0); // [b1, c1, ?, ?]
+        let out1 = i32x4_shuffle::<0, 1, 4, 5>(tmp1, ab_hi); // [b1, c1, a2, b2]
+        let out2 = i32x4_shuffle::<6, 2, 3, 7>(ab_hi, c.0); // [c2, a3, b3, c3]
 
         // SAFETY: dest has enough space.
         unsafe {
@@ -186,47 +181,37 @@ unsafe impl F32SimdVec for F32VecSimd128 {
     ) {
         assert!(dest.len() >= 8 * Self::LEN);
 
-        // Use zip to interleave pairs
-        let ae_lo = i32x4_shuffle::<0, 4, 1, 5>(a.0, e.0);
-        let ae_hi = i32x4_shuffle::<2, 6, 3, 7>(a.0, e.0);
-        let bf_lo = i32x4_shuffle::<0, 4, 1, 5>(b.0, f.0);
-        let bf_hi = i32x4_shuffle::<2, 6, 3, 7>(b.0, f.0);
-        let cg_lo = i32x4_shuffle::<0, 4, 1, 5>(c.0, g.0);
-        let cg_hi = i32x4_shuffle::<2, 6, 3, 7>(c.0, g.0);
-        let dh_lo = i32x4_shuffle::<0, 4, 1, 5>(d.0, h.0);
-        let dh_hi = i32x4_shuffle::<2, 6, 3, 7>(d.0, h.0);
+        // Interleave adjacent pairs
+        let ab_lo = i32x4_shuffle::<0, 4, 1, 5>(a.0, b.0);
+        let ab_hi = i32x4_shuffle::<2, 6, 3, 7>(a.0, b.0);
+        let cd_lo = i32x4_shuffle::<0, 4, 1, 5>(c.0, d.0);
+        let cd_hi = i32x4_shuffle::<2, 6, 3, 7>(c.0, d.0);
+        let ef_lo = i32x4_shuffle::<0, 4, 1, 5>(e.0, f.0);
+        let ef_hi = i32x4_shuffle::<2, 6, 3, 7>(e.0, f.0);
+        let gh_lo = i32x4_shuffle::<0, 4, 1, 5>(g.0, h.0);
+        let gh_hi = i32x4_shuffle::<2, 6, 3, 7>(g.0, h.0);
 
-        // Now interleave ae with bf, and cg with dh
-        let aebf_0 = i32x4_shuffle::<0, 4, 1, 5>(ae_lo, bf_lo);
-        let aebf_1 = i32x4_shuffle::<2, 6, 3, 7>(ae_lo, bf_lo);
-        let aebf_2 = i32x4_shuffle::<0, 4, 1, 5>(ae_hi, bf_hi);
-        let aebf_3 = i32x4_shuffle::<2, 6, 3, 7>(ae_hi, bf_hi);
-        let cgdh_0 = i32x4_shuffle::<0, 4, 1, 5>(cg_lo, dh_lo);
-        let cgdh_1 = i32x4_shuffle::<2, 6, 3, 7>(cg_lo, dh_lo);
-        let cgdh_2 = i32x4_shuffle::<0, 4, 1, 5>(cg_hi, dh_hi);
-        let cgdh_3 = i32x4_shuffle::<2, 6, 3, 7>(cg_hi, dh_hi);
-
-        // Final interleave using 64-bit shuffles
-        let out0 = i64x2_shuffle::<0, 2>(aebf_0, cgdh_0);
-        let out1 = i64x2_shuffle::<1, 3>(aebf_0, cgdh_0);
-        let out2 = i64x2_shuffle::<0, 2>(aebf_1, cgdh_1);
-        let out3 = i64x2_shuffle::<1, 3>(aebf_1, cgdh_1);
-        let out4 = i64x2_shuffle::<0, 2>(aebf_2, cgdh_2);
-        let out5 = i64x2_shuffle::<1, 3>(aebf_2, cgdh_2);
-        let out6 = i64x2_shuffle::<0, 2>(aebf_3, cgdh_3);
-        let out7 = i64x2_shuffle::<1, 3>(aebf_3, cgdh_3);
+        // Combine into 4-wide groups
+        let abcd_0 = i64x2_shuffle::<0, 2>(ab_lo, cd_lo);
+        let abcd_1 = i64x2_shuffle::<1, 3>(ab_lo, cd_lo);
+        let abcd_2 = i64x2_shuffle::<0, 2>(ab_hi, cd_hi);
+        let abcd_3 = i64x2_shuffle::<1, 3>(ab_hi, cd_hi);
+        let efgh_0 = i64x2_shuffle::<0, 2>(ef_lo, gh_lo);
+        let efgh_1 = i64x2_shuffle::<1, 3>(ef_lo, gh_lo);
+        let efgh_2 = i64x2_shuffle::<0, 2>(ef_hi, gh_hi);
+        let efgh_3 = i64x2_shuffle::<1, 3>(ef_hi, gh_hi);
 
         // SAFETY: we just checked that dest has enough space.
         unsafe {
             let ptr = dest.as_mut_ptr().cast::<v128>();
-            v128_store(ptr, out0);
-            v128_store(ptr.add(1), out1);
-            v128_store(ptr.add(2), out2);
-            v128_store(ptr.add(3), out3);
-            v128_store(ptr.add(4), out4);
-            v128_store(ptr.add(5), out5);
-            v128_store(ptr.add(6), out6);
-            v128_store(ptr.add(7), out7);
+            v128_store(ptr, abcd_0);
+            v128_store(ptr.add(1), efgh_0);
+            v128_store(ptr.add(2), abcd_1);
+            v128_store(ptr.add(3), efgh_1);
+            v128_store(ptr.add(4), abcd_2);
+            v128_store(ptr.add(5), efgh_2);
+            v128_store(ptr.add(6), abcd_3);
+            v128_store(ptr.add(7), efgh_3);
         }
     }
 
@@ -402,12 +387,8 @@ unsafe impl F32SimdVec for F32VecSimd128 {
         let i16s = i16x8_narrow_i32x4(i32s, i32s);
         // Saturate i16 -> u8 (signed-to-unsigned narrow, clamping to [0, 255])
         let u8s = u8x16_narrow_i16x8(i16s, i16s);
-        // Store lower 4 bytes
-        let val = u32x4_extract_lane::<0>(u8s);
         // SAFETY: we checked dest has enough space.
-        unsafe {
-            std::ptr::copy_nonoverlapping(&val as *const u32 as *const u8, dest.as_mut_ptr(), 4);
-        }
+        unsafe { v128_store32_lane::<0>(u8s, dest.as_mut_ptr().cast()) }
     }
 
     #[inline(always)]

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -211,8 +211,12 @@ impl F32SimdVec for F32VecSimd128 {
         assert!(src.len() >= 2 * Self::LEN);
         // src = [a0, b0, a1, b1, a2, b2, a3, b3]
         // SAFETY: we just checked that `src` has enough space.
-        let lo = unsafe { v128_load(src.as_ptr().cast()) }; // [a0, b0, a1, b1]
-        let hi = unsafe { v128_load(src.as_ptr().add(4).cast()) }; // [a2, b2, a3, b3]
+        let (lo, hi) = unsafe {
+            (
+                v128_load(src.as_ptr().cast()),        // [a0, b0, a1, b1]
+                v128_load(src.as_ptr().add(4).cast()), // [a2, b2, a3, b3]
+            )
+        };
         let a = i32x4_shuffle::<0, 2, 4, 6>(lo, hi); // [a0, a1, a2, a3]
         let b = i32x4_shuffle::<1, 3, 5, 7>(lo, hi); // [b0, b1, b2, b3]
         (Self(a, d), Self(b, d))
@@ -224,9 +228,13 @@ impl F32SimdVec for F32VecSimd128 {
         // src = [a0,b0,c0, a1,b1,c1, a2,b2,c2, a3,b3,c3]
         // v0 = [a0, b0, c0, a1], v1 = [b1, c1, a2, b2], v2 = [c2, a3, b3, c3]
         // SAFETY: we just checked that `src` has enough space.
-        let v0 = unsafe { v128_load(src.as_ptr().cast()) };
-        let v1 = unsafe { v128_load(src.as_ptr().add(4).cast()) };
-        let v2 = unsafe { v128_load(src.as_ptr().add(8).cast()) };
+        let (v0, v1, v2) = unsafe {
+            (
+                v128_load(src.as_ptr().cast()),
+                v128_load(src.as_ptr().add(4).cast()),
+                v128_load(src.as_ptr().add(8).cast()),
+            )
+        };
 
         // a = [a0, a1, a2, a3] = v0[0], v0[3], v1[2], v2[1]
         let a01 = i32x4_shuffle::<0, 3, 0, 0>(v0, v0); // [a0, a1, ?, ?]
@@ -251,10 +259,14 @@ impl F32SimdVec for F32VecSimd128 {
         assert!(src.len() >= 4 * Self::LEN);
         // src = [a0,b0,c0,d0, a1,b1,c1,d1, a2,b2,c2,d2, a3,b3,c3,d3]
         // SAFETY: we just checked that `src` has enough space.
-        let v0 = unsafe { v128_load(src.as_ptr().cast()) }; // [a0, b0, c0, d0]
-        let v1 = unsafe { v128_load(src.as_ptr().add(4).cast()) }; // [a1, b1, c1, d1]
-        let v2 = unsafe { v128_load(src.as_ptr().add(8).cast()) }; // [a2, b2, c2, d2]
-        let v3 = unsafe { v128_load(src.as_ptr().add(12).cast()) }; // [a3, b3, c3, d3]
+        let (v0, v1, v2, v3) = unsafe {
+            (
+                v128_load(src.as_ptr().cast()),         // [a0, b0, c0, d0]
+                v128_load(src.as_ptr().add(4).cast()),  // [a1, b1, c1, d1]
+                v128_load(src.as_ptr().add(8).cast()),  // [a2, b2, c2, d2]
+                v128_load(src.as_ptr().add(12).cast()), // [a3, b3, c3, d3]
+            )
+        };
 
         // Stage 1: interleave pairs
         let ac02 = i32x4_shuffle::<0, 4, 2, 6>(v0, v1); // [a0, a1, c0, c1]
@@ -275,7 +287,7 @@ impl F32SimdVec for F32VecSimd128 {
         assert!(data.len() > 3 * stride);
 
         let p0 = F32VecSimd128::load_array(d, &data[0]).0;
-        let p1 = F32VecSimd128::load_array(d, &data[1 * stride]).0;
+        let p1 = F32VecSimd128::load_array(d, &data[stride]).0;
         let p2 = F32VecSimd128::load_array(d, &data[2 * stride]).0;
         let p3 = F32VecSimd128::load_array(d, &data[3 * stride]).0;
 
@@ -285,7 +297,7 @@ impl F32SimdVec for F32VecSimd128 {
         let tr3 = i32x4_shuffle::<2, 6, 3, 7>(p2, p3);
 
         F32VecSimd128(i64x2_shuffle::<0, 2>(tr0, tr2), d).store_array(&mut data[0]);
-        F32VecSimd128(i64x2_shuffle::<1, 3>(tr0, tr2), d).store_array(&mut data[1 * stride]);
+        F32VecSimd128(i64x2_shuffle::<1, 3>(tr0, tr2), d).store_array(&mut data[stride]);
         F32VecSimd128(i64x2_shuffle::<0, 2>(tr1, tr3), d).store_array(&mut data[2 * stride]);
         F32VecSimd128(i64x2_shuffle::<1, 3>(tr1, tr3), d).store_array(&mut data[3 * stride]);
     }
@@ -447,6 +459,7 @@ impl F32SimdVec for F32VecSimd128 {
     #[inline(always)]
     fn load_f16_bits(d: Self::Descriptor, mem: &[u16]) -> Self {
         assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space.
         let lo = unsafe { v128_load64_splat(mem.as_ptr().cast()) };
         let zero = i32x4_splat(0);
         let wide =
@@ -478,8 +491,12 @@ impl F32SimdVec for F32VecSimd128 {
         // Convert f32 table to BF16 packed in 128 bits (16 bytes for 8 entries)
         // BF16 is the high 16 bits of f32
         // SAFETY: `table` has 8 elements, so both loads are in bounds.
-        let table_lo = unsafe { v128_load(table.as_ptr().cast()) };
-        let table_hi = unsafe { v128_load(table.as_ptr().add(4).cast()) };
+        let (table_lo, table_hi) = unsafe {
+            (
+                v128_load(table.as_ptr().cast()),
+                v128_load(table.as_ptr().add(4).cast()),
+            )
+        };
 
         // Shift right by 16 to get BF16 values, then narrow to 16-bit
         let lo_shifted = u32x4_shr(table_lo, 16);

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -5,7 +5,6 @@
 
 use std::{
     arch::wasm32::*,
-    mem::MaybeUninit,
     ops::{
         Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
         DivAssign, Mul, MulAssign, Neg, Sub, SubAssign,
@@ -67,9 +66,7 @@ impl SimdDescriptor for Simd128Descriptor {
 #[repr(transparent)]
 pub struct F32VecSimd128(v128, Simd128Descriptor);
 
-// SAFETY: The methods in this implementation that write to `MaybeUninit` (store_interleaved_*)
-// ensure that they write valid data to the output slice without reading uninitialized memory.
-unsafe impl F32SimdVec for F32VecSimd128 {
+impl F32SimdVec for F32VecSimd128 {
     type Descriptor = Simd128Descriptor;
 
     const LEN: usize = 4;
@@ -99,7 +96,7 @@ unsafe impl F32SimdVec for F32VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<f32>]) {
+    fn store_interleaved_2(a: Self, b: Self, dest: &mut [f32]) {
         assert!(dest.len() >= 2 * Self::LEN);
         // a = [a0, a1, a2, a3], b = [b0, b1, b2, b3]
         // out0 = [a0, b0, a1, b1], out1 = [a2, b2, a3, b3]
@@ -114,7 +111,7 @@ unsafe impl F32SimdVec for F32VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<f32>]) {
+    fn store_interleaved_3(a: Self, b: Self, c: Self, dest: &mut [f32]) {
         assert!(dest.len() >= 3 * Self::LEN);
         // a = [a0, a1, a2, a3], b = [b0, b1, b2, b3], c = [c0, c1, c2, c3]
         // out0 = [a0, b0, c0, a1], out1 = [b1, c1, a2, b2], out2 = [c2, a3, b3, c3]
@@ -135,13 +132,7 @@ unsafe impl F32SimdVec for F32VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_4_uninit(
-        a: Self,
-        b: Self,
-        c: Self,
-        d: Self,
-        dest: &mut [MaybeUninit<f32>],
-    ) {
+    fn store_interleaved_4(a: Self, b: Self, c: Self, d: Self, dest: &mut [f32]) {
         assert!(dest.len() >= 4 * Self::LEN);
         // a = [a0,a1,a2,a3], b = [b0,b1,b2,b3], c = [c0,c1,c2,c3], d = [d0,d1,d2,d3]
         // out = [a0,b0,c0,d0, a1,b1,c1,d1, a2,b2,c2,d2, a3,b3,c3,d3]
@@ -836,9 +827,7 @@ impl U32SimdVec for U32VecSimd128 {
 #[repr(transparent)]
 pub struct U8VecSimd128(v128, Simd128Descriptor);
 
-// SAFETY: The methods in this implementation that write to `MaybeUninit` (store_interleaved_*)
-// ensure that they write valid data to the output slice without reading uninitialized memory.
-unsafe impl U8SimdVec for U8VecSimd128 {
+impl U8SimdVec for U8VecSimd128 {
     type Descriptor = Simd128Descriptor;
     const LEN: usize = 16;
 
@@ -862,7 +851,7 @@ unsafe impl U8SimdVec for U8VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<u8>]) {
+    fn store_interleaved_2(a: Self, b: Self, dest: &mut [u8]) {
         assert!(dest.len() >= 2 * Self::LEN);
         let lo = i8x16_shuffle::<0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23>(a.0, b.0);
         let hi =
@@ -876,7 +865,7 @@ unsafe impl U8SimdVec for U8VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<u8>]) {
+    fn store_interleaved_3(a: Self, b: Self, c: Self, dest: &mut [u8]) {
         assert!(dest.len() >= 3 * Self::LEN);
         // 3-way byte interleave using 2 shuffles per output vector.
         let ab0 = i8x16_shuffle::<0, 16, 0, 1, 17, 0, 2, 18, 0, 3, 19, 0, 4, 20, 0, 5>(a.0, b.0);
@@ -902,13 +891,7 @@ unsafe impl U8SimdVec for U8VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_4_uninit(
-        a: Self,
-        b: Self,
-        c: Self,
-        d: Self,
-        dest: &mut [MaybeUninit<u8>],
-    ) {
+    fn store_interleaved_4(a: Self, b: Self, c: Self, d: Self, dest: &mut [u8]) {
         assert!(dest.len() >= 4 * Self::LEN);
         // Stage 1: interleave a,b and c,d
         let ab_lo =
@@ -947,9 +930,7 @@ unsafe impl U8SimdVec for U8VecSimd128 {
 #[repr(transparent)]
 pub struct U16VecSimd128(v128, Simd128Descriptor);
 
-// SAFETY: The methods in this implementation that write to `MaybeUninit` (store_interleaved_*)
-// ensure that they write valid data to the output slice without reading uninitialized memory.
-unsafe impl U16SimdVec for U16VecSimd128 {
+impl U16SimdVec for U16VecSimd128 {
     type Descriptor = Simd128Descriptor;
     const LEN: usize = 8;
 
@@ -973,7 +954,7 @@ unsafe impl U16SimdVec for U16VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_2_uninit(a: Self, b: Self, dest: &mut [MaybeUninit<u16>]) {
+    fn store_interleaved_2(a: Self, b: Self, dest: &mut [u16]) {
         assert!(dest.len() >= 2 * Self::LEN);
         let lo = i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(a.0, b.0);
         let hi = i16x8_shuffle::<4, 12, 5, 13, 6, 14, 7, 15>(a.0, b.0);
@@ -986,7 +967,7 @@ unsafe impl U16SimdVec for U16VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_3_uninit(a: Self, b: Self, c: Self, dest: &mut [MaybeUninit<u16>]) {
+    fn store_interleaved_3(a: Self, b: Self, c: Self, dest: &mut [u16]) {
         assert!(dest.len() >= 3 * Self::LEN);
         // 3-way u16 interleave using 2 shuffles per output vector.
         let ab0 = i16x8_shuffle::<0, 8, 0, 1, 9, 0, 2, 10>(a.0, b.0);
@@ -1008,13 +989,7 @@ unsafe impl U16SimdVec for U16VecSimd128 {
     }
 
     #[inline(always)]
-    fn store_interleaved_4_uninit(
-        a: Self,
-        b: Self,
-        c: Self,
-        d: Self,
-        dest: &mut [MaybeUninit<u16>],
-    ) {
+    fn store_interleaved_4(a: Self, b: Self, c: Self, d: Self, dest: &mut [u16]) {
         assert!(dest.len() >= 4 * Self::LEN);
         // Stage 1: interleave a,b and c,d at 16-bit level
         let ab_lo = i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(a.0, b.0);

--- a/jxl_simd/src/x86_64/avx.rs
+++ b/jxl_simd/src/x86_64/avx.rs
@@ -700,7 +700,7 @@ unsafe impl F32SimdVec for F32VecAvx {
         #[inline]
         fn store_f16_bits_impl(v: __m256, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx::LEN);
-            let bits = _mm256_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
+            let bits = _mm256_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT }>(v);
             // SAFETY: dest.len() >= 8 is checked above. _mm_storeu_si128 supports unaligned stores.
             unsafe { _mm_storeu_si128(dest.as_mut_ptr().cast(), bits) };
         }

--- a/jxl_simd/src/x86_64/avx.rs
+++ b/jxl_simd/src/x86_64/avx.rs
@@ -680,7 +680,7 @@ impl F32SimdVec for F32VecAvx {
         #[inline]
         fn store_f16_bits_impl(v: __m256, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx::LEN);
-            let bits = _mm256_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT }>(v);
+            let bits = _mm256_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
             // SAFETY: dest.len() >= 8 is checked above. _mm_storeu_si128 supports unaligned stores.
             unsafe { _mm_storeu_si128(dest.as_mut_ptr().cast(), bits) };
         }

--- a/jxl_simd/src/x86_64/avx.rs
+++ b/jxl_simd/src/x86_64/avx.rs
@@ -680,7 +680,7 @@ impl F32SimdVec for F32VecAvx {
         #[inline]
         fn store_f16_bits_impl(v: __m256, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx::LEN);
-            let bits = _mm256_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
+            let bits = _mm256_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT }>(v);
             // SAFETY: dest.len() >= 8 is checked above. _mm_storeu_si128 supports unaligned stores.
             unsafe { _mm_storeu_si128(dest.as_mut_ptr().cast(), bits) };
         }

--- a/jxl_simd/src/x86_64/avx512.rs
+++ b/jxl_simd/src/x86_64/avx512.rs
@@ -757,7 +757,7 @@ unsafe impl F32SimdVec for F32VecAvx512 {
         #[inline]
         fn store_f16_bits_impl(v: __m512, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx512::LEN);
-            let bits = _mm512_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
+            let bits = _mm512_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT }>(v);
             // SAFETY: dest.len() >= 16 is checked above.
             unsafe { _mm256_storeu_si256(dest.as_mut_ptr().cast(), bits) };
         }

--- a/jxl_simd/src/x86_64/avx512.rs
+++ b/jxl_simd/src/x86_64/avx512.rs
@@ -737,7 +737,7 @@ impl F32SimdVec for F32VecAvx512 {
         #[inline]
         fn store_f16_bits_impl(v: __m512, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx512::LEN);
-            let bits = _mm512_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT }>(v);
+            let bits = _mm512_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
             // SAFETY: dest.len() >= 16 is checked above.
             unsafe { _mm256_storeu_si256(dest.as_mut_ptr().cast(), bits) };
         }

--- a/jxl_simd/src/x86_64/avx512.rs
+++ b/jxl_simd/src/x86_64/avx512.rs
@@ -737,7 +737,7 @@ impl F32SimdVec for F32VecAvx512 {
         #[inline]
         fn store_f16_bits_impl(v: __m512, dest: &mut [u16]) {
             assert!(dest.len() >= F32VecAvx512::LEN);
-            let bits = _mm512_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(v);
+            let bits = _mm512_cvtps_ph::<{ _MM_FROUND_TO_NEAREST_INT }>(v);
             // SAFETY: dest.len() >= 16 is checked above.
             unsafe { _mm256_storeu_si256(dest.as_mut_ptr().cast(), bits) };
         }

--- a/jxl_simd/src/x86_64/sse42.rs
+++ b/jxl_simd/src/x86_64/sse42.rs
@@ -625,7 +625,7 @@ unsafe impl F32SimdVec for F32VecSse42 {
     #[inline(always)]
     fn load_f16_bits(d: Self::Descriptor, mem: &[u16]) -> Self {
         assert!(mem.len() >= Self::LEN);
-        // SSE4.2 doesn't have F16C, use scalar conversion
+        // TODO: use SIMD bit manipulation instead of scalar loop (see wasm32/simd128.rs)
         let mut result = [0.0f32; 4];
         for i in 0..4 {
             result[i] = crate::f16::from_bits(mem[i]).to_f32();
@@ -636,7 +636,7 @@ unsafe impl F32SimdVec for F32VecSse42 {
     #[inline(always)]
     fn store_f16_bits(self, dest: &mut [u16]) {
         assert!(dest.len() >= Self::LEN);
-        // SSE4.2 doesn't have F16C, use scalar conversion
+        // TODO: use SIMD bit manipulation instead of scalar loop (see wasm32/simd128.rs)
         let mut tmp = [0.0f32; 4];
         self.store(&mut tmp);
         for i in 0..4 {

--- a/jxl_simd/src/x86_64/sse42.rs
+++ b/jxl_simd/src/x86_64/sse42.rs
@@ -605,7 +605,7 @@ impl F32SimdVec for F32VecSse42 {
     #[inline(always)]
     fn load_f16_bits(d: Self::Descriptor, mem: &[u16]) -> Self {
         assert!(mem.len() >= Self::LEN);
-        // SSE4.2 doesn't have F16C, use scalar conversion
+        // TODO: use SIMD bit manipulation instead of scalar loop (see wasm32/simd128.rs)
         let mut result = [0.0f32; 4];
         for i in 0..4 {
             result[i] = crate::f16::from_bits(mem[i]).to_f32();
@@ -616,7 +616,7 @@ impl F32SimdVec for F32VecSse42 {
     #[inline(always)]
     fn store_f16_bits(self, dest: &mut [u16]) {
         assert!(dest.len() >= Self::LEN);
-        // SSE4.2 doesn't have F16C, use scalar conversion
+        // TODO: use SIMD bit manipulation instead of scalar loop (see wasm32/simd128.rs)
         let mut tmp = [0.0f32; 4];
         self.store(&mut tmp);
         for i in 0..4 {

--- a/jxl_transforms/Cargo.toml
+++ b/jxl_transforms/Cargo.toml
@@ -14,11 +14,17 @@ license = "BSD-3-Clause"
 jxl_simd = { path = "../jxl_simd", version = "=0.4.2" }
 
 [dev-dependencies]
-criterion = { version = "0.7.0", features = ["html_reports"] }
 test-log = "0.2.14"
 paste = "1.0.15"
 rand = "0.9.2"
 rand_chacha = "0.9.0"
+
+# rayon doesn't support wasm32
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+criterion = { version = "0.7.0", default-features = false, features = ["html_reports", "plotters", "cargo_bench_support"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.7.0", features = ["html_reports"] }
 
 [features]
 all-simd = ["jxl_simd/all-simd"]
@@ -26,6 +32,7 @@ sse42 = ["jxl_simd/sse42"]
 avx = ["jxl_simd/avx"]
 avx512 = ["jxl_simd/avx512"]
 neon = ["jxl_simd/neon"]
+simd128 = ["jxl_simd/simd128"]
 
 [[bench]]
 name = "dct"

--- a/jxl_transforms/Cargo.toml
+++ b/jxl_transforms/Cargo.toml
@@ -14,11 +14,17 @@ license = "BSD-3-Clause"
 jxl_simd = { path = "../jxl_simd", version = "=0.4.3" }
 
 [dev-dependencies]
-criterion = { version = "0.7.0", features = ["html_reports"] }
 test-log = "0.2.14"
 paste = "1.0.15"
 rand = "0.9.2"
 rand_chacha = "0.9.0"
+
+# rayon doesn't support wasm32
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+criterion = { version = "0.7.0", default-features = false, features = ["html_reports", "plotters", "cargo_bench_support"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.7.0", features = ["html_reports"] }
 
 [features]
 all-simd = ["jxl_simd/all-simd"]
@@ -26,6 +32,7 @@ sse42 = ["jxl_simd/sse42"]
 avx = ["jxl_simd/avx"]
 avx512 = ["jxl_simd/avx512"]
 neon = ["jxl_simd/neon"]
+simd128 = ["jxl_simd/simd128"]
 
 [[bench]]
 name = "dct"


### PR DESCRIPTION
### Description

This PR adds simd128 support for jxl-rs when targeting wasm32. It does not include lcms2 integration for Wasm since this requires build toolchain changes and increases the scope of the PR.

In a local benchmark on an M4 Max, performance increased by 2.49x (8.9 to 22.1 MP/s), 2.02x (11.1 to 22.5 MP/s) and 1.35x (34.5 to 46.6 MP/s), respectively, for the `progressive.jxl`, `bike.jxl` and `cafe.jxl` test images.