### PR TITLE
Fix: capture LZ77 distance cluster before context_map padding (resolves #765)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Helmut Januschka <helmut@januschka.com>
 Inflation <2375962+inflation@users.noreply.github.com>
 Jacob Abel <jacobabel@nullpo.dev>
 Jonathan Brown (Jonnyawsom3) <jonathanbr30@gmail.com>
+Lilith River <lilith@imazen.io>
 Louis Dispa <louis.dispa@outlook.fr>
 Luca Versari
 Martin Bruse <zondolfin@gmail.com>

--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -77,7 +77,7 @@ pub struct Histograms {
     /// `context_map.last()` after a resize would silently return a pad byte
     /// (0) and route LZ77 distance ANS reads through the wrong histogram.
     ///
-    /// Set to 0 when LZ77 is disabled.
+    /// Explicitly stored: context_map can get padded so we cannot use .last()
     lz_dist_cluster: u8,
     // TODO(veluca): figure out why this is unused.
     #[allow(dead_code)]

--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -63,6 +63,22 @@ pub struct Histograms {
     lz77_params: Lz77Params,
     lz77_length_uint: Option<HybridUint>,
     context_map: Vec<u8>,
+    /// Cluster index used for LZ77 distance reads.
+    ///
+    /// Captured at `Histograms::decode` time as the original last entry of
+    /// `context_map`, mirroring libjxl's
+    /// `code->lz77.nonserialized_distance_context = context_map->back()`
+    /// (`dec_ans.cc:362`).
+    ///
+    /// Stored separately because callers may pad `context_map` with zeros
+    /// after decode (see `Frame::decode` calling `Histograms::resize` to
+    /// avoid bounds checks at AC `ZeroDensityContext` lookup sites). That
+    /// padding moves the original last entry, so reading
+    /// `context_map.last()` after a resize would silently return a pad byte
+    /// (0) and route LZ77 distance ANS reads through the wrong histogram.
+    ///
+    /// Set to 0 when LZ77 is disabled.
+    lz_dist_cluster: u8,
     // TODO(veluca): figure out why this is unused.
     #[allow(dead_code)]
     log_alpha_size: usize,
@@ -243,7 +259,7 @@ impl SymbolReader {
             let min_length = min_length.unwrap();
             let dist_multiplier = image_width.unwrap_or(0) as u32;
 
-            let lz_dist_cluster = *histograms.context_map.last().unwrap() as usize;
+            let lz_dist_cluster = histograms.lz_dist_cluster as usize;
             let lz_conf = &histograms.uint_configs[lz_dist_cluster];
             let is_rle = histograms.codes.single_symbol(lz_dist_cluster) == Some(1)
                 && lz_conf.is_split_exponent_zero();
@@ -370,7 +386,7 @@ impl SymbolReader {
                     return 0;
                 };
 
-                let lz_dist_cluster = *histograms.context_map.last().unwrap() as usize;
+                let lz_dist_cluster = histograms.lz_dist_cluster as usize;
                 let distance_sym = match &histograms.codes {
                     Codes::Huffman(hc) => hc.read(br, lz_dist_cluster),
                     Codes::Ans(ans) => self.ans_reader.read(ans, br, lz_dist_cluster),
@@ -592,6 +608,17 @@ impl Histograms {
         };
         assert_eq!(context_map.len(), num_contexts);
 
+        // Capture the LZ77 distance cluster BEFORE any later resize() can pad
+        // context_map with zeros (see Histograms::resize and Frame::decode).
+        // Mirrors libjxl's
+        // ANSCode::lz77.nonserialized_distance_context = context_map->back();
+        // (dec_ans.cc:362).
+        let lz_dist_cluster = if lz77_params.enabled {
+            *context_map.last().unwrap()
+        } else {
+            0
+        };
+
         let use_prefix_code = br.read(1)? != 0;
         let log_alpha_size = if use_prefix_code {
             HUFFMAN_MAX_BITS
@@ -616,6 +643,7 @@ impl Histograms {
             lz77_params,
             lz77_length_uint,
             context_map,
+            lz_dist_cluster,
             log_alpha_size,
             uint_configs,
             codes,
@@ -659,6 +687,7 @@ impl Histograms {
             uint_configs,
             log_alpha_size: 15,
             context_map: vec![0u8; num_contexts],
+            lz_dist_cluster: 0,
             codes,
         }
     }
@@ -669,6 +698,7 @@ impl Histograms {
         let uint_configs = vec![HybridUint::new(8, 0, 0), HybridUint::new(0, 0, 0)];
         let mut context_map = vec![0u8; num_contexts + 1];
         *context_map.last_mut().unwrap() = 1;
+        let lz_dist_cluster = *context_map.last().unwrap();
         Self {
             lz77_params: Lz77Params {
                 enabled: true,
@@ -679,6 +709,7 @@ impl Histograms {
             uint_configs,
             log_alpha_size: 15,
             context_map,
+            lz_dist_cluster,
             codes,
         }
     }

--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -63,20 +63,6 @@ pub struct Histograms {
     lz77_params: Lz77Params,
     lz77_length_uint: Option<HybridUint>,
     context_map: Vec<u8>,
-    /// Cluster index used for LZ77 distance reads.
-    ///
-    /// Captured at `Histograms::decode` time as the original last entry of
-    /// `context_map`, mirroring libjxl's
-    /// `code->lz77.nonserialized_distance_context = context_map->back()`
-    /// (`dec_ans.cc:362`).
-    ///
-    /// Stored separately because callers may pad `context_map` with zeros
-    /// after decode (see `Frame::decode` calling `Histograms::resize` to
-    /// avoid bounds checks at AC `ZeroDensityContext` lookup sites). That
-    /// padding moves the original last entry, so reading
-    /// `context_map.last()` after a resize would silently return a pad byte
-    /// (0) and route LZ77 distance ANS reads through the wrong histogram.
-    ///
     /// Explicitly stored: context_map can get padded so we cannot use .last()
     lz_dist_cluster: u8,
     // TODO(veluca): figure out why this is unused.
@@ -610,9 +596,6 @@ impl Histograms {
 
         // Capture the LZ77 distance cluster BEFORE any later resize() can pad
         // context_map with zeros (see Histograms::resize and Frame::decode).
-        // Mirrors libjxl's
-        // ANSCode::lz77.nonserialized_distance_context = context_map->back();
-        // (dec_ans.cc:362).
         let lz_dist_cluster = if lz77_params.enabled {
             *context_map.last().unwrap()
         } else {


### PR DESCRIPTION
Resolves #765.

## Mechanism

When LZ77 is enabled, `Histograms::decode` follows the spec — the decoded `context_map`'s last entry is the LZ77 distance cluster, matching libjxl's `code->lz77.nonserialized_distance_context = context_map->back()` (`dec_ans.cc:362`).

But `Frame::decode` (`jxl/src/frame/decode.rs:786-789` and `:1057-1059`) then calls `histograms.resize(num_contexts + 16)` to pad `context_map` with 16 zero entries so that `ZeroDensityContext` lookups can index up to `ZERO_DENSITY_CONTEXT_LIMIT` without bounds checks (the PR #671 fix). That padding is correct for AC context lookups — but it also moves the original LZ77 distance cluster away from `context_map.last()`.

The next time the AC reader fires an LZ77 trigger, `lz_dist_cluster = *histograms.context_map.last().unwrap()` reads a zero pad byte, the distance ANS symbol is decoded against histogram `0` (wrong), and the ANS state gets the wrong `dist`/`offset` update. State is corrupted for all subsequent reads, manifesting as `Invalid AC: N nonzeros after decoding block` (or `InvalidNumNonZeros`, or `AnsChecksumMismatch`, depending on how far the corruption propagates before the validation fails).

## Why libjxl C and jxl-oxide don't have this bug

- **libjxl** captures the distance cluster as `lz77_ctx_` at `ANSSymbolReader::Create` time (`dec_ans.cc:411`) and never re-reads `context_map.back()`. It also doesn't do resize-with-padding — it bounds-checks at AC context sites instead.
- **jxl-oxide** pre-clusters and stores the distance histogram explicitly in its `Coder` structure (`crates/jxl-coding/src/lib.rs`), so even if the visible context map were padded, the distance read uses the captured handle.

## Why libjxl reference test corpora don't catch this

libjxl's encoder *never* uses `Lz77Method::Optimal` or `Lz77Method::Greedy` for VarDCT — only `kRLE`, per `lib/jxl/enc_ans_params.h` (`HistogramParams` constructor) + `lib/jxl/enc_frame.cc:1259-1263`. `Optimal`/`kLZ77` are reserved for **Modular** mode at slow tiers (`HistogramParams::ForModular` in `enc_ans.cc`). So the reference test corpus has no Optimal/Greedy LZ77 VarDCT bitstreams to exercise this code path.

Third-party encoders that emit Optimal/Greedy LZ77 in VarDCT streams (e.g. [imazen/jxl-encoder](https://github.com/imazen/jxl-encoder) at effort 9+) trip this on every output file with non-trivial backward references.

## Fix

Capture `lz_dist_cluster` in `Histograms` at decode time, before any external `resize` can shift it. Replaces both call sites of `*histograms.context_map.last().unwrap()` with `histograms.lz_dist_cluster as usize`.

Mirrors libjxl's `ANSCode::lz77.nonserialized_distance_context` pattern.

## Verification

- A 22-file regression corpus (mix of `EndOfBlockResidualNonZeros`, `InvalidNumNonZeros`, `AnsChecksumMismatch` errors — all from the same underlying state corruption) was used to validate. Before fix: 22/22 fail. After fix: 22/22 decode, all matching `djxl 0.12.0` output within standard pixel-parity tolerance.
- Verified directly on `jxl_cli` built from this branch: all 6 previously-failing repro `.jxl` files decode without error.
- This same fix was first applied and validated in our zenjxl-decoder fork (which is a thin downstream port of jxl-rs); full lib test suite (1231 tests) passed there with zero regressions.

## Files

`jxl/src/entropy_coding/decode.rs` — adds `lz_dist_cluster: u8` field to `Histograms`, captures it at decode time, uses it in the two SymbolReader call sites instead of re-reading `context_map.last()`. Test helpers `Histograms::reverse_octet` and `Histograms::rle` updated to set the new field.

Net diff: +33 / −2 lines.