### PR TITLE
perf: always shift in modular::error_weight

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Martin Bruse <zondolfin@gmail.com>
 Moritz Firsching
 Mrmaxmeier <3913977+Mrmaxmeier@users.noreply.github.com>
 Sami Boukortt
+TechPizza <23627133+TechPizzaDev@users.noreply.github.com>
 Tomáš Král <tomas@kral.hk>
 Wonwoo Choi <chwo9843@gmail.com>
 Zoltan Szabadka

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -332,7 +332,12 @@ fn add_bits(x: i32) -> i64 {
 
 #[inline(always)]
 fn error_weight(x: u32, maxweight: u32) -> u32 {
-    let shift = 0.max(floor_log2_nonzero(x as u64 + 1) as i32 - 5);
+    // Inline log2 to merge the XOR and subtraction by 5. 
+    // This avoids branching and permits 32-bit lzcnt instead of 64-bit. 
+    // It also unlocks some auto-vectorization, especially on ARM and AVX512 
+    // which have native 4x32 lzcnt (aligning with NUM_PREDICTORS). 
+    let carry = ((x & 0b11111) == 0b11111) as u32;
+    let shift = 31u32.saturating_sub(((x >> 5) + carry).leading_zeros());
     4u32 + ((maxweight * DIVLOOKUP[(x >> shift) as usize & 63]) >> shift)
 }
 

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -332,12 +332,8 @@ fn add_bits(x: i32) -> i64 {
 
 #[inline(always)]
 fn error_weight(x: u32, maxweight: u32) -> u32 {
-    let shift = floor_log2_nonzero(x as u64 + 1) as i32 - 5;
-    if shift < 0 {
-        4u32 + maxweight * DIVLOOKUP[x as usize & 63]
-    } else {
-        4u32 + ((maxweight * DIVLOOKUP[(x as usize >> shift) & 63]) >> shift)
-    }
+    let shift = 0.max(floor_log2_nonzero(x as u64 + 1) as i32 - 5);
+    4u32 + ((maxweight * DIVLOOKUP[(x >> shift) as usize & 63]) >> shift)
 }
 
 #[inline(always)]
@@ -353,7 +349,7 @@ fn weighted_average(pixels: &[i64; NUM_PREDICTORS], weights: &mut [u32; NUM_PRED
         .fold(((weight_sum >> 1) - 1) as i64, |sum, (i, weight)| {
             sum + pixels[i] * *weight as i64
         });
-    (sum * DIVLOOKUP[(weight_sum - 1) as usize] as i64) >> 24
+    (sum * DIVLOOKUP[(weight_sum - 1) as usize & 63] as i64) >> 24
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Unlocks auto-vec at opt-level=3; mostly effective for AVX512 like Zen4, and shouldn't regress older targets