### PR TITLE
decoder: hide basic info until embedded profile is available

### DIFF
--- a/jxl/src/api/inner/mod.rs
+++ b/jxl/src/api/inner/mod.rs
@@ -47,7 +47,11 @@ impl JxlDecoderInner {
     }
 
     /// Obtains the image's basic information, if available.
+    ///
+    /// Keep this aligned with typed `WithImageInfo` transitions: image info is
+    /// not observable until the embedded profile has been parsed.
     pub fn basic_info(&self) -> Option<&JxlBasicInfo> {
+        self.codestream_parser.embedded_color_profile.as_ref()?;
         self.codestream_parser.basic_info.as_ref()
     }
 
@@ -171,5 +175,33 @@ impl JxlDecoderInner {
     #[cfg(test)]
     pub(crate) fn set_use_simple_pipeline(&mut self, u: bool) {
         self.codestream_parser.set_use_simple_pipeline(u);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JxlDecoderInner;
+    use crate::api::JxlDecoderOptions;
+
+    #[test]
+    fn basic_info_not_visible_before_embedded_profile() {
+        let data = std::fs::read("resources/test/conformance_test_images/cmyk_layers.jxl").unwrap();
+        let mut decoder = JxlDecoderInner::new(JxlDecoderOptions::default());
+
+        for chunk in data.chunks(64) {
+            let mut input = chunk;
+            let _ = decoder.process(&mut input, None);
+
+            if decoder.embedded_color_profile().is_none() {
+                assert!(decoder.basic_info().is_none());
+            }
+
+            if decoder.basic_info().is_some() {
+                assert!(decoder.embedded_color_profile().is_some());
+                return;
+            }
+        }
+
+        panic!("failed to reach image-info state while parsing cmyk_layers.jxl");
     }
 }


### PR DESCRIPTION
## Summary
- make `JxlDecoderInner::basic_info()` return `None` until `embedded_color_profile()` is available
- keep low-level API behavior aligned with typed `WithImageInfo` transitions
- add a focused regression test using `cmyk_layers.jxl` that asserts `basic_info()` is not observable before embedded profile parsing completes

## Why
In incremental CMYK decode flows, callers may poll `basic_info()` to decide when to configure output pixel format. Exposing basic info before embedded profile metadata is ready can trigger an early path that does not match `WithImageInfo` semantics.

## Test
- `cargo test -p jxl basic_info_not_visible_before_embedded_profile -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p jxl --all-targets -- -D warnings`
