### PR TITLE
Fix scan-only panic on empty follow-up process call

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -1990,6 +1990,33 @@ pub(crate) mod tests {
         }
     }
 
+    /// Regression test for Chromium ClusterFuzz issue 502853162.
+    ///
+    /// Scan-only decoding may consume all external input in one `process()`
+    /// call while still having buffered frame data to finalize internally.
+    /// A subsequent empty-input `process()` call must not panic.
+    #[test]
+    fn test_scan_frames_only_empty_followup_no_panic_502853162() {
+        #[rustfmt::skip]
+        let data: &[u8] = &[
+            0xff, 0x0a, 0x31, 0xbd, 0xa2, 0xd0, 0x2a, 0x18,
+            0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x0f, 0xa0, 0x26, 0x00, 0xff,
+        ];
+
+        let opts = JxlDecoderOptions {
+            scan_frames_only: true,
+            pixel_limit: Some(1024 * 1024 * 1024),
+            ..Default::default()
+        };
+        let mut decoder = JxlDecoderInner::new(opts);
+
+        let mut input = data;
+        while decoder.has_more_frames() {
+            let _ = decoder.process(&mut input, None).unwrap();
+        }
+    }
+
     /// Small regression test for issue #728: squeeze transform boundary bug.
     #[test]
     fn test_squeeze_boundary_minimal() {

--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -484,6 +484,9 @@ impl CodestreamParser {
                             self.decoder_state = Some(decoder_state);
                         } else {
                             self.has_more_frames = false;
+                            // Return immediately so we don't re-enter the outer loop and hit the
+                            // API-misuse assertion below inside the same call.
+                            return Ok(());
                         }
                         self.skip_sections = false;
                     }


### PR DESCRIPTION
In scan-only mode, a `process()` call can consume all external input and then finalize a frame from buffered internal state. When that finalization flips `has_more_frames` to false, we can currently continue the same outer loop iteration and hit the `assert!(do_flush)` path even though the call itself is valid. This change returns immediately after that transition, preserving the assert for real API misuse while avoiding this control-flow edge case.
