### PR TITLE
perf: use direct gradient decode path in SingleGradientOnly

### DIFF
--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -348,9 +348,13 @@ impl ModularChannelDecoder for SingleGradientOnly {
         br: &mut BitReader,
         histograms: &Histograms,
     ) -> i32 {
-        let pred = Predictor::Gradient.predict_one(prediction_data, 0);
+        let pred = clamped_gradient(
+            prediction_data.left as i64,
+            prediction_data.top as i64,
+            prediction_data.topleft as i64,
+        );
         let dec = reader.read_signed_clustered_inline(histograms, br, self.clustered_ctx);
-        make_pixel(dec, 1, pred)
+        dec.wrapping_add(pred as i32)
     }
 }
 


### PR DESCRIPTION
Carved out from the ongoing perf/autoresearch stream after PR #705 split work.

Change:
- in `SingleGradientOnly::decode_one`, use direct `clamped_gradient + wrapping_add` instead of routing through the generic predictor helper path.

Why:
- trims hot-loop overhead in modular decode
- no behavior change intended
