### PR TITLE
perf: speed up distinct index collection in low-memory pipeline

### DIFF
--- a/jxl/src/render/low_memory_pipeline/helpers.rs
+++ b/jxl/src/render/low_memory_pipeline/helpers.rs
@@ -50,3 +50,68 @@ pub(super) fn get_distinct_indices<'a, T>(
 
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn get_distinct_indices_arbtest() {
+        arbtest::arbtest(|u| {
+            let outer_len = (u.arbitrary::<u8>()? % 6) as usize + 1;
+            let mut vals = Vec::with_capacity(outer_len);
+            let mut coords = Vec::new();
+
+            for a in 0..outer_len {
+                let inner_len = (u.arbitrary::<u8>()? % 6) as usize + 1;
+                let mut row = Vec::with_capacity(inner_len);
+                for b in 0..inner_len {
+                    row.push(((a as u32) << 16) | b as u32);
+                    coords.push((a, b));
+                }
+                vals.push(row);
+            }
+
+            let selected_len = (u.arbitrary::<u8>()? as usize % coords.len()) + 1;
+            let mut selected = (0..coords.len()).collect::<Vec<_>>();
+            for i in (1..selected.len()).rev() {
+                let j = u.arbitrary::<u16>()? as usize % (i + 1);
+                selected.swap(i, j);
+            }
+            selected.truncate(selected_len);
+            selected.sort_unstable();
+
+            let mut pos = (0..selected_len).collect::<Vec<_>>();
+            for i in (1..selected_len).rev() {
+                let j = u.arbitrary::<u16>()? as usize % (i + 1);
+                pos.swap(i, j);
+            }
+
+            let mut idx = Vec::with_capacity(selected_len);
+            let mut expected_before = vec![0u32; selected_len];
+            let mut expected_after = vec![0u32; selected_len];
+            for (i, &coord_idx) in selected.iter().enumerate() {
+                let (a, b) = coords[coord_idx];
+                let p = pos[i];
+                idx.push((a, b, p));
+                expected_before[p] = vals[a][b];
+                expected_after[p] = 0xA5A5_0000 | p as u32;
+            }
+
+            let mut refs = get_distinct_indices(&mut vals, &idx);
+            assert_eq!(refs.len(), selected_len);
+            for (i, r) in refs.iter_mut().enumerate() {
+                assert_eq!(**r, expected_before[i]);
+                **r = expected_after[i];
+            }
+            drop(refs);
+
+            for (i, &coord_idx) in selected.iter().enumerate() {
+                let (a, b) = coords[coord_idx];
+                let p = pos[i];
+                assert_eq!(vals[a][b], expected_after[p]);
+            }
+
+            Ok(())
+        });
+    }
+}

--- a/jxl/src/render/low_memory_pipeline/helpers.rs
+++ b/jxl/src/render/low_memory_pipeline/helpers.rs
@@ -3,112 +3,205 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#![allow(unsafe_code)]
+
+use crate::render::low_memory_pipeline::row_buffers::RowBuffer;
 use crate::util::ChannelVec;
 
-/// Returns a vector of &mut vals[idx[i].0][idx[i].1], in order of idx[i].2.
-/// Panics if any of the indices are out of bounds or
-/// (idx[i].0, idx[i].1) == (idx[j].0, idx[j].1) for i != j or indices are not
-/// sorted lexicographically.
-#[allow(unsafe_code)]
-pub(super) fn get_distinct_indices<'a, T>(
-    vals: &'a mut [impl AsMut<[T]>],
-    idx: &[(usize, usize, usize)],
-) -> ChannelVec<&'a mut T> {
-    // Build output directly using pointer math to avoid Option overhead.
-    // idx is sorted lexicographically by (a, b), so we iterate vals in order.
-    let mut result: ChannelVec<&'a mut T> = ChannelVec::new();
-    // Pre-fill with dummy values that will be overwritten.
-    // We need the result in idx[i].2 order, so we use a position-indexed buffer.
-    let n = idx.len();
-    let mut ptrs: ChannelVec<*mut T> = ChannelVec::new();
-    for _ in 0..n {
-        ptrs.push(std::ptr::null_mut());
-    }
+pub struct RowBuffers {
+    buffers: Vec<Vec<RowBuffer>>,
+    // The input buffer that each channel of each stage should use.
+    // This is indexed both by stage index (0 corresponds to input data, 1 to stage[0], etc) and by
+    // index *of those channels that are used*.
+    //
+    // # Safety invariant
+    // For each v in stage_input_buffer_index at index idx, we have that:
+    // - for all i = 0..v.len(), v[i].0 <= idx, v[i].0 < self.buffers.len()
+    //   and v[i].1 < self.buffers[v[i].0].len()
+    // - for all i != j in 0..v.len(), v[i] != v[j]
+    stage_input_buffer_index: Vec<Vec<(usize, usize)>>,
+}
 
