### PR TITLE
Use fallible allocation for hf_sections in codestream parser

### DIFF
--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -19,6 +19,7 @@ use crate::{
         frame_header::FrameHeader, toc::IncrementalTocReader,
     },
     icc::IncrementalIccReader,
+    util::NewWithCapacity,
 };
 
 use super::{CodestreamParser, SectionBuffer};
@@ -236,9 +237,21 @@ impl CodestreamParser {
             self.lf_global_section = None;
             self.lf_sections.clear();
             self.hf_global_section = None;
-            self.hf_sections = (0..frame_header.num_groups())
-                .map(|_| (0..frame_header.passes.num_passes).map(|_| None).collect())
-                .collect();
+            // Use fallible allocation: `num_groups()` is derived from the
+            // (untrusted) frame header dimensions and can be astronomically
+            // large for malformed/fuzz inputs. Avoid aborting the process on
+            // OOM and return a recoverable error instead.
+            let num_groups = frame_header.num_groups();
+            let num_passes = frame_header.passes.num_passes as usize;
+            let mut hf_sections = Vec::new_with_capacity(num_groups)?;
+            for _ in 0..num_groups {
+                let mut row = Vec::new_with_capacity(num_passes)?;
+                for _ in 0..num_passes {
+                    row.push(None);
+                }
+                hf_sections.push(row);
+            }
+            self.hf_sections = hf_sections;
             self.candidate_hf_sections.clear();
 
             self.frame_header = Some(frame_header);


### PR DESCRIPTION
Prevents process abort on malformed inputs where `frame_header.num_groups()` is astronomically large (fixes #770).