### PR TITLE
Revisit modular special cases, and add a single-symbol path.

### DIFF
--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -651,6 +651,10 @@ impl Histograms {
     pub fn can_use_config_420_fast_path(&self) -> bool {
         !self.lz77_params.enabled && self.uint_configs.iter().all(|cfg| cfg.is_config_420())
     }
+
+    pub fn single_symbol(&self, ctx: usize) -> Option<u32> {
+        self.codes.single_symbol(ctx)
+    }
 }
 
 #[cfg(test)]

--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -10,10 +10,7 @@ use crate::{
     error::Result,
     frame::modular::{
         IMAGE_OFFSET, IMAGE_PADDING, ModularChannel, Tree,
-        decode::{
-            common::make_pixel,
-            specialized_trees::{TreeSpecialCase, specialize_tree},
-        },
+        decode::{common::make_pixel, specialized_trees::run_on_specialized_tree},
         predict::{PredictionData, WeightedPredictorState},
         tree::{NUM_NONREF_PROPERTIES, PROPERTIES_PER_PREVCHAN, predict},
     },
@@ -23,6 +20,94 @@ use crate::{
 };
 
 const SMALL_CHANNEL_THRESHOLD: usize = 64;
+
+pub(super) trait ModularChannelDecoder {
+    #[inline(always)]
+    fn needs_toptop(&self) -> bool {
+        true
+    }
+
+    fn init_row(&mut self, _buffers: &mut [&mut ModularChannel], _chan: usize, _y: usize) {}
+
+    fn decode_one(
+        &mut self,
+        _prediction_data: PredictionData,
+        _pos: (usize, usize),
+        _xsize: usize,
+        _reader: &mut SymbolReader,
+        _br: &mut BitReader,
+        _histograms: &Histograms,
+    ) -> i32 {
+        0
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[inline(never)]
+    fn decode_row(
+        &mut self,
+        buffers: &mut [&mut ModularChannel],
+        chan: usize,
+        histograms: &Histograms,
+        reader: &mut SymbolReader,
+        br: &mut BitReader,
+        y: usize,
+        xsize: usize,
+    ) {
+        self.init_row(buffers, chan, y);
+        const { assert!(IMAGE_OFFSET.1 == 2) };
+        let [row, row_top, row_toptop] =
+            buffers[chan].data.distinct_full_rows_mut([y + 2, y + 1, y]);
+        let row = &mut row[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + xsize];
+        let row_top = &mut row_top[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + xsize];
+        let row_toptop = &mut row_toptop[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + xsize];
+
+        let do_decode_cold = {
+            #[inline(never)]
+            |decoder: &mut Self,
+             row: &mut [i32],
+             row_top: &mut [i32],
+             row_toptop: &mut [i32],
+             pos: (usize, usize),
+             reader: &mut SymbolReader,
+             br: &mut BitReader|
+             -> (PredictionData, i32) {
+                let prediction_data =
+                    PredictionData::get_rows(row, row_top, row_toptop, pos.0, pos.1);
+                let val = decoder.decode_one(prediction_data, pos, xsize, reader, br, histograms);
+                row[pos.0] = val;
+                (prediction_data, val)
+            }
+        };
+
+        if y < 2 {
+            for x in 0..xsize {
+                do_decode_cold(self, row, row_top, row_toptop, (x, y), reader, br);
+            }
+        } else {
+            let mut last = 0;
+            let mut prediction_data = PredictionData::default();
+            for x in 0..2 {
+                (prediction_data, last) =
+                    do_decode_cold(self, row, row_top, row_toptop, (x, y), reader, br);
+            }
+            for (x, r) in row.iter_mut().enumerate().skip(2).take(xsize - 4) {
+                prediction_data = prediction_data.update_for_interior_row(
+                    row_top,
+                    row_toptop,
+                    x,
+                    last,
+                    self.needs_toptop(),
+                );
+                let val = self.decode_one(prediction_data, (x, y), xsize, reader, br, histograms);
+                *r = val;
+                last = val;
+            }
+            for x in xsize - 2..xsize {
+                do_decode_cold(self, row, row_top, row_toptop, (x, y), reader, br);
+            }
+        }
+    }
+}
 
 // General case decoder, for small buffers for which it's not worth trying to detect tree special cases.
 #[inline(never)]
@@ -79,88 +164,6 @@ fn decode_modular_channel_small(
     Ok(())
 }
 
-pub(super) trait ModularChannelDecoder {
-    const NEEDS_TOP: bool;
-    const NEEDS_TOPTOP: bool;
-    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize);
-    fn decode_one(
-        &mut self,
-        prediction_data: PredictionData,
-        pos: (usize, usize),
-        xsize: usize,
-        reader: &mut SymbolReader,
-        br: &mut BitReader,
-        histograms: &Histograms,
-    ) -> i32;
-}
-
-#[inline(never)]
-fn decode_modular_channel_impl<D: ModularChannelDecoder>(
-    buffers: &mut [&mut ModularChannel],
-    chan: usize,
-    mut decoder: D,
-    reader: &mut SymbolReader,
-    br: &mut BitReader,
-    histograms: &Histograms,
-) -> Result<()> {
-    let size = buffers[chan].data.size();
-    debug_assert!(size.0 >= 4);
-    debug_assert!(size.1 >= 2);
-
-    const { assert!(IMAGE_OFFSET.1 == 2) };
-
-    // Let the compiler decide whether inlining in the borders is worth it.
-    let do_decode_cold =
-        |decoder: &mut D, prediction_data, pos, reader: &mut SymbolReader, br: &mut BitReader| {
-            decoder.decode_one(prediction_data, pos, size.0, reader, br, histograms)
-        };
-
-    for y in 0..size.1 {
-        decoder.init_row(buffers, chan, y);
-        let [row, row_top, row_toptop] =
-            buffers[chan].data.distinct_full_rows_mut([y + 2, y + 1, y]);
-        let row = &mut row[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + size.0];
-        let row_top = &mut row_top[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + size.0];
-        let row_toptop = &mut row_toptop[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + size.0];
-        let mut last = 0;
-        let mut prediction_data = PredictionData::default();
-        for x in 0..2 {
-            prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
-            let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br);
-            row[x] = val;
-            last = val;
-        }
-        if y < 2 {
-            for x in 2..size.0 - 2 {
-                let prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
-                let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br);
-                row[x] = val;
-            }
-        } else {
-            for (x, r) in row.iter_mut().enumerate().skip(2).take(size.0 - 4) {
-                prediction_data = prediction_data.update_for_interior_row(
-                    row_top,
-                    row_toptop,
-                    x,
-                    last,
-                    D::NEEDS_TOP,
-                    D::NEEDS_TOPTOP,
-                );
-                let val =
-                    decoder.decode_one(prediction_data, (x, y), size.0, reader, br, histograms);
-                *r = val;
-                last = val;
-            }
-        }
-        for x in size.0 - 2..size.0 {
-            prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
-            let val = do_decode_cold(&mut decoder, prediction_data, (x, y), reader, br);
-            row[x] = val;
-        }
-    }
-    Ok(())
-}
-
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "debug", skip(buffers, reader, tree))]
 pub(super) fn decode_modular_channel(
@@ -186,27 +189,17 @@ pub(super) fn decode_modular_channel(
     assert_eq!(buffers[chan].data.offset(), IMAGE_OFFSET);
 
     // We now know the channel has size at least IMAGE_PADDING.
-
-    let special_tree = specialize_tree(tree, chan, stream_id, size.0, header)?;
-    match special_tree {
-        TreeSpecialCase::NoTree(t) => {
-            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
+    run_on_specialized_tree(tree, chan, stream_id, size.0, header, {
+        #[inline(never)]
+        |t| {
+            let size = buffers[chan].data.size();
+            debug_assert!(size.0 >= 4);
+            debug_assert!(size.1 >= 2);
+            for y in 0..size.1 {
+                t.decode_row(buffers, chan, &tree.histograms, reader, br, y, size.0);
+            }
+            Ok(())
         }
-        TreeSpecialCase::NoWp(t) => {
-            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
-        }
-        TreeSpecialCase::WpOnlyConfig420(t) => {
-            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
-        }
-        TreeSpecialCase::GradientLookupConfig420(t) => {
-            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
-        }
-        TreeSpecialCase::SingleGradientOnly(t) => {
-            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
-        }
-        TreeSpecialCase::General(t) => {
-            decode_modular_channel_impl(buffers, chan, t, reader, br, &tree.histograms)
-        }
-    }?;
+    })?;
     br.check_for_error()
 }

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -7,7 +7,7 @@ use std::{collections::VecDeque, ops::Range};
 
 use crate::{
     bit_reader::BitReader,
-    entropy_coding::decode::{Histograms, SymbolReader},
+    entropy_coding::decode::{Histograms, SymbolReader, unpack_signed},
     error::Result,
     frame::modular::{
         ModularChannel, Predictor, Tree,
@@ -28,6 +28,7 @@ pub struct NoWpTree {
     flat_nodes: Vec<FlatTreeNode>,
     references: Image<i32>,
     property_buffer: Vec<i32>,
+    single_value: Option<i32>,
 }
 
 impl NoWpTree {
@@ -37,6 +38,7 @@ impl NoWpTree {
         channel: usize,
         stream: usize,
         xsize: usize,
+        single_symbol: Option<u32>,
     ) -> Result<Self> {
         let num_ref_props = max_property_count
             .saturating_sub(NUM_NONREF_PROPERTIES)
@@ -54,14 +56,12 @@ impl NoWpTree {
             flat_nodes,
             references,
             property_buffer,
+            single_value: single_symbol.map(unpack_signed),
         })
     }
 }
 
 impl ModularChannelDecoder for NoWpTree {
-    const NEEDS_TOP: bool = true;
-    const NEEDS_TOPTOP: bool = true;
-
     fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
         precompute_references(buffers, chan, y, &mut self.references);
         self.property_buffer[9] = 0;
@@ -86,7 +86,11 @@ impl ModularChannelDecoder for NoWpTree {
             &self.references,
             &mut self.property_buffer,
         );
-        let dec = reader.read_signed_clustered(histograms, br, prediction_result.context as usize);
+        let dec = if let Some(sv) = self.single_value {
+            sv
+        } else {
+            reader.read_signed_clustered(histograms, br, prediction_result.context as usize)
+        };
         make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
     }
 }
@@ -104,19 +108,24 @@ impl GeneralTree {
         channel: usize,
         stream: usize,
         xsize: usize,
+        single_symbol: Option<u32>,
     ) -> Result<Self> {
         let wp_state = WeightedPredictorState::new(&header.wp_header, xsize);
         Ok(Self {
-            no_wp_tree: NoWpTree::new(nodes, max_property_count, channel, stream, xsize)?,
+            no_wp_tree: NoWpTree::new(
+                nodes,
+                max_property_count,
+                channel,
+                stream,
+                xsize,
+                single_symbol,
+            )?,
             wp_state,
         })
     }
 }
 
 impl ModularChannelDecoder for GeneralTree {
-    const NEEDS_TOP: bool = true;
-    const NEEDS_TOPTOP: bool = true;
-
     fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
         self.no_wp_tree.init_row(buffers, chan, y);
     }
@@ -140,7 +149,11 @@ impl ModularChannelDecoder for GeneralTree {
             &self.no_wp_tree.references,
             &mut self.no_wp_tree.property_buffer,
         );
-        let dec = reader.read_signed_clustered(histograms, br, prediction_result.context as usize);
+        let dec = if let Some(sv) = self.no_wp_tree.single_value {
+            sv
+        } else {
+            reader.read_signed_clustered(histograms, br, prediction_result.context as usize)
+        };
         let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
         self.wp_state.update_errors(val, pos, xsize);
         val
@@ -225,13 +238,6 @@ impl WpOnlyLookupConfig420 {
 }
 
 impl ModularChannelDecoder for WpOnlyLookupConfig420 {
-    const NEEDS_TOP: bool = true;
-    const NEEDS_TOPTOP: bool = true;
-
-    fn init_row(&mut self, _buffers: &mut [&mut ModularChannel], _chan: usize, _y: usize) {
-        // nothing to do
-    }
-
     #[inline(always)]
     fn decode_one(
         &mut self,
@@ -292,10 +298,10 @@ fn make_gradient_lut_config_420(
 }
 
 impl ModularChannelDecoder for GradientLookupConfig420 {
-    const NEEDS_TOP: bool = true;
-    const NEEDS_TOPTOP: bool = false;
-
-    fn init_row(&mut self, _: &mut [&mut ModularChannel], _: usize, _: usize) {}
+    #[inline(always)]
+    fn needs_toptop(&self) -> bool {
+        false
+    }
 
     #[inline(always)]
     fn decode_one(
@@ -333,10 +339,10 @@ pub struct SingleGradientOnly {
 }
 
 impl ModularChannelDecoder for SingleGradientOnly {
-    const NEEDS_TOP: bool = true;
-    const NEEDS_TOPTOP: bool = false;
-
-    fn init_row(&mut self, _: &mut [&mut ModularChannel], _: usize, _: usize) {}
+    #[inline(always)]
+    fn needs_toptop(&self) -> bool {
+        false
+    }
 
     #[inline(always)]
     fn decode_one(
@@ -360,46 +366,41 @@ impl ModularChannelDecoder for SingleGradientOnly {
 
 pub struct NoTree {
     clustered_ctx: usize,
+    single_value: Option<i32>,
 }
 
 impl ModularChannelDecoder for NoTree {
-    const NEEDS_TOP: bool = false;
-    const NEEDS_TOPTOP: bool = false;
-
-    fn init_row(&mut self, _: &mut [&mut ModularChannel], _: usize, _: usize) {}
-
-    #[inline(always)]
-    fn decode_one(
+    #[inline(never)]
+    fn decode_row(
         &mut self,
-        _: PredictionData,
-        _: (usize, usize),
-        _: usize,
+        buffers: &mut [&mut ModularChannel],
+        chan: usize,
+        histograms: &Histograms,
         reader: &mut SymbolReader,
         br: &mut BitReader,
-        histograms: &Histograms,
-    ) -> i32 {
-        let dec = reader.read_signed_clustered_inline(histograms, br, self.clustered_ctx);
-        make_pixel(dec, 1, 0)
+        y: usize,
+        xsize: usize,
+    ) {
+        let row = buffers[chan].data.row_mut(y);
+        debug_assert_eq!(row.len(), xsize);
+        if let Some(sym) = self.single_value {
+            row.fill(sym);
+        } else {
+            for r in row.iter_mut() {
+                *r = reader.read_signed_clustered_inline(histograms, br, self.clustered_ctx);
+            }
+        }
     }
 }
 
-#[allow(clippy::large_enum_variant)]
-pub enum TreeSpecialCase {
-    NoTree(NoTree),
-    NoWp(NoWpTree),
-    WpOnlyConfig420(WpOnlyLookupConfig420),
-    GradientLookupConfig420(GradientLookupConfig420),
-    SingleGradientOnly(SingleGradientOnly),
-    General(GeneralTree),
-}
-
-pub fn specialize_tree(
+pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Result<()>>(
     tree: &Tree,
     channel: usize,
     stream: usize,
     xsize: usize,
     header: &GroupHeader,
-) -> Result<TreeSpecialCase> {
+    run: F,
+) -> Result<()> {
     // TODO(veluca): consider skipping the pruning if header.uses_global_tree is true.
     let mut pruned_tree = Vec::new();
     let mut queue = VecDeque::new();
@@ -409,6 +410,11 @@ pub fn specialize_tree(
 
     let mut uses_wp = false;
     let mut uses_non_wp = false;
+
+    // If, after pruning the tree, `is_single_symbol` is true, then `single_symbol` is the
+    // only symbol that could possibly be decoded by this tree.
+    let mut is_single_symbol = true;
+    let mut single_symbol = None;
 
     // Obtain a pruned tree without nodes that are not relevant in the current channel and stream.
     // Proceed in BFS order, so that we know that the children of a node will be adjacent.
@@ -453,9 +459,25 @@ pub fn specialize_tree(
                     unreachable!()
                 };
                 *id = tree.histograms.map_context_to_cluster(*id as usize) as u32;
+                if is_single_symbol {
+                    if let Some(sym) = tree.histograms.single_symbol(*id as usize) {
+                        if single_symbol.is_none() {
+                            single_symbol = Some(sym);
+                        }
+                        if single_symbol != Some(sym) {
+                            is_single_symbol = false;
+                        }
+                    } else {
+                        is_single_symbol = false;
+                    }
+                }
                 pruned_tree.push(node);
             }
         }
+    }
+
+    if !is_single_symbol {
+        single_symbol = None;
     }
 
     if let [
@@ -467,9 +489,10 @@ pub fn specialize_tree(
         },
     ] = &*pruned_tree
     {
-        return Ok(TreeSpecialCase::NoTree(NoTree {
+        return run(&mut NoTree {
             clustered_ctx: *id as usize,
-        }));
+            single_value: single_symbol.map(unpack_signed),
+        });
     }
 
     if let [
@@ -481,40 +504,43 @@ pub fn specialize_tree(
         },
     ] = &*pruned_tree
     {
-        return Ok(TreeSpecialCase::SingleGradientOnly(SingleGradientOnly {
+        return run(&mut SingleGradientOnly {
             clustered_ctx: *id as usize,
-        }));
+        });
     }
 
     if !uses_non_wp {
         // Try the specialized 420 config version (fast path for effort 3 encoded images)
-        if let Some(wp) = WpOnlyLookupConfig420::new(&pruned_tree, &tree.histograms, header, xsize)
+        if let Some(mut wp) =
+            WpOnlyLookupConfig420::new(&pruned_tree, &tree.histograms, header, xsize)
         {
-            return Ok(TreeSpecialCase::WpOnlyConfig420(wp));
+            return run(&mut wp);
         }
     }
 
     // Non-WP trees (includes effort 2 encoding and some groups in effort > 3)
     if !uses_wp {
         // Try config 420 specialized gradient LUT version (fast path for effort 2 encoded images)
-        if let Some(gl) = make_gradient_lut_config_420(&pruned_tree, &tree.histograms) {
-            return Ok(TreeSpecialCase::GradientLookupConfig420(gl));
+        if let Some(mut gl) = make_gradient_lut_config_420(&pruned_tree, &tree.histograms) {
+            return run(&mut gl);
         }
-        return Ok(TreeSpecialCase::NoWp(NoWpTree::new(
+        return run(&mut NoWpTree::new(
             pruned_tree,
             tree.max_property_count(),
             channel,
             stream,
             xsize,
-        )?));
+            single_symbol,
+        )?);
     }
 
-    Ok(TreeSpecialCase::General(GeneralTree::new(
+    run(&mut GeneralTree::new(
         pruned_tree,
         tree.max_property_count(),
         header,
         channel,
         stream,
         xsize,
-    )?))
+        single_symbol,
+    )?)
 }

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -70,7 +70,6 @@ impl PredictionData {
         row_toptop: &[i32],
         x: usize,
         cur: i32,
-        needs_top: bool,
         needs_toptop: bool,
     ) -> PredictionData {
         debug_assert!(x > 1);
@@ -81,7 +80,7 @@ impl PredictionData {
         let topright = self.toprightright;
         let leftleft = self.left;
         let toptop = if needs_toptop { row_toptop[x] } else { 0 };
-        let toprightright = if needs_top { row_top[x + 2] } else { 0 };
+        let toprightright = row_top[x + 2];
         Self {
             left,
             top,


### PR DESCRIPTION
This gives a significant speedup on jxl-art images (i.e. 1.4x on sunset_logo.jxl)