### PR TITLE
Small fix in maybe_preview_lf_frame.

### DIFF
--- a/jxl/src/frame/lf_preview.rs
+++ b/jxl/src/frame/lf_preview.rs
@@ -385,6 +385,6 @@ impl Frame {
             )?;
         }
 
-        Ok(true)
+        Ok(!regions.is_empty())
     }
 }


### PR DESCRIPTION
Do not return `true` if the `regions` argument is empty.