### PR TITLE
Clamp PQ and bounded HLG transfer-domain output in F16 conversion

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -544,11 +544,7 @@ pub(crate) mod tests {
         let simple_frames = decode(&file, usize::MAX, true, false, None)?.1;
         let frames = decode(&file, usize::MAX, false, false, None)?.1;
         assert_eq!(frames.len(), simple_frames.len());
-        for (fc, (f, sf)) in frames
-            .into_iter()
-            .zip(simple_frames.into_iter())
-            .enumerate()
-        {
+        for (fc, (f, sf)) in frames.into_iter().zip(simple_frames).enumerate() {
             compare_frames(path, fc, &f, &sf)?;
         }
         Ok(())
@@ -565,11 +561,7 @@ pub(crate) mod tests {
 
         // Compare one_shot_frames and frames
         assert_eq!(one_shot_frames.len(), frames.len());
-        for (fc, (f, sf)) in frames
-            .into_iter()
-            .zip(one_shot_frames.into_iter())
-            .enumerate()
-        {
+        for (fc, (f, sf)) in frames.into_iter().zip(one_shot_frames).enumerate() {
             compare_frames(path, fc, &f, &sf)?;
         }
 

--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -308,7 +308,7 @@ impl Frame {
             inv_perm[*pos as usize] = i;
         }
         let mut shuffled_ret = ret.clone();
-        for (br, pos) in ret.into_iter().zip(inv_perm.into_iter()) {
+        for (br, pos) in ret.into_iter().zip(inv_perm) {
             shuffled_ret[pos] = br;
         }
         Ok(shuffled_ret)

--- a/jxl/src/frame/modular/transforms/apply.rs
+++ b/jxl/src/frame/modular/transforms/apply.rs
@@ -790,7 +790,7 @@ pub fn meta_apply_local_transforms<'a, 'b>(
         for (new_pos, (ch_info, buf)) in buf_new_position
             .iter()
             .cloned()
-            .zip(channels.iter_mut().zip(buf_tmp.into_iter()))
+            .zip(channels.iter_mut().zip(buf_tmp))
         {
             assert!(matches!(
                 buffer_storage[new_pos],
@@ -946,7 +946,7 @@ impl TransformStep {
                         wp_header,
                     );
                 }
-                for (pos, buf) in buf_out.iter().zip(out_bufs.into_iter()) {
+                for (pos, buf) in buf_out.iter().zip(out_bufs) {
                     buffers[*pos] = buf;
                 }
             }

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -77,6 +77,7 @@ impl Frame {
         mut pipeline: RenderPipelineBuilder<P>,
         channels: &[usize],
         data_format: JxlDataFormat,
+        clamp_range_for_f16: Option<(f32, f32)>,
     ) -> RenderPipelineBuilder<P> {
         use crate::render::stages::{
             ConvertF32ToF16Stage, ConvertF32ToU8Stage, ConvertF32ToU16Stage,
@@ -97,7 +98,9 @@ impl Frame {
             }
             JxlDataFormat::F16 { .. } => {
                 for &channel in channels {
-                    pipeline = pipeline.add_inout_stage(ConvertF32ToF16Stage::new(channel));
+                    pipeline = pipeline.add_inout_stage(
+                        ConvertF32ToF16Stage::new_with_clamp_range(channel, clamp_range_for_f16),
+                    );
                 }
             }
             // F32 doesn't need conversion - the pipeline already uses f32
@@ -548,6 +551,18 @@ impl Frame {
             })
             .unwrap_or_else(|| output_color_info.tf.clone());
 
+        // Clamp transfer-domain values while converting to f16 so we don't
+        // emit wild out-of-range values to downstream consumers.
+        //
+        // PQ has a bounded signal domain [0,1].
+        // HLG may carry modest overshoot/undershoot (e.g. from narrow-range
+        // workflows), so preserve headroom with a looser clamp.
+        let clamp_range_for_f16 = match &output_tf {
+            TransferFunction::Pq { .. } => Some((0.0, 1.0)),
+            TransferFunction::Hlg { .. } => Some((-0.074, 1.1)),
+            _ => None,
+        };
+
         // Find the Black (K) extra channel if present.
         // In JXL, CMYK is stored as 3 color channels (CMY) + K as extra channel.
         // Pipeline index of K = extra_channel_index + 3
@@ -764,7 +779,12 @@ impl Frame {
                     ));
                 }
                 // Add conversion stages for non-float output formats
-                pipeline = Self::add_conversion_stages(pipeline, color_source_channels, *df);
+                pipeline = Self::add_conversion_stages(
+                    pipeline,
+                    color_source_channels,
+                    *df,
+                    clamp_range_for_f16,
+                );
                 pipeline = pipeline.add_save_stage(
                     color_source_channels,
                     metadata.orientation,
@@ -782,7 +802,7 @@ impl Frame {
             for i in 0..frame_header.num_extra_channels as usize {
                 if let Some(df) = &pixel_format.extra_channel_format[i] {
                     // Add conversion stages for non-float output formats
-                    pipeline = Self::add_conversion_stages(pipeline, &[3 + i], *df);
+                    pipeline = Self::add_conversion_stages(pipeline, &[3 + i], *df, None);
                     pipeline = pipeline.add_save_stage(
                         &[3 + i],
                         metadata.orientation,

--- a/jxl/src/render/simple_pipeline/mod.rs
+++ b/jxl/src/render/simple_pipeline/mod.rs
@@ -87,7 +87,7 @@ impl SimpleRenderPipeline {
                     );
                     let repl_iter = (0..self.shared.num_channels())
                         .filter(|c| stage.uses_channel(*c))
-                        .zip(output_buf.into_iter());
+                        .zip(output_buf);
                     for (c, chan) in repl_iter {
                         output_buffers[c] = chan;
                     }

--- a/jxl/src/render/stages/convert.rs
+++ b/jxl/src/render/stages/convert.rs
@@ -512,11 +512,36 @@ impl RenderPipelineInOutStage for ConvertF32ToU16Stage {
 /// Stage that converts f32 values to f16 (half-precision float) values.
 pub struct ConvertF32ToF16Stage {
     channel: usize,
+    clamp_range: Option<(f32, f32)>,
 }
 
 impl ConvertF32ToF16Stage {
     pub fn new(channel: usize) -> ConvertF32ToF16Stage {
-        ConvertF32ToF16Stage { channel }
+        ConvertF32ToF16Stage {
+            channel,
+            clamp_range: None,
+        }
+    }
+
+    pub fn new_with_clamp_range(
+        channel: usize,
+        clamp_range: Option<(f32, f32)>,
+    ) -> ConvertF32ToF16Stage {
+        ConvertF32ToF16Stage {
+            channel,
+            clamp_range,
+        }
+    }
+
+    pub fn new_with_unit_clamp(channel: usize, clamp_unit_range: bool) -> ConvertF32ToF16Stage {
+        ConvertF32ToF16Stage {
+            channel,
+            clamp_range: if clamp_unit_range {
+                Some((0.0, 1.0))
+            } else {
+                None
+            },
+        }
     }
 }
 
@@ -545,8 +570,15 @@ impl RenderPipelineInOutStage for ConvertF32ToF16Stage {
         _state: Option<&mut dyn std::any::Any>,
     ) {
         let input = &input_rows[0];
-        for i in 0..xsize {
-            output_rows[0][0][i] = crate::util::f16::from_f32(input[0][i]);
+        if let Some((min_value, max_value)) = self.clamp_range {
+            for i in 0..xsize {
+                output_rows[0][0][i] =
+                    crate::util::f16::from_f32(input[0][i].clamp(min_value, max_value));
+            }
+        } else {
+            for i in 0..xsize {
+                output_rows[0][0][i] = crate::util::f16::from_f32(input[0][i]);
+            }
         }
     }
 }
@@ -579,6 +611,15 @@ mod test {
     #[test]
     fn f32_to_f16_consistency() -> Result<()> {
         crate::render::test::test_stage_consistency(|| ConvertF32ToF16Stage::new(0), (500, 500), 1)
+    }
+
+    #[test]
+    fn f32_to_f16_consistency_with_unit_clamp() -> Result<()> {
+        crate::render::test::test_stage_consistency(
+            || ConvertF32ToF16Stage::new_with_unit_clamp(0, true),
+            (500, 500),
+            1,
+        )
     }
 
     /// Test ConvertModularToF32Stage consistency with different bit depths.

--- a/jxl_cli/src/enc/png.rs
+++ b/jxl_cli/src/enc/png.rs
@@ -70,13 +70,10 @@ fn make_cicp(encoding: &JxlColorEncoding) -> Option<png::CodingIndependentCodePo
 
     Some(png::CodingIndependentCodePoints {
         color_primaries: match white_point {
-            JxlWhitePoint::DCI => {
-                if *primaries == JxlPrimaries::P3 {
+            JxlWhitePoint::DCI
+                if *primaries == JxlPrimaries::P3 => {
                     11
-                } else {
-                    return None;
                 }
-            }
             JxlWhitePoint::D65 => match primaries {
                 JxlPrimaries::SRGB => 1,
                 JxlPrimaries::BT2100 => 9,

--- a/jxl_cli/src/enc/png.rs
+++ b/jxl_cli/src/enc/png.rs
@@ -70,10 +70,7 @@ fn make_cicp(encoding: &JxlColorEncoding) -> Option<png::CodingIndependentCodePo
 
     Some(png::CodingIndependentCodePoints {
         color_primaries: match white_point {
-            JxlWhitePoint::DCI
-                if *primaries == JxlPrimaries::P3 => {
-                    11
-                }
+            JxlWhitePoint::DCI if *primaries == JxlPrimaries::P3 => 11,
             JxlWhitePoint::D65 => match primaries {
                 JxlPrimaries::SRGB => 1,
                 JxlPrimaries::BT2100 => 9,


### PR DESCRIPTION
## Summary
- clamp transfer-domain RGB values in `ConvertF32ToF16Stage`
- apply per-transfer bounds when output transfer is HDR:
  - PQ: `[0.0, 1.0]`
  - HLG: `[-0.074, 1.1]`
- keep the fix inside the jxl-rs render pipeline (no extra wrapper-side full-frame post-pass)

## Why
Tiny HDR JXL assets can produce out-of-range transfer-domain values. When those values are emitted in F16 output, downstream consumers can exhibit rendering corruption on some HDR compositor paths.

Applying the clamp in the existing F32->F16 conversion loop keeps overhead minimal and avoids a second pass over the decoded frame.

HLG is not hard-clamped to `[0,1]`; it uses a bounded headroom range to preserve plausible overshoot/undershoot workflows while still rejecting wild values.

## Testing
- `cargo test -p jxl f32_to_f16_consistency_with_unit_clamp -- --nocapture`
