### PR TITLE
perf: avoid extra pull_symbol call in unsigned RLE repeat path

### DIFF
--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -393,8 +393,14 @@ impl SymbolReader {
                     Codes::Ans(ans) => self.ans_reader.read(ans, br, cluster),
                 };
                 rle_state.push_token(token, histograms, br, cluster);
-                if let Some(sym) = rle_state.pull_symbol() {
-                    sym
+                if rle_state.repeat_count > 0 {
+                    rle_state.repeat_count -= 1;
+                    if let Some(sym) = rle_state.last_sym {
+                        sym
+                    } else {
+                        self.errors.lz77_repeat = true;
+                        0
+                    }
                 } else {
                     self.errors.lz77_repeat = true;
                     0


### PR DESCRIPTION
Carved out from the ongoing perf/autoresearch stream after PR #705 split work.

Change:
- in `SymbolReader::read_unsigned_clustered_inline`, after `push_token` consume `repeat_count/last_sym` directly instead of calling `pull_symbol` again.

Why:
- removes one extra call/branch in the hot repeat path
- behavior is unchanged
