### PR TITLE
perf: avoid zero-initializing modular channel payloads

### DIFF
--- a/jxl/src/frame/modular/borrowed_buffers.rs
+++ b/jxl/src/frame/modular/borrowed_buffers.rs
@@ -27,8 +27,14 @@ pub fn with_buffers<T>(
         let b = &buf.buffer_grid[grid];
         let mut data = b.data.borrow_mut();
         if data.is_none() {
+            // SAFETY: The modular decode loop fully writes every pixel in the data region.
+            // The padding region is zeroed for correct boundary behavior in prediction.
+            #[allow(unsafe_code)]
+            let img = unsafe {
+                Image::new_uninit_with_zeroed_padding(b.size, IMAGE_OFFSET, IMAGE_PADDING)?
+            };
             *data = Some(ModularChannel {
-                data: Image::new_with_padding(b.size, IMAGE_OFFSET, IMAGE_PADDING)?,
+                data: img,
                 auxiliary_data: None,
                 shift: buf.info.shift,
                 bit_depth: buf.info.bit_depth,

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -142,13 +142,19 @@ impl ModularChannel {
         Self::new_with_shift(size, Some((0, 0)), bit_depth)
     }
 
+    #[allow(unsafe_code)]
     fn new_with_shift(
         size: (usize, usize),
         shift: Option<(usize, usize)>,
         bit_depth: BitDepth,
     ) -> Result<Self> {
+        // SAFETY: The modular decode loop (decode_modular_channel_impl) fully writes
+        // every pixel in the data region. The padding region is zeroed for correct
+        // boundary behavior in prediction.
+        let data =
+            unsafe { Image::new_uninit_with_zeroed_padding(size, IMAGE_OFFSET, IMAGE_PADDING)? };
         Ok(ModularChannel {
-            data: Image::new_with_padding(size, IMAGE_OFFSET, IMAGE_PADDING)?,
+            data,
             auxiliary_data: None,
             shift,
             bit_depth,

--- a/jxl/src/image/raw.rs
+++ b/jxl/src/image/raw.rs
@@ -46,6 +46,49 @@ impl OwnedRawImage {
         })
     }
 
+    /// Like `new_zeroed_with_padding`, but only zeroes the padding region.
+    /// The main data area (byte_size) is left uninitialized.
+    ///
+    /// # Safety
+    /// The caller must ensure that the main data area is fully written before reading.
+    /// The offset/padding regions are zeroed for correct boundary behavior.
+    #[allow(unsafe_code)]
+    pub unsafe fn new_uninit_with_zeroed_padding(
+        byte_size: (usize, usize),
+        offset: (usize, usize),
+        mut padding: (usize, usize),
+    ) -> Result<Self> {
+        if !(padding.0 + byte_size.0).is_multiple_of(CACHE_LINE_BYTE_SIZE) {
+            padding.0 += CACHE_LINE_BYTE_SIZE - (padding.0 + byte_size.0) % CACHE_LINE_BYTE_SIZE;
+        }
+        let total_cols = byte_size.0 + padding.0;
+        let total_rows = byte_size.1 + padding.1;
+        let mut data = RawImageBuffer::try_allocate((total_cols, total_rows), true)?;
+
+        // Zero only the padding regions:
+        // 1. Top offset rows (full width each)
+        for y in 0..offset.1 {
+            // SAFETY: y is in 0..total_rows, and data has total_rows rows.
+            let row = unsafe { data.row_mut(y) };
+            row.fill(std::mem::MaybeUninit::new(0));
+        }
+        // 2. Left offset columns + right padding columns for data rows
+        for y in offset.1..total_rows {
+            // SAFETY: y is in 0..total_rows, and data has total_rows rows.
+            let row = unsafe { data.row_mut(y) };
+            // Left offset region
+            row[..offset.0].fill(std::mem::MaybeUninit::new(0));
+            // Right padding region: [byte_size.0..total_cols]
+            row[byte_size.0..total_cols].fill(std::mem::MaybeUninit::new(0));
+        }
+
+        Ok(Self {
+            data,
+            offset,
+            padding,
+        })
+    }
+
     pub fn get_rect_including_padding_mut(&mut self, rect: Rect) -> RawImageRectMut<'_> {
         RawImageRectMut {
             // Safety note: we are lending exclusive ownership to RawImageRectMut.

--- a/jxl/src/image/typed.rs
+++ b/jxl/src/image/typed.rs
@@ -36,6 +36,30 @@ impl<T: ImageDataType> Image<T> {
         Ok(Self::from_raw(img))
     }
 
+    /// Like `new_with_padding`, but only zeroes the padding region.
+    /// The main data area is left uninitialized -- caller must write all pixels before reading.
+    ///
+    /// # Safety
+    /// The caller must fully write the main data area before reading from it.
+    #[allow(unsafe_code)]
+    pub unsafe fn new_uninit_with_zeroed_padding(
+        size: (usize, usize),
+        offset: (usize, usize),
+        padding: (usize, usize),
+    ) -> Result<Image<T>> {
+        let s = T::DATA_TYPE_ID.size();
+        // SAFETY: this function has the same safety contract as
+        // OwnedRawImage::new_uninit_with_zeroed_padding, and we only scale dimensions.
+        let img = unsafe {
+            OwnedRawImage::new_uninit_with_zeroed_padding(
+                (size.0 * s, size.1),
+                (offset.0 * s, offset.1),
+                (padding.0 * s, padding.1),
+            )?
+        };
+        Ok(Self::from_raw(img))
+    }
+
     #[instrument(ret, err)]
     pub fn new(size: (usize, usize)) -> Result<Image<T>> {
         Self::new_with_padding(size, (0, 0), (0, 0))


### PR DESCRIPTION
This adds an uninitialized image constructor that zeros only offset/padding regions, then uses it for modular channel allocation. It removes large buffer zeroing work in hot decode paths while preserving prediction boundary behavior. Unsafe is confined to allocation/row access internals and is safe because modular decode fully writes the data region before any read, and padding is explicitly zeroed.