### PR TITLE
Bump crates to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "jxl"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arbtest",
  "array-init",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_cms"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytemuck",
  "jxl",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_simd"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arbtest",
  "paste",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "jxl_transforms"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "jxl_simd",

--- a/jxl/Cargo.toml
+++ b/jxl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl"
 description = "High performance Rust implementation of a JPEG XL decoder"
-version = "0.4.1"
+version = "0.4.2"
 readme = "../README.md"
 keywords = ["jpeg-xl", "decoder"]
 categories = ["multimedia::images"]
@@ -13,15 +13,15 @@ license = "BSD-3-Clause"
 exclude = ["resources/"]
 
 [dependencies]
-jxl_transforms = { path = "../jxl_transforms", version = "=0.4.1" }
+jxl_transforms = { path = "../jxl_transforms", version = "=0.4.2" }
 thiserror = "2.0"
 byteorder = "1.4.3"
 num-derive = "0.4"
 num-traits = "0.2.14"
 array-init = "2.0.0"
 tracing = { version = "0.1.40", optional = true }
-jxl_macros = { path = "../jxl_macros", version = "=0.4.1" }
-jxl_simd = { path = "../jxl_simd", version = "=0.4.1" }
+jxl_macros = { path = "../jxl_macros", version = "=0.4.2" }
+jxl_simd = { path = "../jxl_simd", version = "=0.4.2" }
 
 [dev-dependencies]
 arbtest = "0.3.2"
@@ -29,7 +29,7 @@ paste = "1.0.15"
 rand = "0.9.2"
 rand_xorshift = "0.4.0"
 test-log = { version = "0.2.16", features = ["trace"] }
-jxl_macros = { path = "../jxl_macros", version = "=0.4.1", features = ["test"] }
+jxl_macros = { path = "../jxl_macros", version = "=0.4.2", features = ["test"] }
 
 [features]
 default = ["all-simd"]

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "jxl_cli"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "BSD-3-Clause"
 default-run = "jxl_cli"
 
 [dependencies]
-jxl = { path = "../jxl", version = "=0.4.1", default-features = false }
-jxl_cms = { path = "../jxl_cms", version = "=0.4.1" }
+jxl = { path = "../jxl", version = "=0.4.2", default-features = false }
+jxl_cms = { path = "../jxl_cms", version = "=0.4.2" }
 clap = { version = "4.5.18", features = ["derive"] }
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",
@@ -19,7 +19,7 @@ exr = { version = "1.73.0", optional = true }
 color-eyre = "0.6.5"
 
 [dev-dependencies]
-jxl_macros = { path = "../jxl_macros", features = ["test"], version = "=0.4.1" }
+jxl_macros = { path = "../jxl_macros", features = ["test"], version = "=0.4.2" }
 criterion = { version = "0.7.0", features = ["html_reports"] }
 
 [build-dependencies]

--- a/jxl_cms/Cargo.toml
+++ b/jxl_cms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl_cms"
 description = "High performance Rust implementation of a JPEG XL decoder - CMS integration library"
-version = "0.4.1"
+version = "0.4.2"
 readme = "../README.md"
 keywords = ["jpeg-xl", "decoder"]
 categories = ["multimedia::images"]
@@ -11,7 +11,7 @@ edition = "2024"
 license = "BSD-3-Clause"
 
 [dependencies]
-jxl = { path = "../jxl", version = "=0.4.1" }
+jxl = { path = "../jxl", version = "=0.4.2" }
 lcms2 = { version = "6.1.0", features = ["static"] }
 bytemuck = "1.24.0"
 

--- a/jxl_macros/Cargo.toml
+++ b/jxl_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl_macros"
 description = "High performance Rust implementation of a JPEG XL decoder - supporting macros"
-version = "0.4.1"
+version = "0.4.2"
 readme = "../README.md"
 keywords = ["jpeg-xl", "decoder"]
 categories = ["multimedia::images"]

--- a/jxl_simd/Cargo.toml
+++ b/jxl_simd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl_simd"
 description = "High performance Rust implementation of a JPEG XL decoder - SIMD support code"
-version = "0.4.1"
+version = "0.4.2"
 readme = "../README.md"
 keywords = ["jpeg-xl", "simd"]
 categories = ["multimedia::images"]

--- a/jxl_transforms/Cargo.toml
+++ b/jxl_transforms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jxl_transforms"
 description = "High performance Rust implementation of a JPEG XL decoder - Transforms"
-version = "0.4.1"
+version = "0.4.2"
 readme = "../README.md"
 keywords = ["jpeg-xl", "simd", "dct"]
 categories = ["multimedia::images"]
@@ -11,7 +11,7 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-jxl_simd = { path = "../jxl_simd", version = "=0.4.1" }
+jxl_simd = { path = "../jxl_simd", version = "=0.4.2" }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }


### PR DESCRIPTION
## What this PR does

This PR performs the 0.4.2 release version bump across the workspace crates.

### Version updates
- jxl: 0.4.1 -> 0.4.2
- jxl_cli: 0.4.1 -> 0.4.2
- jxl_cms: 0.4.1 -> 0.4.2
- jxl_macros: 0.4.1 -> 0.4.2
- jxl_simd: 0.4.1 -> 0.4.2
- jxl_transforms: 0.4.1 -> 0.4.2

### Dependency pin updates
- Internal workspace dependency pins updated from =0.4.1 to =0.4.2 where applicable.

### Lockfile
- Cargo.lock refreshed to reflect the new local crate versions.

## Validation
- cargo check --workspace
