### PR TITLE
Fix an unsound API allowing creating slices with incorrect alignment

### DIFF
--- a/jxl/src/image/test.rs
+++ b/jxl/src/image/test.rs
@@ -67,6 +67,20 @@ fn rect_basic() -> Result<()> {
     Ok(())
 }
 
+#[cfg(miri)]
+#[test]
+fn image_from_raw_with_misaligned_offset_triggers_ub() -> Result<()> {
+    use super::OwnedRawImage;
+    // Issue: Image<T>::from_raw checks the base RawImageBuffer alignment, but it does not check
+    // that OwnedRawImage's byte offset is aligned for T. This safe construction leaves the
+    // allocation itself 4-byte aligned while making row(0) start one byte later; Image::<u32>::row
+    // then creates a misaligned &[u32], which Miri reports as UB.
+    let raw = OwnedRawImage::new_zeroed_with_padding((4, 1), (1, 0), (1, 0))?;
+    let image = Image::<u32>::from_raw(raw);
+    let _ = image.row(0);
+    Ok(())
+}
+
 fn f64_conversions<T: ImageDataType + Eq + for<'a> Arbitrary<'a>>() {
     arbtest::arbtest(|u| {
         let t = T::arbitrary(u)?;

--- a/jxl/src/image/test.rs
+++ b/jxl/src/image/test.rs
@@ -67,18 +67,16 @@ fn rect_basic() -> Result<()> {
     Ok(())
 }
 
-#[cfg(miri)]
 #[test]
-fn image_from_raw_with_misaligned_offset_triggers_ub() -> Result<()> {
+#[should_panic(expected = "image byte offset must be aligned to element size")]
+fn image_from_raw_rejects_misaligned_offset() {
     use super::OwnedRawImage;
-    // Issue: Image<T>::from_raw checks the base RawImageBuffer alignment, but it does not check
-    // that OwnedRawImage's byte offset is aligned for T. This safe construction leaves the
-    // allocation itself 4-byte aligned while making row(0) start one byte later; Image::<u32>::row
-    // then creates a misaligned &[u32], which Miri reports as UB.
-    let raw = OwnedRawImage::new_zeroed_with_padding((4, 1), (1, 0), (1, 0))?;
-    let image = Image::<u32>::from_raw(raw);
-    let _ = image.row(0);
-    Ok(())
+    // Regression test: Image<T>::from_raw used to check the base RawImageBuffer alignment but not
+    // OwnedRawImage's byte offset. This safe construction leaves the allocation itself 4-byte
+    // aligned while making row(0) start one byte later; accepting it would let Image::<u32>::row
+    // create a misaligned &[u32], which is UB.
+    let raw = OwnedRawImage::new_zeroed_with_padding((4, 1), (1, 0), (1, 0)).unwrap();
+    let _ = Image::<u32>::from_raw(raw);
 }
 
 fn f64_conversions<T: ImageDataType + Eq + for<'a> Arbitrary<'a>>() {

--- a/jxl/src/image/typed.rs
+++ b/jxl/src/image/typed.rs
@@ -15,7 +15,8 @@ use super::{ImageDataType, OwnedRawImage, RawImageRect, RawImageRectMut, Rect};
 
 #[repr(transparent)]
 pub struct Image<T: ImageDataType> {
-    // Safety invariant: self.raw.data.is_aligned(T::DATA_TYPE_ID.size()) is true.
+    // Safety invariant: self.raw.data and self.raw.byte_offset().0 are aligned to
+    // T::DATA_TYPE_ID.size().
     raw: OwnedRawImage,
     _ph: PhantomData<T>,
 }
@@ -112,6 +113,10 @@ impl<T: ImageDataType> Image<T> {
     pub fn from_raw(raw: OwnedRawImage) -> Self {
         const { assert!(CACHE_LINE_BYTE_SIZE.is_multiple_of(T::DATA_TYPE_ID.size())) };
         assert!(raw.data.is_aligned(T::DATA_TYPE_ID.size()));
+        assert!(
+            raw.byte_offset().0.is_multiple_of(T::DATA_TYPE_ID.size()),
+            "image byte offset must be aligned to element size"
+        );
         Image {
             // Safety note: we just checked alignment.
             raw,
@@ -122,11 +127,11 @@ impl<T: ImageDataType> Image<T> {
     #[inline(always)]
     pub fn row(&self, row: usize) -> &[T] {
         let row = self.raw.row(row);
-        // SAFETY: Since self.raw.data.is_aligned(T::DATA_TYPE_ID.size()) by the safety invariant
-        // on `self`, the returned slice is aligned to T::DATA_TYPE_ID.size(), and sizeof(T) ==
-        // T::DATA_TYPE_ID.size() by the requirements of ImageDataType; moreover, ImageDataType
-        // requires T to be a bag-of-bits type with no padding, so the implicit transmute is not
-        // an issue.
+        // SAFETY: Since self.raw.data and the byte offset are aligned to T::DATA_TYPE_ID.size()
+        // by the safety invariant on `self`, the returned slice is aligned to
+        // T::DATA_TYPE_ID.size(), and sizeof(T) == T::DATA_TYPE_ID.size() by the requirements of
+        // ImageDataType; moreover, ImageDataType requires T to be a bag-of-bits type with no
+        // padding, so the implicit transmute is not an issue.
         unsafe {
             std::slice::from_raw_parts(row.as_ptr().cast::<T>(), row.len() / T::DATA_TYPE_ID.size())
         }
@@ -135,11 +140,11 @@ impl<T: ImageDataType> Image<T> {
     #[inline(always)]
     pub fn row_mut(&mut self, row: usize) -> &mut [T] {
         let row = self.raw.row_mut(row);
-        // SAFETY: Since self.raw.data.is_aligned(T::DATA_TYPE_ID.size()) by the safety invariant
-        // on `self`, the returned slice is aligned to T::DATA_TYPE_ID.size(), and sizeof(T) ==
-        // T::DATA_TYPE_ID.size() by the requirements of ImageDataType; moreover, ImageDataType
-        // requires T to be a bag-of-bits type with no padding, so the implicit transmute is not
-        // an issue.
+        // SAFETY: Since self.raw.data and the byte offset are aligned to T::DATA_TYPE_ID.size()
+        // by the safety invariant on `self`, the returned slice is aligned to
+        // T::DATA_TYPE_ID.size(), and sizeof(T) == T::DATA_TYPE_ID.size() by the requirements of
+        // ImageDataType; moreover, ImageDataType requires T to be a bag-of-bits type with no
+        // padding, so the implicit transmute is not an issue.
         unsafe {
             std::slice::from_raw_parts_mut(
                 row.as_mut_ptr().cast::<T>(),


### PR DESCRIPTION
This fixes a soundness issue in `Image<T>::from_raw`.

`Image<T>::from_raw` checked that the underlying `RawImageBuffer` base pointer, row size, and stride were aligned for `T`, but it did not check `OwnedRawImage`’s byte offset. As a result, safe code could construct an `OwnedRawImage` whose allocation was correctly aligned but whose logical image rows started at a misaligned byte offset. Calling `Image::<u32>::row()` on that image then created a misaligned `&[u32]`, which Miri reports as UB.

The fix adds an offset-alignment check in `Image<T>::from_raw`, so misaligned raw images are rejected before any typed slice can be formed. The regression test constructs such an image with a one-byte offset and verifies that `Image::<u32>::from_raw` panics instead of allowing later UB. The safety comments for typed row access were also updated to include the byte-offset alignment invariant.

## Impact analysis

This cannot be used for out-of-bounds accesses because:

- `OwnedRawImage::row()` first creates a byte slice with normal checked indexing:
  `data.row(...)[offset.0..offset.0 + byte_size.0]`.
  If `offset.0 + byte_size.0` exceeds the allocated row width, this panics before the unsafe typed cast.

- `Image<T>::row()` then does:
  `from_raw_parts(row.as_ptr().cast::<T>(), row.len() / size_of::<T>())`.
  Since the length is rounded down from the byte slice length, the typed slice covers at most the byte slice range, never past it.

I do not believe this issue to be exploitable in any way.

This issue was discovered by GPT-5.5