### PR TITLE
Validate histogram_index in PassInfo against num_histograms

### DIFF
--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -237,6 +237,8 @@ pub enum Error {
     HFBlockOutOfBounds,
     #[error("Invalid AC: nonzeros {0} is too large for {1} 8x8 blocks")]
     InvalidNumNonZeros(usize, usize),
+    #[error("Invalid AC: histogram index {0} is out of bounds (num_histograms = {1})")]
+    InvalidHistogramIndex(usize, usize),
     #[error("Invalid AC: {0} nonzeros after decoding block")]
     EndOfBlockResidualNonZeros(usize),
     #[error("Unknown transfer function for ICC profile")]

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -327,6 +327,16 @@ impl<'a, 'b> PassInfo<'a, 'b> {
         debug!(?pass);
         let histogram_index = br.read(num_histo_bits as usize)? as usize;
         debug!(?histogram_index);
+        // `num_histo_bits` is `ceil_log2(num_histograms)`, so the bitstream can
+        // legally encode values >= `num_histograms` when it is not a power of
+        // two. Reject those here, otherwise downstream indexing into the
+        // per-pass histogram context map can go out of bounds.
+        if histogram_index >= hf_global.num_histograms as usize {
+            return Err(Error::InvalidHistogramIndex(
+                histogram_index,
+                hf_global.num_histograms as usize,
+            ));
+        }
         let reader = Some(SymbolReader::new(
             &hf_global.passes[pass].histograms,
             br,


### PR DESCRIPTION
When num_histograms is not a power of two, the bitstream can encode a value >= num_histograms in ceil_log2(num_histograms) bits, causing out-of-bounds indexing into the per-pass histogram context map (fixes #769).