-    let mut targets = idx.iter();
-    let mut target = targets.next().unwrap();
-    'outer: for (aa, bufs) in vals.iter_mut().enumerate() {
-        for (bb, buf) in bufs.as_mut().iter_mut().enumerate() {
-            let (a, b, pos) = target;
-            if aa == *a && bb == *b {
-                ptrs[*pos] = buf as *mut T;
-                if let Some(t) = targets.next() {
-                    target = t;
-                } else {
-                    break 'outer;
+impl RowBuffers {
+    pub fn new(
+        buffers: Vec<Vec<RowBuffer>>,
+        stage_input_buffer_index: Vec<Vec<(usize, usize)>>,
+    ) -> Self {
+        for (idx, v) in stage_input_buffer_index.iter().enumerate() {
+            for i in 0..v.len() {
+                for j in i + 1..v.len() {
+                    assert_ne!(v[i], v[j]);
                 }
+                assert!(v[i].0 <= idx);
+                assert!(v[i].0 < buffers.len());
+                assert!(v[i].1 < buffers[v[i].0].len());
             }
+        }
+        // Safety note: we just checked the safety invariant.
+        Self {
+            buffers,
+            stage_input_buffer_index,
         }
     }
 
-    for p in ptrs.iter() {
-        debug_assert!(!p.is_null(), "Not all elements were found");
-        // SAFETY: Each pointer was obtained from a distinct &mut T in vals,
-        // and the lexicographic sort + distinctness guarantees no aliasing.
-        result.push(unsafe { &mut **p });
+    pub fn get_input_buffer(&mut self, c: usize) -> &mut RowBuffer {
+        &mut self.buffers[0][c]
     }
 
-    result
+    pub fn get_num_stage_input_buffers(&self, stage: usize) -> usize {
+        self.stage_input_buffer_index[stage].len()
+    }
+
+    pub fn get_stage_input_buffer(&mut self, stage: usize, c: usize) -> &mut RowBuffer {
+        let (si, ci) = self.stage_input_buffer_index[stage][c];
+        &mut self.buffers[si][ci]
+    }
+
+    pub fn get_inout_buffers(
+        &mut self,
+        stage: usize,
+    ) -> (ChannelVec<&RowBuffer>, &mut [RowBuffer]) {
+        assert!(stage.checked_add(1).unwrap() < self.buffers.len());
+        let idx = &self.stage_input_buffer_index[stage];
+        let buf_ptr = self.buffers.as_mut_ptr();
+        let ret = idx
+            .iter()
+            .map(|(a, b)| {
+                // SAFETY: as per safety invariant, `a` is within bounds of the slice pointed at by `buf_ptr`.
+                // Moreover, `b` is within bounds of the slice returned by `as_ptr()`.
+                // Finally, the lifetime of the references are tied to `self`, which owns `self.buffers`.
+                // Also note that we know that *a <= stage.
+                unsafe { &*(*buf_ptr.add(*a)).as_ptr().add(*b) }
+            })
+            .collect();
+        // SAFETY: Above, we only access elements <= stage. `stage + 1` does not overflow (or the
+        // checked_add at the start of the function would have failed), so we are accessing
+        // a distinct vector element (in bounds due to the assert! above), thus we do not violate
+        // aliasing rules. Finally, the reference does not outlive `self` and hence `self.buffers`.
+        let outb = unsafe { &mut *buf_ptr.add(stage + 1) };
+        (ret, &mut outb[..])
+    }
+
+    pub fn get_inplace_buffers(&mut self, stage: usize) -> ChannelVec<&mut RowBuffer> {
+        let idx = &self.stage_input_buffer_index[stage];
+        let buf_ptr = self.buffers.as_mut_ptr();
+        idx.iter()
+            .map(|(a, b)| {
+                // SAFETY: as per safety invariant, `a` is within bounds of the slice pointed at by `buf_ptr`.
+                // Moreover, `b` is within bounds of the slice returned by `as_mut_ptr()`.
+                // Moreover, all the `(a, b)` pairs are distinct, so we do not violate aliasing rules.
+                // Finally, the lifetime of the references are tied to `self`, which owns `self.buffers`,
+                // and `as_mut_ptr` promises to not create tree-borrows-invalidating references to the vec's
+                // data slice.
+                unsafe { &mut *(*buf_ptr.add(*a)).as_mut_ptr().add(*b) }
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::image::DataTypeTag;
+
     #[test]
-    fn get_distinct_indices_arbtest() {
+    fn row_buffers_arbtest() {
         arbtest::arbtest(|u| {
-            let outer_len = (u.arbitrary::<u8>()? % 6) as usize + 1;
-            let mut vals = Vec::with_capacity(outer_len);
-            let mut coords = Vec::new();
+            let num_stages = (u.arbitrary::<u8>()? % 8) as usize + 1;
+            let buffers_len = num_stages + 1;
+            let mut buffers = Vec::with_capacity(buffers_len);
+            let mut buffers_lengths = Vec::with_capacity(buffers_len);
 
-            for a in 0..outer_len {
-                let inner_len = (u.arbitrary::<u8>()? % 6) as usize + 1;
-                let mut row = Vec::with_capacity(inner_len);
+            for a in 0..buffers_len {
+                let inner_len = (u.arbitrary::<u8>()? % 8) as usize + 1;
+                buffers_lengths.push(inner_len);
+                let mut inner_buffers = Vec::with_capacity(inner_len);
                 for b in 0..inner_len {
-                    row.push(((a as u32) << 16) | b as u32);
-                    coords.push((a, b));
+                    let mut row = RowBuffer::new(DataTypeTag::U32, 0, 0, 0, 1).unwrap();
+                    row.get_row_mut::<u32>(0)[0] = ((a as u32) << 16) | b as u32;
+                    inner_buffers.push(row);
                 }
-                vals.push(row);
+                buffers.push(inner_buffers);
             }
 
-            let selected_len = (u.arbitrary::<u8>()? as usize % coords.len()) + 1;
-            let mut selected = (0..coords.len()).collect::<Vec<_>>();
-            for i in (1..selected.len()).rev() {
-                let j = u.arbitrary::<u16>()? as usize % (i + 1);
-                selected.swap(i, j);
-            }
-            selected.truncate(selected_len);
-            selected.sort_unstable();
+            let mut stage_input_buffer_index = Vec::with_capacity(num_stages);
+            for s in 0..num_stages {
+                let mut options = Vec::new();
+                for a in 0..=s {
+                    for b in 0..buffers_lengths[a] {
+                        options.push((a, b));
+                    }
+                }
 
-            let mut pos = (0..selected_len).collect::<Vec<_>>();
-            for i in (1..selected_len).rev() {
-                let j = u.arbitrary::<u16>()? as usize % (i + 1);
-                pos.swap(i, j);
-            }
-
-            let mut idx = Vec::with_capacity(selected_len);
-            let mut expected_before = vec![0u32; selected_len];
-            let mut expected_after = vec![0u32; selected_len];
-            for (i, &coord_idx) in selected.iter().enumerate() {
-                let (a, b) = coords[coord_idx];
-                let p = pos[i];
-                idx.push((a, b, p));
-                expected_before[p] = vals[a][b];
-                expected_after[p] = 0xA5A5_0000 | p as u32;
+                let selected_len = (u.arbitrary::<u8>()? as usize % options.len()) + 1;
+                for i in (1..options.len()).rev() {
+                    let j = u.arbitrary::<u16>()? as usize % (i + 1);
+                    options.swap(i, j);
+                }
+                options.truncate(selected_len);
+                stage_input_buffer_index.push(options);
             }
 
-            let mut refs = get_distinct_indices(&mut vals, &idx);
-            assert_eq!(refs.len(), selected_len);
-            for (i, r) in refs.iter_mut().enumerate() {
-                assert_eq!(**r, expected_before[i]);
-                **r = expected_after[i];
-            }
-            drop(refs);
+            let mut row_buffers = RowBuffers::new(buffers, stage_input_buffer_index.clone());
 
-            for (i, &coord_idx) in selected.iter().enumerate() {
-                let (a, b) = coords[coord_idx];
-                let p = pos[i];
-                assert_eq!(vals[a][b], expected_after[p]);
+            // Test get_input_buffer
+            for c in 0..buffers_lengths[0] {
+                let buf = row_buffers.get_input_buffer(c);
+                let val = buf.get_row::<u32>(0)[0];
+                assert_eq!(val, c as u32);
+            }
+
+            for s in 0..num_stages {
+                let num = row_buffers.get_num_stage_input_buffers(s);
+                assert_eq!(num, stage_input_buffer_index[s].len());
+
+                // Test get_stage_input_buffer
+                for c in 0..num {
+                    let buf = row_buffers.get_stage_input_buffer(s, c);
+                    let val = buf.get_row::<u32>(0)[0];
+                    let (expected_a, expected_b) = stage_input_buffer_index[s][c];
+                    assert_eq!(val, ((expected_a as u32) << 16) | expected_b as u32);
+                }
+
+                // Test get_inplace_buffers (including mutation and restore)
+                {
+                    let mut refs = row_buffers.get_inplace_buffers(s);
+                    assert_eq!(refs.len(), num);
+                    for (c, r) in refs.iter_mut().enumerate() {
+                        let val = r.get_row_mut::<u32>(0)[0];
+                        let (expected_a, expected_b) = stage_input_buffer_index[s][c];
+                        assert_eq!(val, ((expected_a as u32) << 16) | expected_b as u32);
+                        r.get_row_mut::<u32>(0)[0] = 0xA5A5_0000 | c as u32;
+                    }
+
+                    for (c, r) in refs.iter().enumerate() {
+                        let val = r.get_row::<u32>(0)[0];
+                        assert_eq!(val, 0xA5A5_0000 | c as u32);
+                    }
+
+                    for (c, r) in refs.iter_mut().enumerate() {
+                        let (expected_a, expected_b) = stage_input_buffer_index[s][c];
+                        r.get_row_mut::<u32>(0)[0] =
+                            ((expected_a as u32) << 16) | expected_b as u32;
+                    }
+                }
+
+                // Test get_inout_buffers
+                {
+                    let (in_refs, out_slice) = row_buffers.get_inout_buffers(s);
+                    assert_eq!(in_refs.len(), num);
+                    for (c, r) in in_refs.iter().enumerate() {
+                        let val = r.get_row::<u32>(0)[0];
+                        let (expected_a, expected_b) = stage_input_buffer_index[s][c];
+                        assert_eq!(val, ((expected_a as u32) << 16) | expected_b as u32);
+                    }
+
+                    assert_eq!(out_slice.len(), buffers_lengths[s + 1]);
+                    for (b, r) in out_slice.iter().enumerate() {
+                        let val = r.get_row::<u32>(0)[0];
+                        assert_eq!(val, (((s + 1) as u32) << 16) | b as u32);
+                    }
+                }
             }
 
             Ok(())

--- a/jxl/src/render/low_memory_pipeline/helpers.rs
+++ b/jxl/src/render/low_memory_pipeline/helpers.rs
@@ -9,26 +9,29 @@ use crate::util::ChannelVec;
 /// Panics if any of the indices are out of bounds or
 /// (idx[i].0, idx[i].1) == (idx[j].0, idx[j].1) for i != j or indices are not
 /// sorted lexicographically.
+#[allow(unsafe_code)]
 pub(super) fn get_distinct_indices<'a, T>(
     vals: &'a mut [impl AsMut<[T]>],
     idx: &[(usize, usize, usize)],
 ) -> ChannelVec<&'a mut T> {
-    let mut answer_buffer = ChannelVec::new();
-    for _ in 0..idx.len() {
-        answer_buffer.push(None);
+    // Build output directly using pointer math to avoid Option overhead.
+    // idx is sorted lexicographically by (a, b), so we iterate vals in order.
+    let mut result: ChannelVec<&'a mut T> = ChannelVec::new();
+    // Pre-fill with dummy values that will be overwritten.
+    // We need the result in idx[i].2 order, so we use a position-indexed buffer.
+    let n = idx.len();
+    let mut ptrs: ChannelVec<*mut T> = ChannelVec::new();
+    for _ in 0..n {
+        ptrs.push(std::ptr::null_mut());
     }
 
-    // TODO(veluca): in theory, we don't really need to first create a vector of
-    // `Option`s that then get `unwrap`-ed separately. Currently, this function
-    // uses somewhere between 0.5 and 1.5% of the total runtime; if that number
-    // increases, it might be worth investigating how to speed this up.
     let mut targets = idx.iter();
     let mut target = targets.next().unwrap();
     'outer: for (aa, bufs) in vals.iter_mut().enumerate() {
         for (bb, buf) in bufs.as_mut().iter_mut().enumerate() {
             let (a, b, pos) = target;
             if aa == *a && bb == *b {
-                answer_buffer[*pos] = Some(buf);
+                ptrs[*pos] = buf as *mut T;
                 if let Some(t) = targets.next() {
                     target = t;
                 } else {
@@ -38,8 +41,12 @@ pub(super) fn get_distinct_indices<'a, T>(
         }
     }
 
-    answer_buffer
-        .iter_mut()
-        .map(|x| std::mem::take(x).expect("Not all elements were found"))
-        .collect()
+    for p in ptrs.iter() {
+        debug_assert!(!p.is_null(), "Not all elements were found");
+        // SAFETY: Each pointer was obtained from a distinct &mut T in vals,
+        // and the lexicographic sort + distinctness guarantees no aliasing.
+        result.push(unsafe { &mut **p });
+    }
+
+    result
 }

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -16,6 +16,7 @@ use crate::render::MAX_BORDER;
 use crate::render::buffer_splitter::{BufferSplitter, SaveStageBufferInfo};
 use crate::render::internal::Stage;
 use crate::render::low_memory_pipeline::group_scheduler::InputBuffer;
+use crate::render::low_memory_pipeline::helpers::RowBuffers;
 use crate::util::{ShiftRightCeil, tracing_wrappers::*};
 
 use super::RenderPipeline;
@@ -31,12 +32,8 @@ mod save;
 pub struct LowMemoryRenderPipeline {
     shared: RenderPipelineShared<RowBuffer>,
     input_buffers: Vec<InputBuffer>,
-    row_buffers: Vec<Vec<RowBuffer>>,
+    row_buffers: RowBuffers,
     save_buffer_info: Vec<Option<SaveStageBufferInfo>>,
-    // The input buffer that each channel of each stage should use.
-    // This is indexed both by stage index (0 corresponds to input data, 1 to stage[0], etc) and by
-    // index *of those channels that are used*.
-    stage_input_buffer_index: Vec<Vec<(usize, usize)>>,
     // Tracks whether we already rendered the padding around the core frame (if any).
     padding_was_rendered: bool,
     // The amount of pixels that each stage needs to *output* around the current group to
@@ -55,8 +52,6 @@ pub struct LowMemoryRenderPipeline {
     // Pre-filled opaque alpha buffers for stages that need fill_opaque_alpha.
     // Indexed by stage index; None if stage doesn't need alpha fill.
     opaque_alpha_buffers: Vec<Option<RowBuffer>>,
-    // Sorted indices to call get_distinct_indices.
-    sorted_buffer_indices: Vec<Vec<(usize, usize, usize)>>,
     // For each channel and the 3 kinds of buffers (center / topbottom / leftright), buffers that
     // could be reused to store group data for that channel.
     // Indexed by [3*channel] = center, [3*channel+1] = topbottom, [3*channel+2] = leftright.
@@ -233,18 +228,6 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             *ibi = filtered;
         }
 
-        let sorted_buffer_indices = (0..shared.stages.len())
-            .map(|s| {
-                let mut v: Vec<_> = stage_input_buffer_index[s]
-                    .iter()
-                    .enumerate()
-                    .map(|(i, (outer, inner))| (*outer, *inner, i))
-                    .collect();
-                v.sort();
-                v
-            })
-            .collect();
-
         let mut border_size = (0, 0);
         for c in 0..nc {
             border_size.0 = border_size
@@ -265,8 +248,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
 
         Ok(Self {
             input_buffers,
-            stage_input_buffer_index,
-            row_buffers,
+            row_buffers: RowBuffers::new(row_buffers, stage_input_buffer_index),
             padding_was_rendered: false,
             save_buffer_info,
             stage_output_border_pixels: border_pixels_per_stage,
@@ -280,7 +262,6 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             shared,
             downsampling_for_stage,
             opaque_alpha_buffers,
-            sorted_buffer_indices,
             scratch_channel_buffers: (0..nc * 3).map(|_| vec![]).collect(),
         })
     }

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -11,9 +11,9 @@ use crate::{
     image::{DataTypeTag, Rect},
     render::{
         internal::{ChannelInfo, Stage},
-        low_memory_pipeline::{helpers::get_distinct_indices, run_stage::ExtraInfo},
+        low_memory_pipeline::run_stage::ExtraInfo,
     },
-    util::{ChannelVec, ShiftRightCeil, mirror, tracing_wrappers::*},
+    util::{ShiftRightCeil, mirror, tracing_wrappers::*},
 };
 
 use super::{LowMemoryRenderPipeline, row_buffers::RowBuffer};
@@ -95,7 +95,7 @@ impl LowMemoryRenderPipeline {
             (y - group_y0, gy, false)
         };
 
-        let output_row = self.row_buffers[0][c].get_row_mut::<u8>(y);
+        let output_row = self.row_buffers.get_input_buffer(c).get_row_mut::<u8>(y);
 
         let copy_x0 = x0.saturating_sub(self.input_border_pixels[c].0);
         let copy_x1 =
@@ -253,10 +253,7 @@ impl LowMemoryRenderPipeline {
 
                 match stage {
                     Stage::InPlace(s) => {
-                        let mut buffers = get_distinct_indices(
-                            &mut self.row_buffers,
-                            &self.sorted_buffer_indices[i],
-                        );
+                        let mut buffers = self.row_buffers.get_inplace_buffers(i);
                         s.run_stage_on(
                             ExtraInfo {
                                 xsize: shifted_xsize,
@@ -273,11 +270,8 @@ impl LowMemoryRenderPipeline {
                     }
                     Stage::Save(s) => {
                         // Find buffers for channels that will be saved.
-                        // Channel ordering is handled in stage_input_buffer_index construction.
-                        let mut input_data: ChannelVec<_> = self.stage_input_buffer_index[i]
-                            .iter()
-                            .map(|(si, ci)| &self.row_buffers[*si][*ci])
-                            .collect();
+                        // Channel ordering is handled in row_buffers construction.
+                        let (mut input_data, _) = self.row_buffers.get_inout_buffers(i);
                         // Append opaque alpha buffer if fill_opaque_alpha is set
                         if let Some(ref alpha_buf) = self.opaque_alpha_buffers[i] {
                             input_data.push(alpha_buf);
@@ -301,12 +295,14 @@ impl LowMemoryRenderPipeline {
                         let bordery = s.border().1 as isize;
                         // Apply x padding.
                         if gx == 0 && borderx != 0 {
-                            for (si, ci) in self.stage_input_buffer_index[i].iter() {
+                            for c in 0..self.row_buffers.get_num_stage_input_buffers(i) {
                                 for iy in -bordery..=bordery {
                                     let y = mirror(y as isize + iy, shifted_ysize);
                                     apply_x_padding(
                                         s.input_type(),
-                                        self.row_buffers[*si][*ci].get_row_mut::<u8>(y),
+                                        self.row_buffers
+                                            .get_stage_input_buffer(i, c)
+                                            .get_row_mut::<u8>(y),
                                         -(borderx as isize)..0,
                                         // Either xsize is the actual size of the image, or it is
                                         // much larger than borderx, so this works out either way.
@@ -316,12 +312,14 @@ impl LowMemoryRenderPipeline {
                             }
                         }
                         if gx + 1 == self.shared.group_count.0 && borderx != 0 {
-                            for (si, ci) in self.stage_input_buffer_index[i].iter() {
+                            for c in 0..self.row_buffers.get_num_stage_input_buffers(i) {
                                 for iy in -bordery..=bordery {
                                     let y = mirror(y as isize + iy, shifted_ysize);
                                     apply_x_padding(
                                         s.input_type(),
-                                        self.row_buffers[*si][*ci].get_row_mut::<u8>(y),
+                                        self.row_buffers
+                                            .get_stage_input_buffer(i, c)
+                                            .get_row_mut::<u8>(y),
                                         shifted_xsize as isize..(shifted_xsize + borderx) as isize,
                                         // borderx..0 is either data from the neighbouring group or
                                         // data that was filled in by the iteration above.
@@ -330,12 +328,7 @@ impl LowMemoryRenderPipeline {
                                 }
                             }
                         }
-                        let (inb, outb) = self.row_buffers.split_at_mut(i + 1);
-                        // Prepare pointers to input and output buffers.
-                        let input_data: ChannelVec<_> = self.stage_input_buffer_index[i]
-                            .iter()
-                            .map(|(si, ci)| &inb[*si][*ci])
-                            .collect();
+                        let (input_data, outb) = self.row_buffers.get_inout_buffers(i);
                         s.run_stage_on(
                             ExtraInfo {
                                 xsize: shifted_xsize,
@@ -347,7 +340,7 @@ impl LowMemoryRenderPipeline {
                                 image_height: shifted_ysize,
                             },
                             &input_data,
-                            &mut outb[0][..],
+                            outb,
                             self.local_states[i].as_deref_mut(),
                         );
                     }
@@ -375,8 +368,7 @@ impl LowMemoryRenderPipeline {
             let extend = self.shared.extend_stage_index.unwrap();
             // Step 1: get padding from extend stage.
             for c in 0..num_channels {
-                let (si, ci) = self.stage_input_buffer_index[extend][c];
-                let buffer = &mut self.row_buffers[si][ci];
+                let buffer = self.row_buffers.get_stage_input_buffer(extend, c);
                 let Stage::Extend(extend) = &self.shared.stages[extend] else {
                     unreachable!("extend stage is not an extend stage");
                 };
@@ -389,10 +381,7 @@ impl LowMemoryRenderPipeline {
 
                 match stage {
                     Stage::InPlace(s) => {
-                        let mut buffers = get_distinct_indices(
-                            &mut self.row_buffers,
-                            &self.sorted_buffer_indices[i],
-                        );
+                        let mut buffers = self.row_buffers.get_inplace_buffers(i);
                         s.run_stage_on(
                             ExtraInfo {
                                 xsize,
@@ -410,10 +399,7 @@ impl LowMemoryRenderPipeline {
                     Stage::Save(s) => {
                         // Find buffers for channels that will be saved.
                         // Channel ordering is handled in stage_input_buffer_index construction.
-                        let mut input_data: ChannelVec<_> = self.stage_input_buffer_index[i]
-                            .iter()
-                            .map(|(si, ci)| &self.row_buffers[*si][*ci])
-                            .collect();
+                        let (mut input_data, _) = self.row_buffers.get_inout_buffers(i);
                         // Append opaque alpha buffer if fill_opaque_alpha is set
                         if let Some(ref alpha_buf) = self.opaque_alpha_buffers[i] {
                             input_data.push(alpha_buf);
@@ -433,12 +419,7 @@ impl LowMemoryRenderPipeline {
                     }
                     Stage::InOut(s) => {
                         assert_eq!(s.border(), (0, 0));
-                        let (inb, outb) = self.row_buffers.split_at_mut(i + 1);
-                        // Prepare pointers to input and output buffers.
-                        let input_data: ChannelVec<_> = self.stage_input_buffer_index[i]
-                            .iter()
-                            .map(|(si, ci)| &inb[*si][*ci])
-                            .collect();
+                        let (input_data, outb) = self.row_buffers.get_inout_buffers(i);
                         s.run_stage_on(
                             ExtraInfo {
                                 xsize,
@@ -450,7 +431,7 @@ impl LowMemoryRenderPipeline {
                                 image_height: self.shared.input_size.1,
                             },
                             &input_data,
-                            &mut outb[0][..],
+                            outb,
                             self.local_states[i].as_deref_mut(),
                         );
                     }


### PR DESCRIPTION
This removes Option staging in get_distinct_indices and builds the result directly in position order. It reduces overhead in a hot helper used during low-memory pipeline row setup without changing behavior. Unsafe is used only to reborrow previously collected mutable pointers, and is safe because indices are distinct and sorted, so aliasing cannot occur.