### PR TITLE
flush_pixels: gate Ok(true) on real modular decode

### DIFF
--- a/jxl/src/api/inner/process.rs
+++ b/jxl/src/api/inner/process.rs
@@ -147,6 +147,12 @@ impl JxlDecoderInner {
             Ok(()) | Err(crate::error::Error::OutOfBounds(_)) => {
                 let updated = self.codestream_parser.pixels_dirty;
                 self.codestream_parser.pixels_dirty = false;
+                // Clear the modular-side "real decode happened" flag so that
+                // subsequent flushes only report Ok(true) when new real decode
+                // landed in the buffers since this call.
+                if let Some(frame) = self.codestream_parser.frame.as_mut() {
+                    frame.clear_modular_real_decode_since_last_flush();
+                }
                 Ok(updated)
             }
             Err(e) => Err(e),

--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -219,6 +219,16 @@ pub struct Frame {
 }
 
 impl Frame {
+    /// Reset the modular "real decode happened since last flush" flag.
+    /// Called from `flush_pixels` after the consumer has read `pixels_dirty`,
+    /// so that the gate in `decode_and_render_hf_groups` only fires for
+    /// decode activity that follows this flush.
+    pub fn clear_modular_real_decode_since_last_flush(&mut self) {
+        if let Some(lf) = self.lf_global.as_mut() {
+            lf.modular_global.clear_real_decode_since_last_flush();
+        }
+    }
+
     pub fn toc(&self) -> &Toc {
         &self.toc
     }

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -371,9 +371,26 @@ pub struct FullModularImage {
     pipeline_used_channels: Vec<bool>,
     log_group_dim: usize,
     num_groups: (usize, usize),
+    // True if real decoded modular data has reached the buffers since the
+    // last `flush_pixels` cleared this. Set by `read_section0` (when newly
+    // decoded section-0 channel count increases) and `read_stream` (after a
+    // successful subbitstream decode into a section that has buffers). Used
+    // by `decode_and_render_hf_groups` to gate the `rendered` return so that
+    // pure zero-fill flushes (which would render zero placeholders through
+    // the pipeline before any real data is available) do not falsely report
+    // new content. Cleared by `flush_pixels` after consuming `pixels_dirty`.
+    real_decode_since_last_flush: bool,
 }
 
 impl FullModularImage {
+    pub fn real_decode_since_last_flush(&self) -> bool {
+        self.real_decode_since_last_flush
+    }
+
+    pub fn clear_real_decode_since_last_flush(&mut self) {
+        self.real_decode_since_last_flush = false;
+    }
+
     pub fn can_do_partial_render(&self) -> bool {
         self.can_do_partial_render
     }
@@ -449,6 +466,7 @@ impl FullModularImage {
                 pipeline_used_channels: vec![],
                 log_group_dim: frame_header.log_group_dim(),
                 num_groups: frame_header.size_groups(),
+                real_decode_since_last_flush: false,
             });
         }
 
@@ -621,6 +639,7 @@ impl FullModularImage {
             pipeline_used_channels: vec![],
             log_group_dim: frame_header.log_group_dim(),
             num_groups: frame_header.size_groups(),
+            real_decode_since_last_flush: false,
         })
     }
 
@@ -631,6 +650,7 @@ impl FullModularImage {
         br: &mut BitReader,
         allow_partial: bool,
     ) -> Result<()> {
+        let prev_decoded_section0_channels = self.decoded_section0_channels;
         let mut decoded_if_partial = 0;
         let ret = with_buffers(
             &self.buffer_info,
@@ -659,6 +679,9 @@ impl FullModularImage {
             (Err(e), false) => {
                 return Err(e);
             }
+        }
+        if self.decoded_section0_channels > prev_decoded_section0_channels {
+            self.real_decode_since_last_flush = true;
         }
 
         for b in self.section_buffer_indices[0]
@@ -727,6 +750,13 @@ impl FullModularImage {
                 Ok(())
             },
         )?;
+        // Reached here only if `decode_modular_subbitstream` returned Ok above
+        // (the `?` short-circuits on partial-decode errors). Only signal real
+        // decode if the section actually has buffers — empty/meta sections
+        // pass through here as no-ops and do not produce visible content.
+        if !self.section_buffer_indices[section_id].is_empty() {
+            self.real_decode_since_last_flush = true;
+        }
 
         Ok(())
     }

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -315,7 +315,21 @@ impl Frame {
         }
 
         let regions = buffer_splitter.into_changed_regions();
-        let rendered = !regions.is_empty() && self.header.frame_type == FrameType::RegularFrame;
+        // Only gate modular files. VarDCT files write pixels directly via
+        // `decode_hf_group` and don't go through `read_section0`/`read_stream`,
+        // so `real_decode_since_last_flush` would always be false for them and
+        // we'd suppress legitimate progressive renders.
+        let modular_gate_passed = if self.header.encoding == Encoding::Modular {
+            self.lf_global
+                .as_ref()
+                .map(|lf| lf.modular_global.real_decode_since_last_flush())
+                .unwrap_or(false)
+        } else {
+            true
+        };
+        let rendered = !regions.is_empty()
+            && modular_gate_passed
+            && self.header.frame_type == FrameType::RegularFrame;
 
         self.reference_frame_data = reference_frame_data;
         self.lf_frame_data = lf_frame_data;


### PR DESCRIPTION
## Summary

Without this, `flush_pixels` returns `Ok(true)` for modular files before any decoded pixels have actually reached the buffer: `decode_and_render_hf_groups` flushes zero-filled empty channels through the render pipeline, populates `requested_rects`, and `rendered = !regions.is_empty()` fires. Callers that treat `Ok(true)` as "real pixels are available" then read an empty/black surface.

This adds a `real_decode_since_last_flush` flag on `FullModularImage`:

- Set by `read_section0` when newly decoded section-0 channel count grows.
- Set by `read_stream` after a successful subbitstream decode into a section that has buffers (empty/meta sections do not produce content).
- Cleared by `flush_pixels` after consuming `pixels_dirty`.

`decode_and_render_hf_groups` checks the flag for modular frames only; VarDCT frames write pixels directly via `decode_hf_group` and are unaffected. The LF-preview path is also unaffected (it returns earlier).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace --release` — all tests pass