### PR TITLE
Speed up Weighted predictor.

### DIFF
--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -33,7 +33,6 @@ pub(super) trait ModularChannelDecoder {
         &mut self,
         _prediction_data: PredictionData,
         _pos: (usize, usize),
-        _xsize: usize,
         _reader: &mut SymbolReader,
         _br: &mut BitReader,
         _histograms: &Histograms,
@@ -73,7 +72,7 @@ pub(super) trait ModularChannelDecoder {
              -> (PredictionData, i32) {
                 let prediction_data =
                     PredictionData::get_rows(row, row_top, row_toptop, pos.0, pos.1);
-                let val = decoder.decode_one(prediction_data, pos, xsize, reader, br, histograms);
+                let val = decoder.decode_one(prediction_data, pos, reader, br, histograms);
                 row[pos.0] = val;
                 (prediction_data, val)
             }
@@ -98,7 +97,7 @@ pub(super) trait ModularChannelDecoder {
                     last,
                     self.needs_toptop(),
                 );
-                let val = self.decode_one(prediction_data, (x, y), xsize, reader, br, histograms);
+                let val = self.decode_one(prediction_data, (x, y), reader, br, histograms);
                 *r = val;
                 last = val;
             }
@@ -147,7 +146,6 @@ fn decode_modular_channel_small(
             let prediction_result = predict(
                 &tree.nodes,
                 prediction_data,
-                size.0,
                 Some(&mut wp_state),
                 x,
                 y,
@@ -157,7 +155,7 @@ fn decode_modular_channel_small(
             let dec = reader.read_signed(&tree.histograms, br, prediction_result.context as usize);
             let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
             row[x] = val;
-            wp_state.update_errors(val, (x, y), size.0);
+            wp_state.update_errors(val, (x, y));
         }
     }
 

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -65,11 +65,11 @@ impl ModularChannelDecoder for NoWpTree {
         self.property_buffer[9] = 0;
     }
 
+    #[inline(always)]
     fn decode_one(
         &mut self,
         prediction_data: PredictionData,
         pos: (usize, usize),
-        xsize: usize,
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
@@ -77,7 +77,6 @@ impl ModularChannelDecoder for NoWpTree {
         let prediction_result = predict_flat(
             &self.flat_nodes,
             prediction_data,
-            xsize,
             None,
             pos.0,
             pos.1,
@@ -128,11 +127,11 @@ impl ModularChannelDecoder for GeneralTree {
         self.no_wp_tree.init_row(buffers, chan, y);
     }
 
+    #[inline(always)]
     fn decode_one(
         &mut self,
         prediction_data: PredictionData,
         pos: (usize, usize),
-        xsize: usize,
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
@@ -140,7 +139,6 @@ impl ModularChannelDecoder for GeneralTree {
         let prediction_result = predict_flat(
             &self.no_wp_tree.flat_nodes,
             prediction_data,
-            xsize,
             Some(&mut self.wp_state),
             pos.0,
             pos.1,
@@ -153,7 +151,7 @@ impl ModularChannelDecoder for GeneralTree {
             reader.read_signed_clustered(histograms, br, prediction_result.context as usize)
         };
         let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
-        self.wp_state.update_errors(val, pos, xsize);
+        self.wp_state.update_errors(val, pos);
         val
     }
 }
@@ -241,20 +239,17 @@ impl ModularChannelDecoder for WpOnlyLookupConfig420 {
         &mut self,
         prediction_data: PredictionData,
         pos: (usize, usize),
-        xsize: usize,
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
     ) -> i32 {
-        let (wp_pred, property) = self
-            .wp_state
-            .predict_and_property(pos, xsize, &prediction_data);
+        let (wp_pred, property) = self.wp_state.predict_and_property(pos, &prediction_data);
         let ctx = self.lut[(property as i64 - LUT_MIN_SPLITVAL as i64)
             .clamp(0, LUT_TABLE_SIZE as i64 - 1) as usize];
         // Use the specialized 420 fast path
         let dec = reader.read_signed_clustered_config_420(histograms, br, ctx as usize);
         let val = dec.wrapping_add(wp_pred as i32);
-        self.wp_state.update_errors(val, pos, xsize);
+        self.wp_state.update_errors(val, pos);
         val
     }
 }
@@ -306,7 +301,6 @@ impl ModularChannelDecoder for GradientLookupConfig420 {
         &mut self,
         prediction_data: PredictionData,
         _: (usize, usize),
-        _: usize,
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,
@@ -347,7 +341,6 @@ impl ModularChannelDecoder for SingleGradientOnly {
         &mut self,
         prediction_data: PredictionData,
         _: (usize, usize),
-        _: usize,
         reader: &mut SymbolReader,
         br: &mut BitReader,
         histograms: &Histograms,

--- a/jxl/src/frame/modular/flat_tree.rs
+++ b/jxl/src/frame/modular/flat_tree.rs
@@ -34,27 +34,18 @@ pub(super) enum FlatTreeNode {
     },
 }
 
-#[inline]
+#[inline(always)]
 #[allow(clippy::too_many_arguments, unsafe_code)]
 pub(super) fn predict_flat(
     flat_tree: &[FlatTreeNode],
     prediction_data: PredictionData,
-    xsize: usize,
     wp_state: Option<&mut WeightedPredictorState>,
     x: usize,
     y: usize,
     references: &Image<i32>,
     property_buffer: &mut [i32; 256],
 ) -> PredictionResult {
-    let wp_pred = compute_properties(
-        prediction_data,
-        xsize,
-        wp_state,
-        x,
-        y,
-        references,
-        property_buffer,
-    );
+    let wp_pred = compute_properties(prediction_data, wp_state, x, y, references, property_buffer);
 
     let mut pos = 0;
     loop {

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -330,174 +330,191 @@ fn add_bits(x: i32) -> i64 {
     (x as i64) << PRED_EXTRA_BITS
 }
 
-#[inline(always)]
-fn error_weight(x: u32, maxweight: u32) -> u32 {
-    let shift = floor_log2_nonzero(x as u64 + 1) as i32 - 5;
-    if shift < 0 {
-        4u32 + maxweight * DIVLOOKUP[x as usize & 63]
-    } else {
-        4u32 + ((maxweight * DIVLOOKUP[(x as usize >> shift) & 63]) >> shift)
-    }
-}
-
-#[inline(always)]
-fn weighted_average(pixels: &[i64; NUM_PREDICTORS], weights: &mut [u32; NUM_PREDICTORS]) -> i64 {
-    let log_weight = floor_log2_nonzero(weights.iter().fold(0u64, |sum, el| sum + *el as u64));
-    let weight_sum = weights.iter_mut().fold(0, |sum, el| {
-        *el >>= log_weight - 4;
-        sum + *el
-    });
-    let sum = weights
-        .iter()
-        .enumerate()
-        .fold(((weight_sum >> 1) - 1) as i64, |sum, (i, weight)| {
-            sum + pixels[i] * *weight as i64
-        });
-    (sum * DIVLOOKUP[(weight_sum - 1) as usize] as i64) >> 24
-}
-
 #[derive(Debug)]
 pub struct WeightedPredictorState {
     prediction: [i64; NUM_PREDICTORS],
     pred: i64,
-    // Position-major layout: errors for same position are contiguous
-    // Layout: [pos0: p0,p1,p2,p3] [pos1: p0,p1,p2,p3] ...
-    pred_errors_buffer: Vec<u32>,
+    // Safety invariant:
+    // - computing `(xsize + 1) * 2` does not overflow
+    // - `pred_errors_buffer.len() == (xsize + 1) * 2`
+    // - `error.len() == (xsize + 1) * 2`
+    // Note that (at least as of June 2026) the use of unsafe code
+    // that needs these invariants seems to provide meaningful speedups.
+    xsize: usize,
+    pred_errors_buffer: Vec<[u32; NUM_PREDICTORS]>,
+    // Note: we store errors in positions [1..=xsize], and error[0] == 0.
+    // (this is not a safety invariant)
     error: Vec<i32>,
-    wp_header: WeightedHeader,
+    w: [u8; 4],
+    p1c: u8,
+    p2c: u8,
+    p3c: [u8; 5],
 }
 
 impl WeightedPredictorState {
     pub fn new(wp_header: &WeightedHeader, xsize: usize) -> WeightedPredictorState {
-        let num_errors = (xsize + 2) * 2;
+        let num_errors = xsize.checked_add(1).unwrap().checked_mul(2).unwrap();
         WeightedPredictorState {
             prediction: [0; NUM_PREDICTORS],
             pred: 0,
-            // Position-major layout: errors for same position are contiguous
-            // Layout: [pos0: p0,p1,p2,p3] [pos1: p0,p1,p2,p3] ...
-            // This gives better cache locality when accessing all predictors for a position
-            pred_errors_buffer: vec![0; num_errors * NUM_PREDICTORS],
+            // Safety note: safety invariant is true by construction (we checked no
+            // overflows above)
+            xsize,
+            pred_errors_buffer: vec![[0; NUM_PREDICTORS]; num_errors],
             error: vec![0; num_errors],
-            wp_header: wp_header.clone(),
+            // These casts are lossless because w fits in 4 bits and p fits in 5 by
+            // bitstream constraints.
+            w: [
+                wp_header.w0 as u8,
+                wp_header.w1 as u8,
+                wp_header.w2 as u8,
+                wp_header.w3 as u8,
+            ],
+            p1c: wp_header.p1c as u8,
+            p2c: wp_header.p2c as u8,
+            p3c: [
+                wp_header.p3ca as u8,
+                wp_header.p3cb as u8,
+                wp_header.p3cc as u8,
+                wp_header.p3cd as u8,
+                wp_header.p3ce as u8,
+            ],
         }
     }
 
-    /// Get all predictor errors for a given position (contiguous in memory)
-    #[inline(always)]
-    fn get_errors_at_pos(&self, pos: usize) -> &[u32; NUM_PREDICTORS] {
-        let start = pos * NUM_PREDICTORS;
-        self.pred_errors_buffer[start..start + NUM_PREDICTORS]
-            .try_into()
-            .unwrap()
-    }
-
-    /// Get mutable reference to all predictor errors for a given position
-    #[inline(always)]
-    fn get_errors_at_pos_mut(&mut self, pos: usize) -> &mut [u32; NUM_PREDICTORS] {
-        let start = pos * NUM_PREDICTORS;
-        (&mut self.pred_errors_buffer[start..start + NUM_PREDICTORS])
-            .try_into()
-            .unwrap()
-    }
-
-    pub fn save_state(&self, wp_image: &mut Image<i32>, xsize: usize) {
-        let row_stride = xsize + 2;
+    pub fn save_state(&self, wp_image: &mut Image<i32>) {
+        let row_stride = self.xsize + 1;
         wp_image
             .row_mut(0)
             .copy_from_slice(&self.error[0..row_stride]);
-        for r in 0..4 {
-            let start = r * row_stride;
-            let src = &self.pred_errors_buffer[start..start + row_stride];
-            let dst = wp_image.row_mut(1 + r);
-            for (d, &s) in dst.iter_mut().zip(src) {
-                *d = s as i32;
-            }
+        let src = &self.pred_errors_buffer;
+        let [d0, d1, d2, d3] = wp_image.distinct_full_rows_mut([1, 2, 3, 4]);
+        for ((((d0, d1), d2), d3), &s) in d0
+            .iter_mut()
+            .zip(d1.iter_mut())
+            .zip(d2.iter_mut())
+            .zip(d3.iter_mut())
+            .zip(src)
+        {
+            *d0 = s[0] as i32;
+            *d1 = s[1] as i32;
+            *d2 = s[2] as i32;
+            *d3 = s[3] as i32;
         }
     }
 
-    pub fn restore_state(&mut self, wp_image: &Image<i32>, xsize: usize) {
-        let row_stride = xsize + 2;
+    pub fn restore_state(&mut self, wp_image: &Image<i32>) {
+        let row_stride = self.xsize + 1;
         self.error[0..row_stride].copy_from_slice(wp_image.row(0));
-        for r in 0..4 {
-            let start = r * row_stride;
-            let src = wp_image.row(1 + r);
-            let dst = &mut self.pred_errors_buffer[start..start + row_stride];
-            for (d, &s) in dst.iter_mut().zip(src) {
-                *d = s as u32;
-            }
+        let s0 = wp_image.row(1);
+        let s1 = wp_image.row(2);
+        let s2 = wp_image.row(3);
+        let s3 = wp_image.row(4);
+        let dst = &mut self.pred_errors_buffer;
+        for (d, (&s0, (&s1, (&s2, &s3)))) in dst
+            .iter_mut()
+            .zip(s0.iter().zip(s1.iter().zip(s2.iter().zip(s3.iter()))))
+        {
+            *d = [s0 as u32, s1 as u32, s2 as u32, s3 as u32];
         }
     }
 
-    #[inline(always)]
-    pub fn update_errors(&mut self, correct_val: i32, pos: (usize, usize), xsize: usize) {
-        let (cur_row, prev_row) = if pos.1 & 1 != 0 {
-            (0, xsize + 2)
-        } else {
-            (xsize + 2, 0)
-        };
-        let val = add_bits(correct_val);
-        self.error[cur_row + pos.0] = (self.pred - val) as i32;
-
-        // Compute errors for all predictors
-        let mut errs = [0u32; NUM_PREDICTORS];
-        for (err, &pred) in errs.iter_mut().zip(self.prediction.iter()) {
-            *err = (((pred - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
-        }
-
-        // Write to current position (contiguous access)
-        *self.get_errors_at_pos_mut(cur_row + pos.0) = errs;
-
-        // Update previous row position (contiguous access)
-        let prev_errors = self.get_errors_at_pos_mut(prev_row + pos.0 + 1);
-        for i in 0..NUM_PREDICTORS {
-            prev_errors[i] = prev_errors[i].wrapping_add(errs[i]);
-        }
-    }
-
+    // Note: optimizations in this function are a bit finnicky.
+    #[allow(unsafe_code)]
     #[inline(always)]
     pub fn predict_and_property(
         &mut self,
         pos: (usize, usize),
-        xsize: usize,
         data: &PredictionData,
     ) -> (i64, i32) {
+        assert!(pos.0 < self.xsize);
+        // Safety note: the index arithmetic in this function is guaranteed
+        // not to overflow thanks to the safety invariant and the check on `pos.0`
+        // above.
+        // The debug_assert! are documentation of safety-relevant properties in
+        // code form.
         let (cur_row, prev_row) = if pos.1 & 1 != 0 {
-            (0, xsize + 2)
+            (0, self.xsize + 1)
         } else {
-            (xsize + 2, 0)
+            (self.xsize + 1, 0)
         };
-        let pos_n = prev_row + pos.0;
-        let pos_ne = if pos.0 < xsize - 1 { pos_n + 1 } else { pos_n };
-        let pos_nw = if pos.0 > 0 { pos_n - 1 } else { pos_n };
-        // Get errors at the 3 neighboring positions (contiguous access per position)
-        let errors_n = self.get_errors_at_pos(pos_n);
-        let errors_ne = self.get_errors_at_pos(pos_ne);
-        let errors_nw = self.get_errors_at_pos(pos_nw);
-
-        let mut weights = [0u32; NUM_PREDICTORS];
-        for i in 0..NUM_PREDICTORS {
-            weights[i] = error_weight(
-                errors_n[i]
-                    .wrapping_add(errors_ne[i])
-                    .wrapping_add(errors_nw[i]),
-                self.wp_header.w(i).unwrap(),
-            );
-        }
-        let n = add_bits(data.top);
-        let w = add_bits(data.left);
-        let ne = add_bits(data.topright);
-        let nw = add_bits(data.topleft);
-        let nn = add_bits(data.toptop);
-
-        let te_w = if pos.0 == 0 {
-            0
+        // Safety note: guaranteed to be < self.xsize.
+        let pos_ne = if pos.0 + 1 < self.xsize {
+            pos.0 + 1
         } else {
-            self.error[cur_row + pos.0 - 1] as i64
+            pos.0
         };
-        let te_n = self.error[pos_n] as i64;
-        let te_nw = self.error[pos_nw] as i64;
+        // Safety note: guaranteed to be < self.xsize.
+        let pos_nw = pos.0.saturating_sub(1);
+
+        debug_assert!(prev_row + pos.0 < self.pred_errors_buffer.len());
+        // SAFETY: prev_row <= xsize + 1, so the index is < 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.pred_error_buffers.len() == 2*(xsize+1)`).
+        let err_n = unsafe { self.pred_errors_buffer.get_unchecked(prev_row + pos.0) };
+        debug_assert!(prev_row + pos_ne < self.pred_errors_buffer.len());
+        // SAFETY: prev_row <= xsize + 1, so the index is < 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.pred_error_buffers.len() == 2*(xsize+1)`).
+        let err_ne = unsafe { self.pred_errors_buffer.get_unchecked(prev_row + pos_ne) };
+        debug_assert!(prev_row + pos_nw < self.pred_errors_buffer.len());
+        // SAFETY: prev_row <= xsize + 1, so the index is < 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.pred_error_buffers.len() == 2*(xsize+1)`).
+        let err_nw = unsafe { self.pred_errors_buffer.get_unchecked(prev_row + pos_nw) };
+
+        let err0 = err_n[0].wrapping_add(err_ne[0]).wrapping_add(err_nw[0]);
+        let err1 = err_n[1].wrapping_add(err_ne[1]).wrapping_add(err_nw[1]);
+        let err2 = err_n[2].wrapping_add(err_ne[2]).wrapping_add(err_nw[2]);
+        let err3 = err_n[3].wrapping_add(err_ne[3]).wrapping_add(err_nw[3]);
+
+        let shift0 = (err0 as u64 + 1).ilog2().saturating_sub(5);
+        let shift1 = (err1 as u64 + 1).ilog2().saturating_sub(5);
+        let shift2 = (err2 as u64 + 1).ilog2().saturating_sub(5);
+        let shift3 = (err3 as u64 + 1).ilog2().saturating_sub(5);
+
+        debug_assert!(err0 >> shift0 < 64);
+        // SAFETY: x >> ((x+1).ilog2().saturating_sub(5)) < 64 for any x (see `error_weight_bounds`).
+        // (Note: the compiler doesn't seem to realize this)
+        let div0 = unsafe { *DIVLOOKUP.get_unchecked(err0 as usize >> shift0) };
+        debug_assert!(err1 >> shift1 < 64);
+        // SAFETY: same as div0
+        let div1 = unsafe { *DIVLOOKUP.get_unchecked(err1 as usize >> shift1) };
+        debug_assert!(err2 >> shift2 < 64);
+        // SAFETY: same as div0
+        let div2 = unsafe { *DIVLOOKUP.get_unchecked(err2 as usize >> shift2) };
+        debug_assert!(err3 >> shift3 < 64);
+        // SAFETY: same as div0
+        let div3 = unsafe { *DIVLOOKUP.get_unchecked(err3 as usize >> shift3) };
+
+        let w0 = 4u32 + ((self.w[0] as u32 * div0) >> shift0);
+        let w1 = 4u32 + ((self.w[1] as u32 * div1) >> shift1);
+        let w2 = 4u32 + ((self.w[2] as u32 * div2) >> shift2);
+        let w3 = 4u32 + ((self.w[3] as u32 * div3) >> shift3);
+        // Safety note: we know that w0, w1, w2, w3 >= 4 because u8 * DIVLOOKUP[i] + 4 never
+        // overflows.
+        debug_assert!(w0 >= 4);
+        debug_assert!(w1 >= 4);
+        debug_assert!(w2 >= 4);
+        debug_assert!(w3 >= 4);
+
+        // Note: this might access what's morally equivalent to position -1,
+        // but that value is guaranteed to be 0.
+
+        debug_assert!(cur_row + pos.0 < self.error.len());
+        // SAFETY: cur_row <= xsize + 1, so the index is < 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.error.len() == 2*(xsize+1)`).
+        let te_w = unsafe { *self.error.get_unchecked(cur_row + pos.0) as i64 };
+        debug_assert!(prev_row + 1 + pos.0 < self.error.len());
+        // SAFETY: prev_row <= xsize + 1, so the index is <= 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.error.len() == 2*(xsize+1)`).
+        let te_n = unsafe { *self.error.get_unchecked(prev_row + 1 + pos.0) as i64 };
+        debug_assert!(prev_row + 1 + pos_nw < self.error.len());
+        // SAFETY: prev_row <= xsize + 1, so the index is <= 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.error.len() == 2*(xsize+1)`).
+        let te_nw = unsafe { *self.error.get_unchecked(prev_row + 1 + pos_nw) as i64 };
         let sum_wn = te_n + te_w;
-        let te_ne = self.error[pos_ne] as i64;
+        debug_assert!(prev_row + 1 + pos_ne < self.error.len());
+        // SAFETY: prev_row <= xsize + 1, so the index is <= 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.error.len() == 2*(xsize+1)`).
+        let te_ne = unsafe { *self.error.get_unchecked(prev_row + 1 + pos_ne) as i64 };
 
         let mut p = te_w;
         if te_n.abs() > p.abs() {
@@ -510,31 +527,115 @@ impl WeightedPredictorState {
             p = te_ne;
         }
 
-        self.prediction[0] = w + ne - n;
-        self.prediction[1] = n - (((sum_wn + te_ne) * self.wp_header.p1c as i64) >> 5);
-        self.prediction[2] = w - (((sum_wn + te_nw) * self.wp_header.p2c as i64) >> 5);
-        self.prediction[3] = n
-            - ((te_nw * (self.wp_header.p3ca as i64)
-                + (te_n * (self.wp_header.p3cb as i64))
-                + (te_ne * (self.wp_header.p3cc as i64))
-                + ((nn - n) * (self.wp_header.p3cd as i64))
-                + ((nw - w) * (self.wp_header.p3ce as i64)))
+        let n = add_bits(data.top);
+        let w = add_bits(data.left);
+        let ne = add_bits(data.topright);
+        let nw = add_bits(data.topleft);
+        let nn = add_bits(data.toptop);
+
+        let p0 = w + ne - n;
+        let p1 = n - (((sum_wn + te_ne) * self.p1c as i64) >> 5);
+        let p2 = w - (((sum_wn + te_nw) * self.p2c as i64) >> 5);
+        let p3 = n
+            - ((te_nw * (self.p3c[0] as i64)
+                + (te_n * (self.p3c[1] as i64))
+                + (te_ne * (self.p3c[2] as i64))
+                + ((nn - n) * (self.p3c[3] as i64))
+                + ((nw - w) * (self.p3c[4] as i64)))
                 >> 5);
 
-        self.pred = weighted_average(&self.prediction, &mut weights);
+        let log_weight = floor_log2_nonzero(w0 as u64 + w1 as u64 + w2 as u64 + w3 as u64);
+        debug_assert!(log_weight >= 4);
+        // Safety note: due to all weights being >= 4, their sum is >= 16 so the base2 log
+        // is at least 4. Thus, the subtractions below do not overflow.
+
+        let w0s = w0 as i64 >> (log_weight - 4);
+        let w1s = w1 as i64 >> (log_weight - 4);
+        let w2s = w2 as i64 >> (log_weight - 4);
+        let w3s = w3 as i64 >> (log_weight - 4);
+
+        let weight_sum = w0s + w1s + w2s + w3s;
+        debug_assert!(weight_sum > 0);
+        // Safety note: weight_sum > 0.
+        // Let wM be the largest of w0, w1, w2, w3. Then, their sum is at most 4*wM,
+        // so log_weight <= wM.ilog2() + 2. It follows that log_weight - 4 < wM.ilog2(),
+        // which guarantees that the shift to compute wMs does not return 0.
+        debug_assert!(weight_sum <= 64);
+        // Safety note: weight_sum <= 64.
+        // Note that w0s + w1s + w2s + w3s <= (w0 + w1 + w2 + w3) >> (log_weight - 4) since
+        // shifting rounds down. This last quantity is at most 64 (in fact, at most 31),
+        // as checked in scaled_weight_bounds (note that 16 <= w0 + w1 + w2 + w3 <= 4 * u32::MAX)
+
+        let sum = (weight_sum >> 1) - 1 + w0s * p0 + w1s * p1 + w2s * p2 + w3s * p3;
+
+        // SAFETY: given that weight_sum > 0 and weight_sum <= 64, weight_sum - 1 is
+        // in bounds of DIVLOOKUP.
+        let mut pred =
+            (sum * unsafe { *DIVLOOKUP.get_unchecked((weight_sum - 1) as usize) } as i64) >> 24;
 
         if ((te_n ^ te_w) | (te_n ^ te_nw)) <= 0 {
             let mx = w.max(ne.max(n));
             let mn = w.min(ne.min(n));
-            self.pred = mn.max(mx.min(self.pred));
+            pred = mn.max(mx.min(pred));
         }
-        ((self.pred + PREDICTION_ROUND) >> PRED_EXTRA_BITS, p as i32)
+        self.prediction = [p0, p1, p2, p3];
+        self.pred = pred;
+        ((pred + PREDICTION_ROUND) >> PRED_EXTRA_BITS, p as i32)
+    }
+
+    #[allow(unsafe_code)]
+    #[inline(always)]
+    pub fn update_errors(&mut self, correct_val: i32, pos: (usize, usize)) {
+        assert!(pos.0 < self.xsize);
+        let (cur_row, prev_row) = if pos.1 & 1 != 0 {
+            (0, self.xsize + 1)
+        } else {
+            (self.xsize + 1, 0)
+        };
+        let val = add_bits(correct_val);
+        debug_assert!(cur_row + pos.0 + 1 < self.error.len());
+        // SAFETY: cur_row <= xsize + 1, so the index is <= 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.error.len() == 2*(xsize+1)`).
+        unsafe { *self.error.get_unchecked_mut(cur_row + pos.0 + 1) = (self.pred - val) as i32 };
+
+        // Compute errors for all predictors
+        let err0 =
+            (((self.prediction[0] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+        let err1 =
+            (((self.prediction[1] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+        let err2 =
+            (((self.prediction[2] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+        let err3 =
+            (((self.prediction[3] - val).abs() + PREDICTION_ROUND) >> PRED_EXTRA_BITS) as u32;
+
+        debug_assert!(cur_row + pos.0 < self.pred_errors_buffer.len());
+        // SAFETY: cur_row <= xsize + 1, so the index is < 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.pred_errors_buffer.len() == 2*(xsize+1)`).
+        unsafe {
+            *self.pred_errors_buffer.get_unchecked_mut(cur_row + pos.0) = [err0, err1, err2, err3];
+        }
+
+        debug_assert!(prev_row + pos.0 + 1 < self.pred_errors_buffer.len());
+        // SAFETY: prev_row <= xsize + 1, so the index is <= 2*xsize + 1, which is in-bounds due to
+        // the safety invariant (`self.pred_errors_buffer.len() == 2*(xsize+1)`).
+        let prev_errors = unsafe {
+            self.pred_errors_buffer
+                .get_unchecked_mut(prev_row + pos.0 + 1)
+        };
+
+        prev_errors[0] = prev_errors[0].wrapping_add(err0);
+        prev_errors[1] = prev_errors[1].wrapping_add(err1);
+        prev_errors[2] = prev_errors[2].wrapping_add(err2);
+        prev_errors[3] = prev_errors[3].wrapping_add(err3);
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::headers::modular::{GroupHeader, WeightedHeader};
+    use crate::{
+        headers::modular::{GroupHeader, WeightedHeader},
+        util::floor_log2_nonzero,
+    };
 
     use super::{PredictionData, WeightedPredictorState};
 
@@ -561,7 +662,6 @@ mod tests {
         let pos = (rng.next() as usize % xsize, rng.next() as usize % ysize);
         let res = state.predict_and_property(
             pos,
-            xsize,
             &PredictionData {
                 top: rng.next() as i32 % 256,
                 left: rng.next() as i32 % 256,
@@ -572,7 +672,7 @@ mod tests {
                 toprightright: 0,
             },
         );
-        state.update_errors((rng.next() % 256) as i32, pos, xsize);
+        state.update_errors((rng.next() % 256) as i32, pos);
         res
     }
 
@@ -605,5 +705,21 @@ mod tests {
         assert_eq!(step(&mut rng, &mut state, xsize, ysize), (110i64, -60i32));
         assert_eq!(step(&mut rng, &mut state, xsize, ysize), (165i64, 0i32));
         assert_eq!(step(&mut rng, &mut state, xsize, ysize), (153i64, -60i32));
+    }
+
+    #[test]
+    fn error_weight_bounds() {
+        for i in 0..u32::MAX {
+            let shift = (i as u64 + 1).ilog2().saturating_sub(5);
+            assert!(((i as usize) >> shift) < 64, "i = {i}, shift = {shift}");
+        }
+    }
+
+    #[test]
+    fn scaled_weight_bounds() {
+        for i in 16..u32::MAX as u64 * 4 {
+            let shift = floor_log2_nonzero(i) - 4;
+            assert!((i >> shift) < 32, "i = {i}, shift = {shift}");
+        }
     }
 }

--- a/jxl/src/frame/modular/transforms/palette.rs
+++ b/jxl/src/frame/modular/transforms/palette.rs
@@ -215,7 +215,7 @@ pub fn do_palette_step_general(
                         /*bit_depth=*/ bit_depth,
                     );
                     let prediction_data = PredictionData::get(&out.data, x, y);
-                    let (wp_pred, _) = wp_state.predict_and_property((x, y), w, &prediction_data);
+                    let (wp_pred, _) = wp_state.predict_and_property((x, y), &prediction_data);
                     let pred = predictor.predict_one(prediction_data, wp_pred);
                     let val = if index < num_deltas as i32 {
                         (pred + palette_entry as i64) as i32
@@ -223,7 +223,7 @@ pub fn do_palette_step_general(
                         palette_entry
                     };
                     out.data.row_mut(y)[x] = val;
-                    wp_state.update_errors(val, (x, y), w);
+                    wp_state.update_errors(val, (x, y));
                 }
             }
         }
@@ -376,10 +376,7 @@ pub fn do_palette_step_group_row(
             let out_row_idx = c * grid_ysize * grid_xsize + grid_y * grid_xsize;
             if grid_y > 0 {
                 let prev_row_idx = out_row_idx - grid_y * grid_xsize;
-                wp_state.restore_state(
-                    buf_out[prev_row_idx].auxiliary_data.as_ref().unwrap(),
-                    total_w,
-                );
+                wp_state.restore_state(buf_out[prev_row_idx].auxiliary_data.as_ref().unwrap());
             }
             for y in 0..h {
                 for (grid_x, index_buf) in buf_in.iter().enumerate().take(grid_xsize) {
@@ -396,23 +393,20 @@ pub fn do_palette_step_group_row(
                         let prediction_data = get_prediction_data(
                             buf_out, out_idx, grid_x, grid_y, grid_xsize, x, y, xsize, ysize,
                         );
-                        let (pred, _) = wp_state.predict_and_property(
-                            (grid_x * xsize + x, y & 1),
-                            total_w,
-                            &prediction_data,
-                        );
+                        let (pred, _) = wp_state
+                            .predict_and_property((grid_x * xsize + x, y & 1), &prediction_data);
                         let val = if index < num_deltas as i32 {
                             (pred + palette_entry as i64) as i32
                         } else {
                             palette_entry
                         };
                         buf_out[out_idx].data.row_mut(y)[x] = val;
-                        wp_state.update_errors(val, (grid_x * xsize + x, y & 1), total_w);
+                        wp_state.update_errors(val, (grid_x * xsize + x, y & 1));
                     }
                 }
             }
-            let mut wp_image = Image::<i32>::new((total_w + 2, 5))?;
-            wp_state.save_state(&mut wp_image, total_w);
+            let mut wp_image = Image::<i32>::new((total_w + 1, 5))?;
+            wp_state.save_state(&mut wp_image);
             buf_out[out_row_idx].auxiliary_data = Some(wp_image);
         }
     } else {

--- a/jxl/src/frame/modular/tree.rs
+++ b/jxl/src/frame/modular/tree.rs
@@ -185,10 +185,9 @@ const NUM_TREE_CONTEXTS: usize = 6;
 
 /// Computes properties for tree traversal. Shared between flat and non-flat prediction.
 /// Returns the weighted predictor prediction value.
-#[inline]
+#[inline(always)]
 pub(super) fn compute_properties(
     prediction_data: PredictionData,
-    xsize: usize,
     wp_state: Option<&mut WeightedPredictorState>,
     x: usize,
     y: usize,
@@ -230,7 +229,7 @@ pub(super) fn compute_properties(
 
     // Weighted predictor property.
     let (wp_pred, wp_prop) = wp_state
-        .map(|wp_state| wp_state.predict_and_property((x, y), xsize, &prediction_data))
+        .map(|wp_state| wp_state.predict_and_property((x, y), &prediction_data))
         .unwrap_or((0, 0));
     property_buffer[15] = wp_prop;
 
@@ -252,22 +251,13 @@ pub(super) fn compute_properties(
 pub(super) fn predict(
     tree: &[TreeNode],
     prediction_data: PredictionData,
-    xsize: usize,
     wp_state: Option<&mut WeightedPredictorState>,
     x: usize,
     y: usize,
     references: &Image<i32>,
     property_buffer: &mut [i32],
 ) -> PredictionResult {
-    let wp_pred = compute_properties(
-        prediction_data,
-        xsize,
-        wp_state,
-        x,
-        y,
-        references,
-        property_buffer,
-    );
+    let wp_pred = compute_properties(prediction_data, wp_state, x, y, references, property_buffer);
 
     trace!(?property_buffer, "new properties");
 

--- a/jxl/src/headers/modular.rs
+++ b/jxl/src/headers/modular.rs
@@ -64,21 +64,6 @@ pub struct WeightedHeader {
     pub w3: u32,
 }
 
-impl WeightedHeader {
-    pub fn w(&self, i: usize) -> Result<u32> {
-        match i {
-            0 => Ok(self.w0),
-            1 => Ok(self.w1),
-            2 => Ok(self.w2),
-            3 => Ok(self.w3),
-            _ => unreachable!(
-            "WeightedHeader::w called with an out-of-bounds index: {}.
-            This indicates a logical error in the calling code, which should ensure 'i' is within 0..=3.",
-            i),
-        }
-    }
-}
-
 #[derive(UnconditionalCoder, Debug, PartialEq, Clone, Copy)]
 pub struct SqueezeParams {
     pub horizontal: bool,


### PR DESCRIPTION
Also add more `#[inline]` attributes. On my laptop ~7% speedup for e3, ~30% for sunset_logo.jxl:

```
main - sunset:
Decoded 64033200 pixels in 7.401 seconds: 8.652 MP/s
Decoded 64033200 pixels in 7.432 seconds: 8.616 MP/s
Decoded 64033200 pixels in 7.441 seconds: 8.606 MP/s

new - sunset:
Decoded 64033200 pixels in 5.655 seconds: 11.323 MP/s
Decoded 64033200 pixels in 5.648 seconds: 11.338 MP/s
Decoded 64033200 pixels in 5.666 seconds: 11.301 MP/s

main - green queen e3:
Decoded 77394600 pixels in 4.767 seconds: 16.236 MP/s
Decoded 77394600 pixels in 4.852 seconds: 15.953 MP/s
Decoded 77394600 pixels in 4.782 seconds: 16.183 MP/s

new - green queen e3:
Decoded 77394600 pixels in 4.452 seconds: 17.382 MP/s
Decoded 77394600 pixels in 4.509 seconds: 17.166 MP/s
Decoded 77394600 pixels in 4.441 seconds: 17.425 MP/s
```

Supercedes #715, #789 .