### PR TITLE
Add public TOC inspection API for progressive streaming

### DIFF
--- a/jxl/src/api/data_types.rs
+++ b/jxl/src/api/data_types.rs
@@ -288,3 +288,21 @@ pub struct JxlFrameHeader {
     /// Frame size (width, height)
     pub size: (usize, usize),
 }
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum TocGroupKind {
+    All,
+    LfGlobal,
+    LfGroup(u32),
+    HfGlobal,
+    GroupPass { pass_idx: u32, group_idx: u32 },
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct TocEntry {
+    pub kind: TocGroupKind,
+    /// Offset in bytes from the start of frame data (after the frame header).
+    pub offset: u64,
+    /// Size of the entry in bytes.
+    pub size: u32,
+}

--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -5,7 +5,7 @@
 
 use super::{
     JxlBasicInfo, JxlBitstreamInput, JxlColorProfile, JxlDecoderInner, JxlDecoderOptions,
-    JxlOutputBuffer, JxlPixelFormat, ProcessingResult,
+    JxlOutputBuffer, JxlPixelFormat, ProcessingResult, TocEntry,
 };
 #[cfg(test)]
 use crate::frame::Frame;
@@ -269,6 +269,57 @@ impl JxlDecoder<WithFrameInfo> {
     /// Number of passes we have full data for.
     pub fn num_completed_passes(&self) -> usize {
         self.inner.num_completed_passes().unwrap()
+    }
+
+    /// Returns the number of TOC entries in the current frame.
+    pub fn toc_num_entries(&self) -> usize {
+        self.inner.toc_num_entries().unwrap()
+    }
+
+    /// Returns the TOC entry at the given index, or `None` if out of bounds.
+    ///
+    /// # TOC layout
+    ///
+    /// Entries are returned in bitstream (physical) order. For single-group
+    /// frames there is one [`TocGroupKind::All`] entry. For multi-group frames
+    /// without a TOC permutation the order is:
+    /// - index 0: [`TocGroupKind::LfGlobal`]
+    /// - indices `1..=num_lf_groups`: [`TocGroupKind::LfGroup`]
+    /// - index `1 + num_lf_groups`: [`TocGroupKind::HfGlobal`]
+    /// - the rest: [`TocGroupKind::GroupPass`], pass-major
+    ///
+    /// When the frame has a permuted TOC the same set of kinds is present but
+    /// may appear in any order; each entry's `kind` is resolved through the
+    /// permutation, so identify a section by its `kind`, not by its index.
+    ///
+    /// The entry `offset` is relative to the start of frame data (after the
+    /// frame header) and is the cumulative size of the preceding sections in
+    /// this same bitstream order. Designed for progressive-streaming use cases
+    /// that need section byte boundaries without fully decoding the frame.
+    ///
+    /// [`TocGroupKind::All`]: crate::api::TocGroupKind::All
+    /// [`TocGroupKind::LfGlobal`]: crate::api::TocGroupKind::LfGlobal
+    /// [`TocGroupKind::LfGroup`]: crate::api::TocGroupKind::LfGroup
+    /// [`TocGroupKind::HfGlobal`]: crate::api::TocGroupKind::HfGlobal
+    /// [`TocGroupKind::GroupPass`]: crate::api::TocGroupKind::GroupPass
+    pub fn toc_entry(&self, index: usize) -> Option<TocEntry> {
+        self.inner.toc_entry(index)
+    }
+
+    /// Returns the total size of frame section data in bytes, ie the sum of
+    /// all TOC entry sizes, or the amount of section data
+    /// needed to fully decode the frame (not counting the frame header).
+    pub fn frame_data_size(&self) -> u64 {
+        self.inner.frame_data_size().unwrap()
+    }
+
+    /// Returns the byte offset, from the start of the input (file-absolute,
+    /// including any ISOBMFF container), at which the current frame's
+    /// TOC-described section data begins (immediately after the frame header).
+    ///
+    /// [`toc_entry`](Self::toc_entry) offsets are relative to this position.
+    pub fn frame_data_offset(&self) -> u64 {
+        self.inner.frame_data_offset().unwrap()
     }
 
     /// Draws all the pixels we have data for.
@@ -2111,6 +2162,261 @@ pub(crate) mod tests {
                     g,
                     b,
                 );
+            }
+        }
+    }
+
+    // ---- TOC API tests ------------------------------------------------------
+
+    use crate::api::{TocEntry, TocGroupKind};
+
+    /// Drive a fresh decoder over `file` to the `WithFrameInfo` state, where
+    /// the TOC API is available.
+    fn decode_to_frame_info(file: &[u8]) -> JxlDecoder<WithFrameInfo> {
+        let options = JxlDecoderOptions::default();
+        let mut decoder = JxlDecoder::<states::Initialized>::new(options);
+        let mut input = file;
+        let mut with_info = loop {
+            match decoder.process(&mut input).unwrap() {
+                ProcessingResult::Complete { result } => break result,
+                ProcessingResult::NeedsMoreInput { fallback, .. } => decoder = fallback,
+            }
+        };
+        loop {
+            match with_info.process(&mut input).unwrap() {
+                ProcessingResult::Complete { result } => break result,
+                ProcessingResult::NeedsMoreInput { fallback, .. } => with_info = fallback,
+            }
+        }
+    }
+
+    fn collect_toc(d: &JxlDecoder<WithFrameInfo>) -> Vec<TocEntry> {
+        (0..d.toc_num_entries())
+            .map(|i| d.toc_entry(i).expect("in-range TOC entry"))
+            .collect()
+    }
+
+    /// Invariants that must hold for any valid frame's TOC, derived purely
+    /// from the entries themselves (no external reference decoder).
+    fn assert_toc_invariants(d: &JxlDecoder<WithFrameInfo>) {
+        let entries = collect_toc(d);
+        assert!(!entries.is_empty(), "a frame always has >= 1 TOC entry");
+
+        // Offsets are relative to frame_data_offset, start at 0, and are the
+        // running sum of preceding section sizes (contiguous layout).
+        let mut acc = 0u64;
+        for (i, e) in entries.iter().enumerate() {
+            assert_eq!(e.offset, acc, "entry {i} offset is not contiguous");
+            acc += e.size as u64;
+        }
+        // frame_data_size is the total of all section sizes.
+        assert_eq!(d.frame_data_size(), acc, "frame_data_size != sum of sizes");
+        // Section data starts after the codestream header + frame header + TOC.
+        assert!(d.frame_data_offset() > 0, "frame_data_offset should be > 0");
+
+        // The multiset of kinds must be exactly the JPEG XL section layout —
+        // this validates the (possibly permuted) bitstream-order -> spec-kind
+        // mapping is internally consistent.
+        if entries.len() == 1 {
+            assert_eq!(entries[0].kind, TocGroupKind::All);
+            return;
+        }
+        let mut lf_globals = 0;
+        let mut hf_globals = 0;
+        let mut lf_group_idxs = Vec::new();
+        let mut group_passes = Vec::new();
+        for e in &entries {
+            match e.kind {
+                TocGroupKind::All => panic!("All kind in a multi-entry frame"),
+                TocGroupKind::LfGlobal => lf_globals += 1,
+                TocGroupKind::HfGlobal => hf_globals += 1,
+                TocGroupKind::LfGroup(i) => lf_group_idxs.push(i),
+                TocGroupKind::GroupPass {
+                    pass_idx,
+                    group_idx,
+                } => group_passes.push((pass_idx, group_idx)),
+            }
+        }
+        assert_eq!(lf_globals, 1, "exactly one LfGlobal expected");
+        assert_eq!(hf_globals, 1, "exactly one HfGlobal expected");
+
+        // LfGroup indices form a complete 0..num_lf_groups set.
+        lf_group_idxs.sort_unstable();
+        for (i, idx) in lf_group_idxs.iter().enumerate() {
+            assert_eq!(*idx as usize, i, "LfGroup indices not a contiguous 0..n");
+        }
+
+        // GroupPass (pass, group) pairs form a complete pass x group grid.
+        let num_groups = group_passes.iter().map(|&(_, g)| g).max().unwrap_or(0) as usize + 1;
+        let num_passes = group_passes.len() / num_groups.max(1);
+        assert_eq!(
+            group_passes.len(),
+            num_groups * num_passes,
+            "GroupPass count is not num_groups * num_passes"
+        );
+        let mut seen = std::collections::HashSet::new();
+        for &(p, g) in &group_passes {
+            assert!(seen.insert((p, g)), "duplicate GroupPass ({p}, {g})");
+            assert!((g as usize) < num_groups, "group_idx out of range");
+            assert!((p as usize) < num_passes, "pass_idx out of range");
+        }
+    }
+
+    #[test]
+    fn test_toc_invariants_basic() {
+        let file = std::fs::read("resources/test/basic.jxl").unwrap();
+        assert_toc_invariants(&decode_to_frame_info(&file));
+    }
+
+    #[test]
+    fn test_toc_invariants_multigroup() {
+        // A multi-group image exercises the LfGroup / HfGlobal / GroupPass
+        // layout rather than the single "All" entry.
+        let file = std::fs::read("resources/test/multiple_lf_420.jxl").unwrap();
+        assert_toc_invariants(&decode_to_frame_info(&file));
+    }
+
+    #[test]
+    fn test_toc_invariants_permuted() {
+        // has_permutation.jxl has a permuted TOC; the invariants check that the
+        // bitstream-order -> spec-kind mapping survives the permutation.
+        let file = std::fs::read("resources/test/has_permutation.jxl").unwrap();
+        assert_toc_invariants(&decode_to_frame_info(&file));
+    }
+
+    #[test]
+    fn test_toc_permutation_container_consistency() {
+        // The bare and containerised variants of the same permuted image must
+        // report identical TOC structure (kinds, indices, sizes, relative
+        // offsets) and frame_data_size. Only frame_data_offset differs — the
+        // containerised file's section data starts later by the box overhead.
+        let bare = std::fs::read("resources/test/has_permutation.jxl").unwrap();
+        let cont = std::fs::read("resources/test/has_permutation_with_container.jxl").unwrap();
+
+        let db = decode_to_frame_info(&bare);
+        let dc = decode_to_frame_info(&cont);
+
+        let eb = collect_toc(&db);
+        let ec = collect_toc(&dc);
+
+        assert_eq!(eb.len(), ec.len(), "entry count differs bare vs container");
+        for (i, (b, c)) in eb.iter().zip(ec.iter()).enumerate() {
+            assert_eq!(b.kind, c.kind, "entry {i} kind differs");
+            assert_eq!(b.offset, c.offset, "entry {i} relative offset differs");
+            assert_eq!(b.size, c.size, "entry {i} size differs");
+        }
+        assert_eq!(
+            db.frame_data_size(),
+            dc.frame_data_size(),
+            "frame_data_size differs bare vs container"
+        );
+        assert!(
+            dc.frame_data_offset() > db.frame_data_offset(),
+            "containerised frame_data_offset ({}) should exceed bare ({}) by the \
+             container box overhead",
+            dc.frame_data_offset(),
+            db.frame_data_offset(),
+        );
+    }
+
+    /// Drive a decoder to `WithFrameInfo` by feeding `chunk_size` bytes at a
+    /// time, exercising the incremental `OutOfBounds` parse path (frame header
+    /// + TOC split across multiple `process()` calls).
+    fn decode_to_frame_info_chunked(file: &[u8], chunk_size: usize) -> JxlDecoder<WithFrameInfo> {
+        let options = JxlDecoderOptions::default();
+        let mut decoder = JxlDecoder::<states::Initialized>::new(options);
+        let mut remaining = file;
+        let mut window = &remaining[0..0];
+        // Stage 1: Initialized -> WithImageInfo.
+        let mut with_info = loop {
+            window = &remaining[..(window.len() + chunk_size).min(remaining.len())];
+            let before = window.len();
+            let res = decoder.process(&mut window).unwrap();
+            remaining = &remaining[(before - window.len())..];
+            match res {
+                ProcessingResult::Complete { result } => break result,
+                ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                    assert!(!remaining.is_empty(), "ran out of input before image info");
+                    decoder = fallback;
+                }
+            }
+        };
+        // Stage 2: WithImageInfo -> WithFrameInfo (this is where the TOC is
+        // parsed; small chunks force the OutOfBounds retry path).
+        loop {
+            window = &remaining[..(window.len() + chunk_size).min(remaining.len())];
+            let before = window.len();
+            let res = with_info.process(&mut window).unwrap();
+            remaining = &remaining[(before - window.len())..];
+            match res {
+                ProcessingResult::Complete { result } => break result,
+                ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                    assert!(!remaining.is_empty(), "ran out of input before frame info");
+                    with_info = fallback;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_toc_offset_chunked_matches_single_shot() {
+        // Regression: feeding a frame in tiny chunks splits frame-header + TOC
+        // parsing across multiple process() calls (the OutOfBounds path). The
+        // resulting frame_data_offset / frame_data_size / TOC entries MUST
+        // match the single-shot feed — otherwise the section-data byte anchor
+        // undercounts and every progressive split boundary shifts.
+        for name in [
+            "resources/test/basic.jxl",
+            "resources/test/multiple_lf_420.jxl",
+            "resources/test/has_permutation.jxl",
+            "resources/test/has_permutation_with_container.jxl",
+        ] {
+            let file = std::fs::read(name).unwrap();
+            let single = decode_to_frame_info(&file);
+            let single_offset = single.frame_data_offset();
+            let single_size = single.frame_data_size();
+            let single_entries = collect_toc(&single);
+
+            // 1 byte at a time is the most aggressive split; also test a few
+            // small sizes to vary where the boundary lands.
+            for chunk in [1usize, 3, 7, 17] {
+                let chunked = decode_to_frame_info_chunked(&file, chunk);
+                assert_eq!(
+                    chunked.frame_data_offset(),
+                    single_offset,
+                    "{name}: frame_data_offset differs at chunk_size={chunk} \
+                     (chunked={}, single={single_offset})",
+                    chunked.frame_data_offset(),
+                );
+                assert_eq!(
+                    chunked.frame_data_size(),
+                    single_size,
+                    "{name}: frame_data_size differs at chunk_size={chunk}"
+                );
+                let chunked_entries = collect_toc(&chunked);
+                assert_eq!(
+                    chunked_entries.len(),
+                    single_entries.len(),
+                    "{name}: TOC entry count differs at chunk_size={chunk}"
+                );
+                for (i, (a, b)) in chunked_entries
+                    .iter()
+                    .zip(single_entries.iter())
+                    .enumerate()
+                {
+                    assert_eq!(
+                        a.kind, b.kind,
+                        "{name}: entry {i} kind differs at chunk={chunk}"
+                    );
+                    assert_eq!(
+                        a.offset, b.offset,
+                        "{name}: entry {i} offset differs at chunk={chunk}"
+                    );
+                    assert_eq!(
+                        a.size, b.size,
+                        "{name}: entry {i} size differs at chunk={chunk}"
+                    );
+                }
             }
         }
     }

--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -84,6 +84,17 @@ pub(super) struct CodestreamParser {
     // the frame is done.
     frame_header: Option<FrameHeader>,
     toc_parser: Option<IncrementalTocReader>,
+    /// Whole bytes consumed by the current frame's header, captured when the
+    /// frame header is parsed and used (together with the TOC byte size) to
+    /// compute the frame's section-data offset.
+    frame_header_byte_size: usize,
+    /// Whole bytes consumed by the current frame's TOC, accumulated across
+    /// process() calls. The TOC can be read incrementally (each OutOfBounds
+    /// retry consumes a partial slice), so this must accumulate rather than be
+    /// recomputed from the final call's BitReader — otherwise the section-data
+    /// offset undercounts by the bytes consumed in earlier retries. Reset to 0
+    /// when a new frame's TOC parse begins.
+    toc_byte_size: usize,
     pub(super) frame: Option<Frame>,
 
     // Buffers.
@@ -165,6 +176,8 @@ impl CodestreamParser {
             is_gray: false,
             frame_header: None,
             toc_parser: None,
+            frame_header_byte_size: 0,
+            toc_byte_size: 0,
             frame: None,
             non_section_buf: SmallBuffer::new(4096),
             non_section_bit_offset: 0,
@@ -196,6 +209,28 @@ impl CodestreamParser {
             #[cfg(test)]
             decoded_frames: 0,
         }
+    }
+
+    /// Number of TOC entries in the current frame, if a frame header has
+    /// been parsed.
+    pub(super) fn toc_num_entries(&self) -> Option<usize> {
+        self.frame.as_ref().map(|f| f.header().num_toc_entries())
+    }
+
+    /// TOC entry at `index` for the current frame, if available.
+    pub(super) fn toc_entry(&self, index: usize) -> Option<crate::api::TocEntry> {
+        self.frame.as_ref().and_then(|f| f.toc_entry(index))
+    }
+
+    /// Total size in bytes of the current frame's section data.
+    pub(super) fn frame_data_size(&self) -> Option<u64> {
+        self.frame.as_ref().map(|f| f.total_bytes_in_toc() as u64)
+    }
+
+    /// Byte offset from the start of the input (including any ISOBMFF
+    /// container) to where the current frame's section data begins.
+    pub(super) fn frame_data_offset(&self) -> Option<u64> {
+        self.frame.as_ref().and_then(|f| f.frame_data_offset())
     }
 
     fn has_visible_frame(&self) -> bool {

--- a/jxl/src/api/inner/codestream_parser/non_section.rs
+++ b/jxl/src/api/inner/codestream_parser/non_section.rs
@@ -245,6 +245,7 @@ impl CodestreamParser {
 
             self.frame_header = Some(frame_header);
             let bits = br.total_bits_read();
+            self.frame_header_byte_size = bits / 8;
             self.non_section_buf.consume(bits / 8);
             self.non_section_bit_offset = (bits % 8) as u8;
         }
@@ -255,6 +256,7 @@ impl CodestreamParser {
             if self.toc_parser.is_none() {
                 let num_toc_entries = self.frame_header.as_ref().unwrap().num_toc_entries();
                 self.toc_parser = Some(IncrementalTocReader::new(num_toc_entries as u32, &mut br)?);
+                self.toc_byte_size = 0;
             }
 
             let toc_parser = self.toc_parser.as_mut().unwrap();
@@ -264,6 +266,7 @@ impl CodestreamParser {
                     Ok(()) => bits = br.total_bits_read(),
                     Err(Error::OutOfBounds(c)) => {
                         self.non_section_buf.consume(bits / 8);
+                        self.toc_byte_size += bits / 8;
                         self.non_section_bit_offset = (bits % 8) as u8;
                         // Estimate >= 16 bits per remaining entry to read.
                         return Err(Error::OutOfBounds(
@@ -277,6 +280,7 @@ impl CodestreamParser {
 
             bits = br.total_bits_read();
             self.non_section_buf.consume(bits / 8);
+            self.toc_byte_size += bits / 8;
             self.non_section_bit_offset = (bits % 8) as u8;
             self.toc_parser.take().unwrap().finalize()
         };
@@ -286,6 +290,13 @@ impl CodestreamParser {
             toc,
             self.decoder_state.take().unwrap(),
         )?;
+
+        // Absolute codestream offset where this frame's section data begins.
+        frame.set_data_offset(
+            self.current_frame_file_offset as u64
+                + self.frame_header_byte_size as u64
+                + self.toc_byte_size as u64,
+        );
 
         let mut sections: Vec<_> = frame
             .toc()

--- a/jxl/src/api/inner/mod.rs
+++ b/jxl/src/api/inner/mod.rs
@@ -96,6 +96,28 @@ impl JxlDecoderInner {
         Some(self.codestream_parser.num_completed_passes())
     }
 
+    /// Number of TOC entries in the current frame, if a frame header has
+    /// been parsed.
+    pub fn toc_num_entries(&self) -> Option<usize> {
+        self.codestream_parser.toc_num_entries()
+    }
+
+    /// TOC entry at `index` for the current frame, if available.
+    pub fn toc_entry(&self, index: usize) -> Option<crate::api::TocEntry> {
+        self.codestream_parser.toc_entry(index)
+    }
+
+    /// Total size in bytes of the current frame's section data.
+    pub fn frame_data_size(&self) -> Option<u64> {
+        self.codestream_parser.frame_data_size()
+    }
+
+    /// Byte offset from the start of the input (file-absolute; includes any ISOBMFF container) to where the current
+    /// frame's TOC-described section data begins.
+    pub fn frame_data_offset(&self) -> Option<u64> {
+        self.codestream_parser.frame_data_offset()
+    }
+
     /// Fully resets the decoder to its initial state.
     ///
     /// This clears all state including pixel_format. For animation loop playback,

--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -248,6 +248,7 @@ impl Frame {
             header: frame_header,
             color_channels,
             toc,
+            data_offset: 0,
             lf_global: None,
             hf_global: None,
             lf_image,

--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -186,6 +186,10 @@ pub enum RenderUnit {
 pub struct Frame {
     header: FrameHeader,
     toc: Toc,
+    /// Absolute byte offset, from the start of the input (file-absolute; includes any ISOBMFF container), at which this
+    /// frame's TOC-described section data begins (after the frame header +
+    /// TOC). Set by the codestream parser; 0 until then.
+    data_offset: u64,
     color_channels: usize,
     lf_global: Option<LfGlobalState>,
     hf_global: Option<HfGlobalState>,
@@ -229,6 +233,82 @@ impl Frame {
 
     pub fn total_bytes_in_toc(&self) -> usize {
         self.toc.entries.iter().map(|x| *x as usize).sum()
+    }
+
+    /// Returns the TOC entry at `index`, in **bitstream (physical) order** —
+    /// the order sections are laid out in the codestream. Returns `None` if
+    /// the index is out of bounds.
+    ///
+    /// The entry's `offset` is relative to [`frame_data_offset`](Self::frame_data_offset)
+    /// (i.e. the first physical section is at offset 0), and is the sum of
+    /// the sizes of the preceding physical sections. `kind` is the logical
+    /// section kind stored at this physical position, resolved through the
+    /// TOC permutation when present.
+    pub fn toc_entry(&self, index: usize) -> Option<crate::api::TocEntry> {
+        use crate::api::TocEntry;
+        let sizes = &self.toc.entries; // sizes in bitstream order
+        if index >= sizes.len() {
+            return None;
+        }
+        // Offset = cumulative size of preceding physical sections.
+        let offset: u64 = sizes[..index].iter().map(|&s| s as u64).sum();
+        // Resolve the spec-order index for this physical position. The TOC
+        // permutation maps spec index -> bitstream position; we need its
+        // inverse (bitstream position -> spec index).
+        let spec_idx = if self.toc.permuted {
+            self.toc
+                .permutation
+                .iter()
+                .position(|&p| p as usize == index)
+                .unwrap_or(index)
+        } else {
+            index
+        };
+        Some(TocEntry {
+            kind: self.toc_kind_for_spec_index(spec_idx),
+            offset,
+            size: sizes[index],
+        })
+    }
+
+    /// Maps a spec-order TOC index to its [`TocGroupKind`](crate::api::TocGroupKind),
+    /// following the JPEG XL section layout: `LfGlobal`, then `num_lf_groups`
+    /// `LfGroup`s, then `HfGlobal`, then `num_passes * num_groups`
+    /// `GroupPass`es (pass-major). Single-entry frames are `All`.
+    fn toc_kind_for_spec_index(&self, spec_idx: usize) -> crate::api::TocGroupKind {
+        use crate::api::TocGroupKind;
+        if self.header.num_toc_entries() == 1 {
+            return TocGroupKind::All;
+        }
+        let num_lf_groups = self.header.num_lf_groups();
+        let num_groups = self.header.num_groups();
+        if spec_idx == 0 {
+            TocGroupKind::LfGlobal
+        } else if spec_idx <= num_lf_groups {
+            TocGroupKind::LfGroup((spec_idx - 1) as u32)
+        } else if spec_idx == num_lf_groups + 1 {
+            TocGroupKind::HfGlobal
+        } else {
+            let j = spec_idx - (num_lf_groups + 2);
+            TocGroupKind::GroupPass {
+                pass_idx: (j / num_groups) as u32,
+                group_idx: (j % num_groups) as u32,
+            }
+        }
+    }
+
+    /// Returns the byte offset, from the start of the input (file-absolute; includes any ISOBMFF container), at which
+    /// this frame's TOC-described section data begins (immediately after the
+    /// frame header + TOC). [`toc_entry`](Self::toc_entry) offsets are
+    /// relative to this. Set by the codestream parser once the TOC is parsed.
+    pub fn frame_data_offset(&self) -> Option<u64> {
+        Some(self.data_offset)
+    }
+
+    /// Records the absolute codestream byte offset where this frame's section
+    /// data begins. Called by the codestream parser after the TOC is parsed.
+    pub(crate) fn set_data_offset(&mut self, offset: u64) {
+        self.data_offset = offset;
     }
 
     #[instrument(level = "debug", skip(self), ret)]


### PR DESCRIPTION
Expose the frame Table of Contents through the public decoder API so streaming consumers can locate frame-section byte boundaries without fully decoding the bitstream: `TocEntry` / `TocGroupKind` plus `JxlDecoder::{toc_num_entries, toc_entry, frame_data_size, frame_data_offset}`, available once the decoder reaches `WithFrameInfo`.

Entries are reported in bitstream order, each kind resolved through the TOC permutation when present. The section-data offset accumulates the TOC byte size across `process()` calls, since the TOC may be parsed incrementally.

Tests cover TOC invariants (single/multi-group, permuted), bare-vs- container consistency, and a chunked-vs-single-shot regression.

AI disclosure: written with Claude Code (Opus 4.8) but all code reviewed and unit tested, as well as against jxl-oxide and libjxl outputs. Also tested against an in-house JXL streaming server and client previously using jxl-oxide. 

Closes #387 