### PR TITLE
perf: use padded BitReader fast path in codestream sections

### DIFF
--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -28,10 +28,37 @@ use crate::{
 mod non_section;
 mod sections;
 
+/// Buffer for a single codestream section.
+///
+/// When allocated, `data` always contains `len + PADDING` bytes: `len` bytes
+/// of real payload followed by [`PADDING`] zero bytes. The padding lets
+/// `BitReader::refill()` always take the fast 8-byte-read path.
 struct SectionBuffer {
     len: usize,
     data: Vec<u8>,
     section: Section,
+}
+
+/// Number of zero-padding bytes appended after real data in every
+/// [`SectionBuffer`]. Must be >= 8 so that `BitReader::refill()` can always
+/// do a single 8-byte LE read.
+const PADDING: usize = 8;
+
+impl SectionBuffer {
+    /// Allocate the backing store if not yet allocated.
+    /// The buffer is `len + PADDING` bytes; the trailing [`PADDING`] bytes
+    /// are zero-initialized and must stay zero.
+    fn ensure_allocated(&mut self) {
+        if self.data.is_empty() {
+            self.data.resize(self.len + PADDING, 0);
+        }
+    }
+
+    /// Create a [`BitReader`] that uses the zero-padded buffer for fast refill.
+    fn bit_reader(&self) -> crate::bit_reader::BitReader<'_> {
+        debug_assert!(self.data.len() >= self.len + PADDING);
+        crate::bit_reader::BitReader::new_with_initial_bits(&self.data, self.len * 8)
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -394,11 +421,8 @@ impl CodestreamParser {
                         .max(1);
                     // Ensure enough section buffers are available for reading available data.
                     for buf in self.sections.iter_mut() {
-                        if buf.data.is_empty() {
-                            buf.data.resize(buf.len, 0);
-                        }
-                        readable_section_data =
-                            readable_section_data.saturating_sub(buf.data.len());
+                        buf.ensure_allocated();
+                        readable_section_data = readable_section_data.saturating_sub(buf.len);
                         if readable_section_data == 0 {
                             break;
                         }
@@ -415,7 +439,7 @@ impl CodestreamParser {
                         if buf.data.is_empty() {
                             break;
                         }
-                        let len = buf.data.len();
+                        let len = buf.len;
                         if len > ready {
                             let readable = (available_codestream + ready).min(len);
                             section_buffers.push(IoSliceMut::new(&mut buf.data[ready..readable]));

--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -52,10 +52,37 @@ fn err_unless_more_container_input(
     Ok(())
 }
 
+/// Buffer for a single codestream section.
+///
+/// When allocated, `data` always contains `len + PADDING` bytes: `len` bytes
+/// of real payload followed by [`PADDING`] zero bytes. The padding lets
+/// `BitReader::refill()` always take the fast 8-byte-read path.
 struct SectionBuffer {
     len: usize,
     data: Vec<u8>,
     section: Section,
+}
+
+/// Number of zero-padding bytes appended after real data in every
+/// [`SectionBuffer`]. Must be >= 8 so that `BitReader::refill()` can always
+/// do a single 8-byte LE read.
+const PADDING: usize = 8;
+
+impl SectionBuffer {
+    /// Allocate the backing store if not yet allocated.
+    /// The buffer is `len + PADDING` bytes; the trailing [`PADDING`] bytes
+    /// are zero-initialized and must stay zero.
+    fn ensure_allocated(&mut self) {
+        if self.data.is_empty() {
+            self.data.resize(self.len + PADDING, 0);
+        }
+    }
+
+    /// Create a [`BitReader`] that uses the zero-padded buffer for fast refill.
+    fn bit_reader(&self) -> crate::bit_reader::BitReader<'_> {
+        debug_assert!(self.data.len() >= self.len + PADDING);
+        crate::bit_reader::BitReader::new_with_initial_bits(&self.data, self.len * 8)
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -421,11 +448,8 @@ impl CodestreamParser {
                         .max(1);
                     // Ensure enough section buffers are available for reading available data.
                     for buf in self.sections.iter_mut() {
-                        if buf.data.is_empty() {
-                            buf.data.resize(buf.len, 0);
-                        }
-                        readable_section_data =
-                            readable_section_data.saturating_sub(buf.data.len());
+                        buf.ensure_allocated();
+                        readable_section_data = readable_section_data.saturating_sub(buf.len);
                         if readable_section_data == 0 {
                             break;
                         }
@@ -457,7 +481,7 @@ impl CodestreamParser {
                         if buf.data.is_empty() {
                             break;
                         }
-                        let len = buf.data.len();
+                        let len = buf.len;
                         if len > ready {
                             let readable = (available_codestream + ready).min(len);
                             section_buffers.push(IoSliceMut::new(&mut buf.data[ready..readable]));

--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -330,12 +330,12 @@ impl CodestreamParser {
                 break;
             }
             let mut data = Vec::new();
-            data.try_reserve_exact(buf.len)?;
-            data.resize(buf.len, 0);
+            data.try_reserve_exact(buf.len + super::PADDING)?;
+            data.resize(buf.len + super::PADDING, 0);
             buf.data = data;
             self.ready_section_data += self
                 .non_section_buf
-                .take(&mut [IoSliceMut::new(&mut buf.data)]);
+                .take(&mut [IoSliceMut::new(&mut buf.data[..buf.len])]);
         }
 
         self.section_state =

--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -332,12 +332,12 @@ impl CodestreamParser {
                 break;
             }
             let mut data = Vec::new();
-            data.try_reserve_exact(buf.len)?;
-            data.resize(buf.len, 0);
+            data.try_reserve_exact(buf.len + super::PADDING)?;
+            data.resize(buf.len + super::PADDING, 0);
             buf.data = data;
             self.ready_section_data += self
                 .non_section_buf
-                .take(&mut [IoSliceMut::new(&mut buf.data)]);
+                .take(&mut [IoSliceMut::new(&mut buf.data[..buf.len])]);
         }
 
         self.section_state =

--- a/jxl/src/api/inner/codestream_parser/sections.rs
+++ b/jxl/src/api/inner/codestream_parser/sections.rs
@@ -89,10 +89,7 @@ impl CodestreamParser {
         let complete_lf_global;
         let (lf_global, lf_global_is_complete) = if let Some(d) = self.lf_global_section.take() {
             complete_lf_global = d;
-            (
-                Some(&complete_lf_global.data[..complete_lf_global.len]),
-                true,
-            )
+            (Some(&complete_lf_global), true)
         } else if do_flush
             && self
                 .sections
@@ -106,10 +103,7 @@ impl CodestreamParser {
             )
         {
             self.section_state.lf_global_flush_len = self.ready_section_data;
-            (
-                Some(&self.sections[0].data[..self.ready_section_data]),
-                false,
-            )
+            (Some(&self.sections[0]), false)
         } else {
             (None, false)
         };
@@ -117,11 +111,15 @@ impl CodestreamParser {
         'process: {
             if frame_header.num_groups() == 1 && frame_header.passes.num_passes == 1 {
                 // Single-group special case.
-                let Some(buf) = lf_global else {
+                let Some(section) = lf_global else {
                     break 'process;
                 };
                 assert!(self.sections.is_empty() || !lf_global_is_complete);
-                let mut br = BitReader::new(buf);
+                let mut br = if lf_global_is_complete {
+                    section.bit_reader()
+                } else {
+                    BitReader::new(&section.data[..self.ready_section_data])
+                };
                 let res = (|| -> Result<()> {
                     frame.decode_lf_global(&mut br, !lf_global_is_complete)?;
                     frame.decode_lf_group(0, &mut br)?;
@@ -147,8 +145,13 @@ impl CodestreamParser {
                     Err(e) => return Err(e),
                 }
             } else {
-                if let Some(buf) = lf_global {
-                    match frame.decode_lf_global(&mut BitReader::new(buf), !lf_global_is_complete) {
+                if let Some(section) = lf_global {
+                    let mut br = if lf_global_is_complete {
+                        section.bit_reader()
+                    } else {
+                        BitReader::new(&section.data[..self.ready_section_data])
+                    };
+                    match frame.decode_lf_global(&mut br, !lf_global_is_complete) {
                         Ok(_) => {
                             self.section_state.lf_global_done = true;
                             processed_section = true;
@@ -168,7 +171,7 @@ impl CodestreamParser {
                     let Section::Lf { group } = lf_section.section else {
                         unreachable!()
                     };
-                    frame.decode_lf_group(group, &mut BitReader::new(&lf_section.data))?;
+                    frame.decode_lf_group(group, &mut lf_section.bit_reader())?;
                     processed_section = true;
                     self.section_state.remaining_lf -= 1;
                 }
@@ -178,7 +181,7 @@ impl CodestreamParser {
                 }
 
                 if let Some(hf_global) = self.hf_global_section.take() {
-                    frame.decode_hf_global(&mut BitReader::new(&hf_global.data))?;
+                    frame.decode_hf_global(&mut hf_global.bit_reader())?;
                     frame.finalize_lf()?;
                     self.section_state.hf_global_done = true;
                     processed_section = true;
@@ -202,7 +205,7 @@ impl CodestreamParser {
                             break;
                         };
                         self.section_state.completed_passes[g] += 1;
-                        sections.push((pass, BitReader::new(&s.data)));
+                        sections.push((pass, s.bit_reader()));
                     }
                     if !sections.is_empty() {
                         group_readers.push((g, sections));

--- a/jxl/src/bit_reader.rs
+++ b/jxl/src/bit_reader.rs
@@ -45,6 +45,22 @@ impl<'a> BitReader<'a> {
         }
     }
 
+    /// Constructs a BitReader with an explicit `initial_bits` limit.
+    ///
+    /// `data` may be longer than `initial_bits / 8` (e.g. zero-padded) so that
+    /// `refill()` always takes the fast 8-byte-read path.  Out-of-bounds
+    /// detection still uses `initial_bits`.
+    pub fn new_with_initial_bits(data: &[u8], initial_bits: usize) -> BitReader<'_> {
+        debug_assert!(data.len() * 8 >= initial_bits);
+        BitReader {
+            data,
+            bit_buf: 0,
+            bits_in_buf: 0,
+            total_bits_read: 0,
+            initial_bits,
+        }
+    }
+
     /// Reads `num` bits from the buffer without consuming them.
     #[inline]
     pub fn peek(&mut self, num: usize) -> u64 {


### PR DESCRIPTION
This adds a padded BitReader constructor and uses it for codestream sections that already have complete buffered data. It keeps incremental/incomplete paths unchanged while avoiding slow refill handling on complete section reads.