### PR TITLE
perf: tighten VarDCT group coefficient hot loop

### DIFF
--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -61,7 +61,7 @@ impl Default for VarDctBuffers {
     }
 }
 
-#[inline(always)]
+#[inline]
 fn predict_num_nonzeros(nzeros_map: &Image<u32>, bx: usize, by: usize) -> usize {
     if bx == 0 {
         if by == 0 {
@@ -375,7 +375,6 @@ impl<'a, 'b> PassInfo<'a, 'b> {
 
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
-#[allow(unsafe_code)]
 pub fn decode_vardct_group(
     group: usize,
     passes: &mut [(usize, BitReader)],
@@ -573,6 +572,9 @@ pub fn decode_vardct_group(
                     let mut prev = if nonzeros > num_coeffs / 16 { 0 } else { 1 };
                     let permutation = &pass_info.coeff_orders[shape_id * 3 + c];
                     let current_coeffs = &mut coeffs[c][coeffs_offset..coeffs_offset + num_coeffs];
+                    // Asserting once lets the compiler elide the bounds check on
+                    // `permutation[k]` inside the loop given `k < num_coeffs`.
+                    assert!(permutation.len() >= num_coeffs);
                     for k in num_blocks..num_coeffs {
                         if nonzeros == 0 {
                             break;
@@ -583,13 +585,8 @@ pub fn decode_vardct_group(
                             reader.read_signed_inline(&pass_info.histograms, br, ctx) << *shift;
                         prev = if coeff != 0 { 1 } else { 0 };
                         nonzeros -= prev;
-                        // SAFETY: permutation[k] is validated to be < num_coeffs during
-                        // coeff_order decoding, and current_coeffs.len() == num_coeffs.
-                        // k < num_coeffs by loop bounds.
-                        let coeff_index = unsafe { *permutation.get_unchecked(k) } as usize;
-                        // SAFETY: coeff_index comes from permutation[k], which is validated
-                        // to be < num_coeffs, and current_coeffs.len() == num_coeffs.
-                        unsafe { *current_coeffs.get_unchecked_mut(coeff_index) += coeff };
+                        let coeff_index = permutation[k] as usize;
+                        current_coeffs[coeff_index] += coeff;
                     }
                     if nonzeros != 0 {
                         return Err(Error::EndOfBlockResidualNonZeros(nonzeros));

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -47,10 +47,10 @@ impl VarDctBuffers {
 
     /// Reset buffers to zero for reuse.
     pub fn reset(&mut self) {
-        self.scratch.fill(0.0);
-        for buf in &mut self.transform_buffer {
-            buf.fill(0.0);
-        }
+        // scratch does NOT need zeroing: each block's LF coefficients are fully written
+        // by copy_from_slice before transform_to_pixels reads them.
+        // transform_buffer does NOT need zeroing: dequant_block fully overwrites
+        // all num_coeffs entries before transform_to_pixels reads them.
         self.coeffs_storage.fill(0);
     }
 }
@@ -61,7 +61,7 @@ impl Default for VarDctBuffers {
     }
 }
 
-#[inline]
+#[inline(always)]
 fn predict_num_nonzeros(nzeros_map: &Image<u32>, bx: usize, by: usize) -> usize {
     if bx == 0 {
         if by == 0 {
@@ -375,6 +375,7 @@ impl<'a, 'b> PassInfo<'a, 'b> {
 
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
+#[allow(unsafe_code)]
 pub fn decode_vardct_group(
     group: usize,
     passes: &mut [(usize, BitReader)],
@@ -582,8 +583,13 @@ pub fn decode_vardct_group(
                             reader.read_signed_inline(&pass_info.histograms, br, ctx) << *shift;
                         prev = if coeff != 0 { 1 } else { 0 };
                         nonzeros -= prev;
-                        let coeff_index = permutation[k] as usize;
-                        current_coeffs[coeff_index] += coeff;
+                        // SAFETY: permutation[k] is validated to be < num_coeffs during
+                        // coeff_order decoding, and current_coeffs.len() == num_coeffs.
+                        // k < num_coeffs by loop bounds.
+                        let coeff_index = unsafe { *permutation.get_unchecked(k) } as usize;
+                        // SAFETY: coeff_index comes from permutation[k], which is validated
+                        // to be < num_coeffs, and current_coeffs.len() == num_coeffs.
+                        unsafe { *current_coeffs.get_unchecked_mut(coeff_index) += coeff };
                     }
                     if nonzeros != 0 {
                         return Err(Error::EndOfBlockResidualNonZeros(nonzeros));


### PR DESCRIPTION
This removes unnecessary VarDCT scratch/transform zeroing and tightens coefficient writeback indexing in the hot decode loop. It keeps decode behavior unchanged while reducing redundant memory work. Unsafe is used only for permutation/current-coefficient indexing with bounds guaranteed by validated coefficient order and loop limits.