### PR TITLE
flush_pixels: return whether new pixels were rendered

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -193,8 +193,11 @@ impl JxlDecoder<WithImageInfo> {
 
     /// Draws all the pixels we have data for. This is useful for i.e. previewing LF frames.
     ///
+    /// Returns `true` if any new pixels were written to `buffers` since the
+    /// previous call to `flush_pixels`; `false` if nothing new was rendered.
+    ///
     /// Note: see `process` for alignment requirements for the buffer data.
-    pub fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer<'_>]) -> Result<()> {
+    pub fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer<'_>]) -> Result<bool> {
         self.inner.flush_pixels(buffers)
     }
 
@@ -276,8 +279,11 @@ impl JxlDecoder<WithFrameInfo> {
 
     /// Draws all the pixels we have data for.
     ///
+    /// Returns `true` if any new pixels were written to `buffers` since the
+    /// previous call to `flush_pixels`; `false` if nothing new was rendered.
+    ///
     /// Note: see `process` for alignment requirements for the buffer data.
-    pub fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer<'_>]) -> Result<()> {
+    pub fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer<'_>]) -> Result<bool> {
         self.inner.flush_pixels(buffers)
     }
 

--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -88,6 +88,10 @@ pub(super) struct CodestreamParser {
     // group indices that *might* have new renderable data.
     candidate_hf_sections: HashSet<usize>,
 
+    /// Set when `decode_and_render_hf_groups` actually writes to the output
+    /// buffer (i.e. `regions` is non-empty). Cleared by `flush_pixels`.
+    pub(super) pixels_dirty: bool,
+
     pub(super) has_more_frames: bool,
 
     header_needed_bytes: Option<u64>,
@@ -154,6 +158,7 @@ impl CodestreamParser {
             hf_global_section: None,
             hf_sections: vec![],
             candidate_hf_sections: HashSet::new(),
+            pixels_dirty: false,
             has_more_frames: true,
             header_needed_bytes: None,
             scanned_frames: Vec::new(),

--- a/jxl/src/api/inner/codestream_parser/sections.rs
+++ b/jxl/src/api/inner/codestream_parser/sections.rs
@@ -127,7 +127,7 @@ impl CodestreamParser {
                     frame.decode_lf_group(0, &mut br)?;
                     frame.decode_hf_global(&mut br)?;
                     frame.finalize_lf()?;
-                    frame.decode_and_render_hf_groups(
+                    self.pixels_dirty |= frame.decode_and_render_hf_groups(
                         output_buffers,
                         pixel_format,
                         vec![(0, vec![(0, br)])],
@@ -226,7 +226,7 @@ impl CodestreamParser {
                     self.candidate_hf_sections.clear();
                 }
 
-                frame.decode_and_render_hf_groups(
+                self.pixels_dirty |= frame.decode_and_render_hf_groups(
                     output_buffers,
                     pixel_format,
                     group_readers,
@@ -245,7 +245,7 @@ impl CodestreamParser {
         }
 
         if do_flush && !called_render_hf && frame.can_do_early_rendering() {
-            frame.decode_and_render_hf_groups(
+            self.pixels_dirty |= frame.decode_and_render_hf_groups(
                 output_buffers,
                 pixel_format,
                 vec![],

--- a/jxl/src/api/inner/process.rs
+++ b/jxl/src/api/inner/process.rs
@@ -131,8 +131,11 @@ impl JxlDecoderInner {
         ))
     }
 
-    /// Draws all the pixels we have data for.
-    pub fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer]) -> Result<()> {
+    /// Draws all the pixels we have data for. Returns `true` if any new pixels
+    /// were written to `buffers` since the previous call to `flush_pixels`;
+    /// returns `false` if no new rendering has happened, in which case the
+    /// contents of `buffers` are unchanged from the caller's perspective.
+    pub fn flush_pixels(&mut self, buffers: &mut [JxlOutputBuffer]) -> Result<bool> {
         let mut input: &[u8] = &[];
         match self.codestream_parser.process(
             &mut self.box_parser,
@@ -141,8 +144,11 @@ impl JxlDecoderInner {
             Some(buffers),
             true,
         ) {
-            Ok(()) => Ok(()),
-            Err(crate::error::Error::OutOfBounds(_)) => Ok(()),
+            Ok(()) | Err(crate::error::Error::OutOfBounds(_)) => {
+                let updated = self.codestream_parser.pixels_dirty;
+                self.codestream_parser.pixels_dirty = false;
+                Ok(updated)
+            }
             Err(e) => Err(e),
         }
     }

--- a/jxl/src/frame/lf_preview.rs
+++ b/jxl/src/frame/lf_preview.rs
@@ -274,14 +274,14 @@ impl Frame {
         output_buffers: &mut [JxlOutputBuffer<'_>],
         changed_regions: Option<&[Rect]>,
         output_profile: &JxlColorProfile,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if self.header.needs_blending() {
-            return Ok(());
+            return Ok(false);
         }
         if !((self.header.has_lf_frame() && self.header.frame_type == FrameType::RegularFrame)
             || (self.header.frame_type == FrameType::LFFrame && self.header.lf_level == 1))
         {
-            return Ok(());
+            return Ok(false);
         }
 
         let output_color_info = OutputColorInfo::from_header(&self.decoder_state.file_header)?;
@@ -293,18 +293,18 @@ impl Frame {
                 output_color_info.luminances,
             )
         }) else {
-            return Ok(());
+            return Ok(false);
         };
 
         if output_tf.is_linear() {
-            return Ok(());
+            return Ok(false);
         }
 
         let image_metadata = &self.decoder_state.file_header.image_metadata;
         if !image_metadata.xyb_encoded || !image_metadata.extra_channel_info.is_empty() {
             // We only render LF frames for XYB VarDCT images with no extra channels.
             // TODO(veluca): we might want to relax this to "no alpha".
-            return Ok(());
+            return Ok(false);
         }
         let color_type = pixel_format.color_type;
         let data_format = pixel_format.color_data_format.unwrap();
@@ -316,12 +316,12 @@ impl Frame {
             )
         {
             // We only render color data, and only to 3- or 4- channel output buffers.
-            return Ok(());
+            return Ok(false);
         }
         // We already have a fully-rendered frame and we are not requesting to re-render
         // specific regions.
         if self.decoder_state.lf_frame_was_rendered && changed_regions.is_none() {
-            return Ok(());
+            return Ok(false);
         }
         if changed_regions.is_none() {
             self.decoder_state.lf_frame_was_rendered = true;
@@ -385,6 +385,6 @@ impl Frame {
             )?;
         }
 
-        Ok(())
+        Ok(true)
     }
 }

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -135,6 +135,9 @@ impl Frame {
         Ok(())
     }
 
+    /// Returns `true` if any pixels were written to the output buffers during
+    /// this call, `false` if the call was a no-op for the buffers (e.g. no new
+    /// HF groups, no flush work, or the render pipeline was not yet ready).
     pub fn decode_and_render_hf_groups(
         &mut self,
         api_buffers: &mut Option<&mut [JxlOutputBuffer<'_>]>,
@@ -142,12 +145,12 @@ impl Frame {
         groups: Vec<(usize, Vec<(usize, BitReader)>)>,
         do_flush: bool,
         output_profile: &JxlColorProfile,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if self.render_pipeline.is_none() || self.lf_global.is_none() {
             assert_eq!(groups.iter().map(|x| x.1.len()).sum::<usize>(), 0);
             // We don't yet have any output ready (as the pipeline would be initialized otherwise),
             // so exit without doing anything.
-            return Ok(());
+            return Ok(false);
         }
 
         let mut buffers: Vec<Option<JxlOutputBuffer>> = Vec::new();
@@ -312,18 +315,19 @@ impl Frame {
         }
 
         let regions = buffer_splitter.into_changed_regions();
+        let rendered = !regions.is_empty() && self.header.frame_type == FrameType::RegularFrame;
 
         self.reference_frame_data = reference_frame_data;
         self.lf_frame_data = lf_frame_data;
 
         if self.header.frame_type == FrameType::LFFrame && self.header.lf_level == 1 {
             if do_flush && let Some(buffers) = api_buffers {
-                self.maybe_preview_lf_frame(
+                return self.maybe_preview_lf_frame(
                     pixel_format,
                     buffers,
                     Some(&regions[..]),
                     output_profile,
-                )?;
+                );
             } else if self.incomplete_groups == 0 {
                 // If we are not requesting another flush at the end of the LF frame, we
                 // probably have a partial render. Ensure we re-render the LF frame when
@@ -332,7 +336,7 @@ impl Frame {
             }
         }
 
-        Ok(())
+        Ok(rendered)
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Currently flush_pixels returns Result<()> and unconditionally re-runs the do_flush=true rendering path even when nothing has changed since the last flush. Callers that consume the rendered output (e.g. the Firefox decoder) end up doing redundant per-row post-processing for every flush, even when the output buffer is identical to the previous flush.

Track a pixels_dirty flag on the codestream parser that is set only when decode_and_render_hf_groups actually writes to the output buffers (i.e. buffer_splitter.into_changed_regions() is non-empty). flush_pixels checks and clears this flag, returning Ok(false) when nothing has been rendered since the last call so the caller can skip its post-processing entirely.

decode_and_render_hf_groups now returns Result<bool> so its callers in sections.rs can decide whether to mark pixels_dirty.