### PR TITLE
perf: optimize weighted predictor core and row updates

### DIFF
--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -47,11 +47,15 @@ fn decode_modular_channel_small(
 
     const { assert!(IMAGE_OFFSET.1 == 2) };
 
+    let mut property_buffer: Vec<i32> = vec![0; num_properties];
+    property_buffer[0] = chan as i32;
+    property_buffer[1] = stream_id as i32;
+
     for y in 0..size.1 {
         precompute_references(buffers, chan, y, &mut references);
-        let mut property_buffer: Vec<i32> = vec![0; num_properties];
-        property_buffer[0] = chan as i32;
-        property_buffer[1] = stream_id as i32;
+        // Reset property 9 (local gradient depends on previous row's value)
+        property_buffer[9] = 0;
+        wp_state.set_row(y, size.0);
         let [row, row_top, row_toptop] =
             buffers[chan].data.distinct_full_rows_mut([y + 2, y + 1, y]);
         let row = &mut row[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + size.0];
@@ -79,6 +83,7 @@ fn decode_modular_channel_small(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub(super) trait ModularChannelDecoder {
     const NEEDS_TOP: bool;
     const NEEDS_TOPTOP: bool;
@@ -137,18 +142,13 @@ fn decode_modular_channel_impl<D: ModularChannelDecoder>(
                 row[x] = val;
             }
         } else {
-            for (x, r) in row.iter_mut().enumerate().skip(2).take(size.0 - 4) {
-                prediction_data = prediction_data.update_for_interior_row(
-                    row_top,
-                    row_toptop,
-                    x,
-                    last,
-                    D::NEEDS_TOP,
-                    D::NEEDS_TOPTOP,
-                );
+            #[allow(unsafe_code)]
+            for x in 2..size.0 - 2 {
+                prediction_data.update_for_interior_row(row_top, row_toptop, x, last);
                 let val =
                     decoder.decode_one(prediction_data, (x, y), size.0, reader, br, histograms);
-                *r = val;
+                // SAFETY: x is in [2, size.0 - 2), and row.len() == size.0.
+                unsafe { *row.get_unchecked_mut(x) = val };
                 last = val;
             }
         }

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -119,6 +119,8 @@ impl ModularChannelDecoder for GeneralTree {
 
     fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
         self.no_wp_tree.init_row(buffers, chan, y);
+        let xsize = buffers[chan].data.size().0;
+        self.wp_state.set_row(y, xsize);
     }
 
     fn decode_one(
@@ -228,8 +230,9 @@ impl ModularChannelDecoder for WpOnlyLookupConfig420 {
     const NEEDS_TOP: bool = true;
     const NEEDS_TOPTOP: bool = true;
 
-    fn init_row(&mut self, _buffers: &mut [&mut ModularChannel], _chan: usize, _y: usize) {
-        // nothing to do
+    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
+        let xsize = buffers[chan].data.size().0;
+        self.wp_state.set_row(y, xsize);
     }
 
     #[inline(always)]

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -9,11 +9,9 @@ use crate::{
     image::Image,
     util::floor_log2_nonzero,
 };
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 
 #[repr(u8)]
-#[derive(Debug, FromPrimitive, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Predictor {
     Zero = 0,
     West = 1,
@@ -43,11 +41,29 @@ impl Predictor {
     }
 }
 
+impl Predictor {
+    /// Fast conversion from u32. Since Predictor is #[repr(u8)] with
+    /// contiguous values 0..=13, a bounds check + transmute replaces
+    /// the num_derive FromPrimitive chain (from_u32 -> from_u64 -> from_i64).
+    #[inline(always)]
+    #[allow(unsafe_code)]
+    pub fn from_u32_fast(value: u32) -> Option<Self> {
+        if value <= Predictor::AverageAll as u32 {
+            // SAFETY: Predictor is #[repr(u8)] with contiguous discriminants 0..=13,
+            // and we verified value is in range.
+            Some(unsafe { std::mem::transmute::<u8, Self>(value as u8) })
+        } else {
+            None
+        }
+    }
+}
+
 impl TryFrom<u32> for Predictor {
     type Error = Error;
 
+    #[inline(always)]
     fn try_from(value: u32) -> Result<Self> {
-        Self::from_u32(value).ok_or(Error::InvalidPredictor(value))
+        Self::from_u32_fast(value).ok_or(Error::InvalidPredictor(value))
     }
 }
 
@@ -63,36 +79,29 @@ pub struct PredictionData {
 }
 
 impl PredictionData {
-    #[inline]
+    #[inline(always)]
+    #[allow(unsafe_code)]
     pub fn update_for_interior_row(
-        self,
+        &mut self,
         row_top: &[i32],
         row_toptop: &[i32],
         x: usize,
         cur: i32,
-        needs_top: bool,
-        needs_toptop: bool,
-    ) -> PredictionData {
+    ) {
         debug_assert!(x > 1);
         debug_assert!(x + 2 < row_top.len());
-        let left = cur;
-        let top = self.topright;
-        let topleft = self.top;
-        let topright = self.toprightright;
-        let leftleft = self.left;
-        let toptop = if needs_toptop { row_toptop[x] } else { 0 };
-        let toprightright = if needs_top { row_top[x + 2] } else { 0 };
-        Self {
-            left,
-            top,
-            toptop,
-            topleft,
-            topright,
-            leftleft,
-            toprightright,
-        }
+        self.leftleft = self.left;
+        self.topleft = self.top;
+        self.top = self.topright;
+        self.topright = self.toprightright;
+        self.left = cur;
+        // SAFETY: x < row_toptop.len() because x < width and row_toptop has width elements.
+        self.toptop = unsafe { *row_toptop.get_unchecked(x) };
+        // SAFETY: x + 2 < row_top.len() asserted above.
+        self.toprightright = unsafe { *row_top.get_unchecked(x + 2) };
     }
 
+    #[inline(always)]
     pub fn get_rows(row: &[i32], row_top: &[i32], row_toptop: &[i32], x: usize, y: usize) -> Self {
         let left = if x > 0 {
             row[x - 1]
@@ -126,6 +135,7 @@ impl PredictionData {
         }
     }
 
+    #[inline(always)]
     pub fn get(rect: &Image<i32>, x: usize, y: usize) -> Self {
         Self::get_rows(
             rect.row(y),
@@ -136,6 +146,7 @@ impl PredictionData {
         )
     }
 
+    #[inline(always)]
     #[allow(clippy::too_many_arguments)]
     pub fn get_with_neighbors(
         rect: &Image<i32>,
@@ -250,6 +261,7 @@ impl PredictionData {
     }
 }
 
+#[inline(always)]
 pub fn clamped_gradient(left: i64, top: i64, topleft: i64) -> i64 {
     // Same code/logic as libjxl.
     let min = left.min(top);
@@ -262,7 +274,7 @@ pub fn clamped_gradient(left: i64, top: i64, topleft: i64) -> i64 {
 impl Predictor {
     pub const NUM_PREDICTORS: u32 = Predictor::AverageAll as u32 + 1;
 
-    #[inline]
+    #[inline(always)]
     pub fn predict_one(
         &self,
         PredictionData {
@@ -302,6 +314,7 @@ impl Predictor {
         }
     }
 
+    #[inline(always)]
     fn select(left: i64, top: i64, topleft: i64) -> i64 {
         let p = left + top - topleft;
         if (p - left).abs() < (p - top).abs() {
@@ -332,29 +345,46 @@ fn add_bits(x: i32) -> i64 {
 }
 
 #[inline(always)]
+#[allow(unsafe_code)]
 fn error_weight(x: u32, maxweight: u32) -> u32 {
-    let shift = floor_log2_nonzero(x as u64 + 1) as i32 - 5;
-    if shift < 0 {
-        4u32 + maxweight * DIVLOOKUP[x as usize & 63]
-    } else {
-        4u32 + ((maxweight * DIVLOOKUP[(x as usize >> shift) & 63]) >> shift)
-    }
+    // Branchless version matching libjxl: clamp shift to 0 instead of branching
+    // Use u32 lzcnt directly (avoids zero-extend to u64)
+    let log2 = 31u32 ^ (x + 1).leading_zeros();
+    let shift = (log2 as i32 - 5).max(0) as u32;
+    // SAFETY: x >> shift is < 64 because:
+    // - if shift == 0: x < 32 (since log2(x+1) < 5), so x < 64
+    // - if shift > 0: x >> shift < 2^5 = 32 < 64
+    4u32 + ((maxweight * unsafe { *DIVLOOKUP.get_unchecked((x >> shift) as usize) }) >> shift)
 }
 
 #[inline(always)]
+#[allow(unsafe_code)]
 fn weighted_average(pixels: &[i64; NUM_PREDICTORS], weights: &mut [u32; NUM_PREDICTORS]) -> i64 {
-    let log_weight = floor_log2_nonzero(weights.iter().fold(0u64, |sum, el| sum + *el as u64));
-    let weight_sum = weights.iter_mut().fold(0, |sum, el| {
-        *el >>= log_weight - 4;
-        sum + *el
-    });
-    let sum = weights
-        .iter()
-        .enumerate()
-        .fold(((weight_sum >> 1) - 1) as i64, |sum, (i, weight)| {
-            sum + pixels[i] * *weight as i64
-        });
-    (sum * DIVLOOKUP[(weight_sum - 1) as usize] as i64) >> 24
+    // Sum weights as u32 (always fits in practice).
+    let sum32 = weights[0]
+        .wrapping_add(weights[1])
+        .wrapping_add(weights[2])
+        .wrapping_add(weights[3]);
+    let log_weight = if sum32 > 0 {
+        31u32 ^ sum32.leading_zeros()
+    } else {
+        floor_log2_nonzero(weights.iter().fold(0u64, |sum, el| sum + *el as u64))
+    };
+    let shift = log_weight - 4;
+    weights[0] >>= shift;
+    weights[1] >>= shift;
+    weights[2] >>= shift;
+    weights[3] >>= shift;
+    let weight_sum = weights[0] + weights[1] + weights[2] + weights[3];
+    let sum = ((weight_sum >> 1) - 1) as i64
+        + pixels[0] * weights[0] as i64
+        + pixels[1] * weights[1] as i64
+        + pixels[2] * weights[2] as i64
+        + pixels[3] * weights[3] as i64;
+    debug_assert!((weight_sum - 1) < 64, "weight_sum={}", weight_sum);
+    // SAFETY: weight_sum <= 64 after the shift-right by (log_weight - 4).
+    let div = unsafe { *DIVLOOKUP.get_unchecked((weight_sum - 1) as usize) };
+    (sum * div as i64) >> 24
 }
 
 #[derive(Debug)]
@@ -366,11 +396,22 @@ pub struct WeightedPredictorState {
     pred_errors_buffer: Vec<u32>,
     error: Vec<i32>,
     wp_header: WeightedHeader,
+    /// Pre-computed max weights from wp_header, avoids match+unwrap per iteration.
+    maxweights: [u32; NUM_PREDICTORS],
+    /// Precomputed row offsets (set once per row via set_row)
+    cur_row: usize,
+    prev_row: usize,
 }
 
 impl WeightedPredictorState {
     pub fn new(wp_header: &WeightedHeader, xsize: usize) -> WeightedPredictorState {
         let num_errors = (xsize + 2) * 2;
+        let maxweights = [
+            wp_header.w(0).unwrap(),
+            wp_header.w(1).unwrap(),
+            wp_header.w(2).unwrap(),
+            wp_header.w(3).unwrap(),
+        ];
         WeightedPredictorState {
             prediction: [0; NUM_PREDICTORS],
             pred: 0,
@@ -380,25 +421,33 @@ impl WeightedPredictorState {
             pred_errors_buffer: vec![0; num_errors * NUM_PREDICTORS],
             error: vec![0; num_errors],
             wp_header: wp_header.clone(),
+            maxweights,
+            cur_row: 0,
+            prev_row: 0,
         }
     }
 
     /// Get all predictor errors for a given position (contiguous in memory)
     #[inline(always)]
+    #[allow(unsafe_code)]
     fn get_errors_at_pos(&self, pos: usize) -> &[u32; NUM_PREDICTORS] {
         let start = pos * NUM_PREDICTORS;
-        self.pred_errors_buffer[start..start + NUM_PREDICTORS]
-            .try_into()
-            .unwrap()
+        debug_assert!(start + NUM_PREDICTORS <= self.pred_errors_buffer.len());
+        // SAFETY: start + NUM_PREDICTORS <= buffer.len() because pos < num_errors
+        // (which is (xsize+2)*2), and buffer.len() = num_errors * NUM_PREDICTORS.
+        unsafe { &*(self.pred_errors_buffer.as_ptr().add(start) as *const [u32; NUM_PREDICTORS]) }
     }
 
     /// Get mutable reference to all predictor errors for a given position
     #[inline(always)]
+    #[allow(unsafe_code, dead_code)]
     fn get_errors_at_pos_mut(&mut self, pos: usize) -> &mut [u32; NUM_PREDICTORS] {
         let start = pos * NUM_PREDICTORS;
-        (&mut self.pred_errors_buffer[start..start + NUM_PREDICTORS])
-            .try_into()
-            .unwrap()
+        debug_assert!(start + NUM_PREDICTORS <= self.pred_errors_buffer.len());
+        // SAFETY: same invariant as get_errors_at_pos.
+        unsafe {
+            &mut *(self.pred_errors_buffer.as_mut_ptr().add(start) as *mut [u32; NUM_PREDICTORS])
+        }
     }
 
     pub fn save_state(&self, wp_image: &mut Image<i32>, xsize: usize) {
@@ -411,44 +460,223 @@ impl WeightedPredictorState {
         self.error[xsize + 2..].copy_from_slice(wp_image.row(0));
     }
 
+    /// Precompute row offsets for the current y. Call once per row before the x loop.
     #[inline(always)]
-    pub fn update_errors(&mut self, correct_val: i32, pos: (usize, usize), xsize: usize) {
-        let (cur_row, prev_row) = if pos.1 & 1 != 0 {
-            (0, xsize + 2)
+    pub fn set_row(&mut self, y: usize, xsize: usize) {
+        if y & 1 != 0 {
+            self.cur_row = 0;
+            self.prev_row = xsize + 2;
         } else {
-            (xsize + 2, 0)
-        };
-        let val = add_bits(correct_val);
-        self.error[cur_row + pos.0] = (self.pred - val) as i32;
-
-        // Compute errors for all predictors
-        let mut errs = [0u32; NUM_PREDICTORS];
-        for (err, &pred) in errs.iter_mut().zip(self.prediction.iter()) {
-            *err = (((pred - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+            self.cur_row = xsize + 2;
+            self.prev_row = 0;
         }
+    }
 
-        // Write to current position (contiguous access)
-        *self.get_errors_at_pos_mut(cur_row + pos.0) = errs;
+    #[allow(unsafe_code)]
+    pub fn update_errors(&mut self, correct_val: i32, pos: (usize, usize), xsize: usize) {
+        let _ = xsize; // xsize now precomputed in set_row
+        let cur_row = self.cur_row;
+        let prev_row = self.prev_row;
+        let val = add_bits(correct_val);
+        // SAFETY: cur_row + pos.0 < (xsize+2)*2 = error.len() since pos.0 < xsize
+        // and cur_row is either 0 or xsize+2.
+        unsafe { *self.error.get_unchecked_mut(cur_row + pos.0) = (self.pred - val) as i32 };
 
-        // Update previous row position (contiguous access)
-        let prev_errors = self.get_errors_at_pos_mut(prev_row + pos.0 + 1);
-        for i in 0..NUM_PREDICTORS {
-            prev_errors[i] = prev_errors[i].wrapping_add(errs[i]);
+        // Compute errors for all predictors and write to cur + accumulate to prev in one pass.
+        // Unrolled to avoid loop overhead and help register allocation.
+        let cur_start = (cur_row + pos.0) * NUM_PREDICTORS;
+        let prev_start = (prev_row + pos.0 + 1) * NUM_PREDICTORS;
+        debug_assert!(cur_start + NUM_PREDICTORS <= self.pred_errors_buffer.len());
+        debug_assert!(prev_start + NUM_PREDICTORS <= self.pred_errors_buffer.len());
+        let buf = self.pred_errors_buffer.as_mut_ptr();
+        // SAFETY: cur_start/prev_start ranges are bounds-checked above, and each access
+        // stays within [0, pred_errors_buffer.len()).
+        unsafe {
+            let e0 =
+                (((self.prediction[0] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+            let e1 =
+                (((self.prediction[1] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+            let e2 =
+                (((self.prediction[2] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+            let e3 =
+                (((self.prediction[3] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+            // Write current position
+            *buf.add(cur_start) = e0;
+            *buf.add(cur_start + 1) = e1;
+            *buf.add(cur_start + 2) = e2;
+            *buf.add(cur_start + 3) = e3;
+            // Accumulate to previous row
+            *buf.add(prev_start) = (*buf.add(prev_start)).wrapping_add(e0);
+            *buf.add(prev_start + 1) = (*buf.add(prev_start + 1)).wrapping_add(e1);
+            *buf.add(prev_start + 2) = (*buf.add(prev_start + 2)).wrapping_add(e2);
+            *buf.add(prev_start + 3) = (*buf.add(prev_start + 3)).wrapping_add(e3);
         }
     }
 
     #[inline(always)]
+    #[allow(unsafe_code)]
     pub fn predict_and_property(
         &mut self,
         pos: (usize, usize),
         xsize: usize,
         data: &PredictionData,
     ) -> (i64, i32) {
-        let (cur_row, prev_row) = if pos.1 & 1 != 0 {
-            (0, xsize + 2)
-        } else {
-            (xsize + 2, 0)
+        self.predict_impl(pos, xsize, data, true)
+    }
+
+    /// Predict without computing the WP property (property 15).
+    /// Use when the tree doesn't split on property 15.
+    #[inline(always)]
+    #[allow(unsafe_code, dead_code)]
+    pub fn predict_no_property(
+        &mut self,
+        pos: (usize, usize),
+        xsize: usize,
+        data: &PredictionData,
+    ) -> i64 {
+        self.predict_impl(pos, xsize, data, false).0
+    }
+
+    /// Interior predict with WP property. No edge checks.
+    #[inline(always)]
+    #[allow(unsafe_code, dead_code)]
+    pub fn predict_and_property_interior(
+        &mut self,
+        x: usize,
+        xsize: usize,
+        data: &PredictionData,
+    ) -> (i64, i32) {
+        self.predict_interior::<true>(x, xsize, data)
+    }
+
+    /// Interior predict without WP property. No edge checks.
+    #[inline(always)]
+    #[allow(unsafe_code, dead_code)]
+    pub fn predict_no_property_interior(
+        &mut self,
+        x: usize,
+        xsize: usize,
+        data: &PredictionData,
+    ) -> i64 {
+        self.predict_interior::<false>(x, xsize, data).0
+    }
+
+    /// Interior version: no edge checks. x > 0 and x < xsize-1 guaranteed.
+    #[inline(always)]
+    #[allow(unsafe_code, dead_code)]
+    pub fn predict_interior<const COMPUTE_PROPERTY: bool>(
+        &mut self,
+        x: usize,
+        _xsize: usize,
+        data: &PredictionData,
+    ) -> (i64, i32) {
+        let cur_row = self.cur_row;
+        let prev_row = self.prev_row;
+        let pos_n = prev_row + x;
+        // No edge checks: x > 0 and x < xsize-1 guaranteed in interior
+        let pos_ne = pos_n + 1;
+        let pos_nw = pos_n - 1;
+        // Direct pointer access to error buffers -- avoids get_errors_at_pos overhead
+        let base = self.pred_errors_buffer.as_ptr();
+        let off_n = pos_n * NUM_PREDICTORS;
+        let off_ne = pos_ne * NUM_PREDICTORS;
+        let off_nw = pos_nw * NUM_PREDICTORS;
+        let mut weights = [0u32; NUM_PREDICTORS];
+        // SAFETY: pos_n/pos_ne/pos_nw are valid row positions, so each computed offset
+        // points to 4 contiguous predictor-error entries within pred_errors_buffer.
+        unsafe {
+            weights[0] = error_weight(
+                (*base.add(off_n))
+                    .wrapping_add(*base.add(off_ne))
+                    .wrapping_add(*base.add(off_nw)),
+                self.maxweights[0],
+            );
+            weights[1] = error_weight(
+                (*base.add(off_n + 1))
+                    .wrapping_add(*base.add(off_ne + 1))
+                    .wrapping_add(*base.add(off_nw + 1)),
+                self.maxweights[1],
+            );
+            weights[2] = error_weight(
+                (*base.add(off_n + 2))
+                    .wrapping_add(*base.add(off_ne + 2))
+                    .wrapping_add(*base.add(off_nw + 2)),
+                self.maxweights[2],
+            );
+            weights[3] = error_weight(
+                (*base.add(off_n + 3))
+                    .wrapping_add(*base.add(off_ne + 3))
+                    .wrapping_add(*base.add(off_nw + 3)),
+                self.maxweights[3],
+            );
+        }
+        let n = add_bits(data.top);
+        let w = add_bits(data.left);
+        let ne = add_bits(data.topright);
+        let nw = add_bits(data.topleft);
+        let nn = add_bits(data.toptop);
+
+        let err_base = self.error.as_ptr();
+        // SAFETY: x > 0 in the interior path, and pos_n/pos_nw/pos_ne are all valid
+        // indexes within error.len() = (xsize + 2) * 2.
+        let (te_w, te_n, te_nw, te_ne) = unsafe {
+            (
+                *err_base.add(cur_row + x - 1) as i64,
+                *err_base.add(pos_n) as i64,
+                *err_base.add(pos_nw) as i64,
+                *err_base.add(pos_ne) as i64,
+            )
         };
+        let sum_wn = te_n + te_w;
+
+        let p = if COMPUTE_PROPERTY {
+            let mut p = te_w;
+            if te_n.abs() > p.abs() {
+                p = te_n;
+            }
+            if te_nw.abs() > p.abs() {
+                p = te_nw;
+            }
+            if te_ne.abs() > p.abs() {
+                p = te_ne;
+            }
+            p
+        } else {
+            0
+        };
+
+        self.prediction[0] = w + ne - n;
+        self.prediction[1] = n - (((sum_wn + te_ne) * self.wp_header.p1c as i64) >> 5);
+        self.prediction[2] = w - (((sum_wn + te_nw) * self.wp_header.p2c as i64) >> 5);
+        self.prediction[3] = n
+            - ((te_nw * (self.wp_header.p3ca as i64)
+                + (te_n * (self.wp_header.p3cb as i64))
+                + (te_ne * (self.wp_header.p3cc as i64))
+                + ((nn - n) * (self.wp_header.p3cd as i64))
+                + ((nw - w) * (self.wp_header.p3ce as i64)))
+                >> 5);
+
+        self.pred = weighted_average(&self.prediction, &mut weights);
+
+        if ((te_n ^ te_w) | (te_n ^ te_nw)) <= 0 {
+            let mx = w.max(ne.max(n));
+            let mn = w.min(ne.min(n));
+            self.pred = mn.max(mx.min(self.pred));
+        }
+        ((self.pred + PREDICTION_ROUND) >> PRED_EXTRA_BITS, p as i32)
+    }
+
+    #[inline(always)]
+    #[allow(unsafe_code)]
+    fn predict_impl(
+        &mut self,
+        pos: (usize, usize),
+        xsize: usize,
+        data: &PredictionData,
+        compute_property: bool,
+    ) -> (i64, i32) {
+        let cur_row = self.cur_row;
+        let prev_row = self.prev_row;
         let pos_n = prev_row + pos.0;
         let pos_ne = if pos.0 < xsize - 1 { pos_n + 1 } else { pos_n };
         let pos_nw = if pos.0 > 0 { pos_n - 1 } else { pos_n };
@@ -463,7 +691,7 @@ impl WeightedPredictorState {
                 errors_n[i]
                     .wrapping_add(errors_ne[i])
                     .wrapping_add(errors_nw[i]),
-                self.wp_header.w(i).unwrap(),
+                self.maxweights[i],
             );
         }
         let n = add_bits(data.top);
@@ -475,23 +703,35 @@ impl WeightedPredictorState {
         let te_w = if pos.0 == 0 {
             0
         } else {
-            self.error[cur_row + pos.0 - 1] as i64
+            // SAFETY: when pos.0 > 0, cur_row + pos.0 - 1 is a valid error index.
+            unsafe { *self.error.get_unchecked(cur_row + pos.0 - 1) as i64 }
         };
-        let te_n = self.error[pos_n] as i64;
-        let te_nw = self.error[pos_nw] as i64;
+        // SAFETY: pos_n/pos_nw/pos_ne are clamped to valid neighborhood positions
+        // in error.len() = (xsize + 2) * 2.
+        let (te_n, te_nw, te_ne) = unsafe {
+            (
+                *self.error.get_unchecked(pos_n) as i64,
+                *self.error.get_unchecked(pos_nw) as i64,
+                *self.error.get_unchecked(pos_ne) as i64,
+            )
+        };
         let sum_wn = te_n + te_w;
-        let te_ne = self.error[pos_ne] as i64;
 
-        let mut p = te_w;
-        if te_n.abs() > p.abs() {
-            p = te_n;
-        }
-        if te_nw.abs() > p.abs() {
-            p = te_nw;
-        }
-        if te_ne.abs() > p.abs() {
-            p = te_ne;
-        }
+        let p = if compute_property {
+            let mut p = te_w;
+            if te_n.abs() > p.abs() {
+                p = te_n;
+            }
+            if te_nw.abs() > p.abs() {
+                p = te_nw;
+            }
+            if te_ne.abs() > p.abs() {
+                p = te_ne;
+            }
+            p
+        } else {
+            0
+        };
 
         self.prediction[0] = w + ne - n;
         self.prediction[1] = n - (((sum_wn + te_ne) * self.wp_header.p1c as i64) >> 5);
@@ -542,6 +782,7 @@ mod tests {
         ysize: usize,
     ) -> (i64, i32) {
         let pos = (rng.next() as usize % xsize, rng.next() as usize % ysize);
+        state.set_row(pos.1, xsize);
         let res = state.predict_and_property(
             pos,
             xsize,

--- a/jxl/src/frame/modular/transforms/apply.rs
+++ b/jxl/src/frame/modular/transforms/apply.rs
@@ -562,7 +562,7 @@ fn meta_apply_single_transform(
             let num_channels = transform.num_channels as usize;
             let num_colors = transform.num_colors as usize;
             let num_deltas = transform.num_deltas as usize;
-            let pred = Predictor::from_u32(transform.predictor_id)
+            let pred = Predictor::from_u32_fast(transform.predictor_id)
                 .expect("header decoding should ensure a valid predictor");
             check_equal_channels(channels, begin_channel, num_channels)?;
             // We already checked the bit_depth for all channels from `begin_channel` is

--- a/jxl/src/frame/modular/transforms/palette.rs
+++ b/jxl/src/frame/modular/transforms/palette.rs
@@ -205,6 +205,7 @@ pub fn do_palette_step_general(
         for (chan_index, out) in buf_out.iter_mut().enumerate() {
             let mut wp_state = WeightedPredictorState::new(wp_header, w);
             for y in 0..h {
+                wp_state.set_row(y, w);
                 let idx = buf_in.data.row(y);
                 for (x, &index) in idx.iter().enumerate() {
                     let palette_entry = get_palette_value(
@@ -383,6 +384,7 @@ pub fn do_palette_step_group_row(
                 );
             }
             for y in 0..h {
+                wp_state.set_row(y & 1, total_w);
                 for (grid_x, index_buf) in buf_in.iter().enumerate().take(grid_xsize) {
                     let index_img = index_buf.data.row(y);
                     let out_idx = out_row_idx + grid_x;


### PR DESCRIPTION
This speeds up weighted prediction by removing derived-enum conversion overhead, unrolling hot error/weight paths, and reusing per-row predictor state. It also updates row initialization call sites so the optimized predictor state layout remains behavior-equivalent. Unsafe is used only for bounds-check elimination on indices that are guarded by row-size invariants and debug assertions.