### PR TITLE
Avoid subtract overflow in save_lowmem for 1px-wide save regions

### DIFF
--- a/jxl/src/headers/image_metadata.rs
+++ b/jxl/src/headers/image_metadata.rs
@@ -65,6 +65,20 @@ impl Orientation {
         }
     }
 
+    /// Returns the per-pixel step in display coordinates when iterating along
+    /// the frame's x axis. Equivalent to
+    /// `display_pixel((1, y), size) - display_pixel((0, y), size)` but works
+    /// for any non-empty `size` (the latter form would underflow when
+    /// `size.0 == 1` and the orientation flips x).
+    pub fn display_row_step(&self) -> (isize, isize) {
+        match self {
+            Orientation::Identity | Orientation::FlipVertical => (1, 0),
+            Orientation::FlipHorizontal | Orientation::Rotate180 => (-1, 0),
+            Orientation::Transpose | Orientation::Rotate90Cw => (0, 1),
+            Orientation::AntiTranspose | Orientation::Rotate90Ccw => (0, -1),
+        }
+    }
+
     pub fn display_pixel(&self, (x, y): (usize, usize), size: (usize, usize)) -> (usize, usize) {
         match self {
             Orientation::Identity => (x, y),

--- a/jxl/src/render/low_memory_pipeline/save/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/save/mod.rs
@@ -102,11 +102,12 @@ impl SaveStage {
         for (c, d) in data.iter().enumerate() {
             let nc = self.output_channels();
             let (x0, y0) = self.orientation.display_pixel((0, relative_y), save_size);
-            let (x1, y1) = self.orientation.display_pixel((1, relative_y), save_size);
             let x0 = x0 as isize;
             let y0 = y0 as isize;
-            let dx = x1 as isize - x0;
-            let dy = y1 as isize - y0;
+            // Compute the per-pixel step directly from the orientation rather
+            // than via `display_pixel((1, ..))`, which would underflow when
+            // `save_size.0 == 1` and the orientation flips x.
+            let (dx, dy) = self.orientation.display_row_step();
             match self.data_format {
                 JxlDataFormat::U8 { .. } => {
                     let src_row = d.get_row::<u8>(frame_y);


### PR DESCRIPTION
Compute the per-pixel display step directly from the orientation instead of via `display_pixel((1, ..), save_size)`, which underflows when `save_size.0 == 1` and the orientation flips x (fixes #768).