### PR TITLE
More modular fast paths and optimizations

### DIFF
--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -436,6 +436,24 @@ impl SymbolReader {
         self.read_signed_clustered_inline(histograms, br, cluster)
     }
 
+    /// Fast path for reads without LZ77.
+    /// Preconditions: histograms has LZ77 disabled and reader state is None.
+    #[inline(always)]
+    pub fn read_signed_clustered_no_lz77(
+        &mut self,
+        histograms: &Histograms,
+        br: &mut BitReader,
+        cluster: usize,
+    ) -> i32 {
+        debug_assert!(matches!(self.state, SymbolReaderState::None));
+        let token = match &histograms.codes {
+            Codes::Huffman(hc) => hc.read(br, cluster),
+            Codes::Ans(ans) => self.ans_reader.read(ans, br, cluster),
+        };
+        let unsigned = histograms.uint_configs[cluster].read(token, br);
+        unpack_signed(unsigned)
+    }
+
     /// Specialized fast path for when all HybridUint configs are 420.
     ///
     /// # Preconditions
@@ -654,6 +672,11 @@ impl Histograms {
 
     pub fn single_symbol(&self, ctx: usize) -> Option<u32> {
         self.codes.single_symbol(ctx)
+    }
+
+    /// Returns true when LZ77 is disabled.
+    pub fn has_no_lz77(&self) -> bool {
+        !self.lz77_params.enabled
     }
 }
 

--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -32,8 +32,8 @@ pub fn unpack_signed(unsigned: u32) -> i32 {
     ((unsigned >> 1) ^ ((!unsigned) & 1).wrapping_sub(1)) as i32
 }
 
-#[derive(UnconditionalCoder, Debug)]
-struct Lz77Params {
+#[derive(UnconditionalCoder, Debug, Clone, Copy)]
+pub(crate) struct Lz77Params {
     pub enabled: bool,
     #[condition(enabled)]
     #[coder(u2S(224, 512, 4096, Bits(15) + 8))]
@@ -44,7 +44,7 @@ struct Lz77Params {
 }
 
 #[derive(Debug)]
-enum Codes {
+pub(crate) enum Codes {
     Huffman(HuffmanCodes),
     Ans(AnsCodes),
 }
@@ -146,51 +146,9 @@ impl Lz77State {
 }
 
 #[derive(Debug)]
-struct RleState {
-    min_symbol: u32,
-    min_length: u32,
-    last_sym: Option<u32>,
-    repeat_count: u32,
-}
-
-impl RleState {
-    #[inline]
-    fn push_token(
-        &mut self,
-        token: u32,
-        histograms: &Histograms,
-        br: &mut BitReader,
-        cluster: usize,
-    ) {
-        if let Some(token) = token.checked_sub(self.min_symbol) {
-            let lz_length_conf = histograms.lz77_length_uint.as_ref().unwrap();
-            let count = lz_length_conf.read(token, br);
-            // If this calculation overflows, the bitstream is invalid (it would be rejected
-            // on the LZ77 path), but we don't report an error.
-            self.repeat_count = count.wrapping_add(self.min_length);
-        } else {
-            let sym = histograms.uint_configs[cluster].read(token, br);
-            self.last_sym = Some(sym);
-            self.repeat_count = 1;
-        }
-    }
-
-    #[inline]
-    fn pull_symbol(&mut self) -> Option<u32> {
-        if self.repeat_count > 0 {
-            self.repeat_count -= 1;
-            self.last_sym
-        } else {
-            None
-        }
-    }
-}
-
-#[derive(Debug)]
 enum SymbolReaderState {
     None,
     Lz77(Lz77State),
-    Rle(RleState),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -245,29 +203,15 @@ impl SymbolReader {
             let min_length = min_length.unwrap();
             let dist_multiplier = image_width.unwrap_or(0) as u32;
 
-            let lz_dist_cluster = histograms.lz_dist_cluster as usize;
-            let lz_conf = &histograms.uint_configs[lz_dist_cluster];
-            let is_rle = histograms.codes.single_symbol(lz_dist_cluster) == Some(1)
-                && lz_conf.is_split_exponent_zero();
-
-            if is_rle {
-                SymbolReaderState::Rle(RleState {
-                    min_symbol,
-                    min_length,
-                    last_sym: None,
-                    repeat_count: 0,
-                })
-            } else {
-                SymbolReaderState::Lz77(Lz77State {
-                    min_symbol,
-                    min_length,
-                    dist_multiplier,
-                    window: Vec::new_with_capacity(1 << Lz77State::LOG_WINDOW_SIZE)?,
-                    num_to_copy: 0,
-                    copy_pos: 0,
-                    num_decoded: 0,
-                })
-            }
+            SymbolReaderState::Lz77(Lz77State {
+                min_symbol,
+                min_length,
+                dist_multiplier,
+                window: Vec::new_with_capacity(1 << Lz77State::LOG_WINDOW_SIZE)?,
+                num_to_copy: 0,
+                copy_pos: 0,
+                num_decoded: 0,
+            })
         } else {
             SymbolReaderState::None
         };
@@ -384,24 +328,6 @@ impl SymbolReader {
                 lz77_state.push_decoded_symbol(sym);
                 sym
             }
-
-            SymbolReaderState::Rle(rle_state) => {
-                if let Some(sym) = rle_state.pull_symbol() {
-                    return sym;
-                }
-
-                let token = match &histograms.codes {
-                    Codes::Huffman(hc) => hc.read(br, cluster),
-                    Codes::Ans(ans) => self.ans_reader.read(ans, br, cluster),
-                };
-                rle_state.push_token(token, histograms, br, cluster);
-                if let Some(sym) = rle_state.pull_symbol() {
-                    sym
-                } else {
-                    self.errors.lz77_repeat = true;
-                    0
-                }
-            }
         }
     }
 
@@ -506,10 +432,6 @@ impl SymbolReader {
                     window,
                 }
             }
-            SymbolReaderState::Rle(rle_state) => StateCheckpoint::Rle {
-                last_sym: rle_state.last_sym,
-                repeat_count: rle_state.repeat_count,
-            },
         };
 
         Checkpoint {
@@ -553,17 +475,6 @@ impl SymbolReader {
                 lz77_state.num_to_copy = num_to_copy;
                 lz77_state.copy_pos = copy_pos;
                 lz77_state.num_decoded = num_decoded;
-            }
-            StateCheckpoint::Rle {
-                last_sym,
-                repeat_count,
-            } => {
-                let SymbolReaderState::Rle(rle_state) = &mut self.state else {
-                    panic!("checkpoint type mismatch");
-                };
-
-                rle_state.last_sym = last_sym;
-                rle_state.repeat_count = repeat_count;
             }
         }
 
@@ -655,50 +566,25 @@ impl Histograms {
     pub fn single_symbol(&self, ctx: usize) -> Option<u32> {
         self.codes.single_symbol(ctx)
     }
-}
 
-#[cfg(test)]
-impl Histograms {
-    /// Builds a decoder that reads an octet at a time and emits its bit-reversed value.
-    pub fn reverse_octet(num_contexts: usize) -> Self {
-        let d = HuffmanCodes::byte_histogram();
-        let codes = Codes::Huffman(d);
-        let uint_configs = vec![HybridUint::new(8, 0, 0)];
-        Self {
-            lz77_params: Lz77Params {
-                enabled: false,
-                min_symbol: None,
-                min_length: None,
-            },
-            lz77_length_uint: None,
-            uint_configs,
-            log_alpha_size: 15,
-            context_map: vec![0u8; num_contexts],
-            lz_dist_cluster: 0,
-            codes,
-        }
+    pub(crate) fn codes(&self) -> &Codes {
+        &self.codes
     }
 
-    pub fn rle(num_contexts: usize, min_symbol: u32, min_length: u32) -> Self {
-        let d = HuffmanCodes::byte_histogram_rle();
-        let codes = Codes::Huffman(d);
-        let uint_configs = vec![HybridUint::new(8, 0, 0), HybridUint::new(0, 0, 0)];
-        let mut context_map = vec![0u8; num_contexts + 1];
-        *context_map.last_mut().unwrap() = 1;
-        let lz_dist_cluster = *context_map.last().unwrap();
-        Self {
-            lz77_params: Lz77Params {
-                enabled: true,
-                min_symbol: Some(min_symbol),
-                min_length: Some(min_length),
-            },
-            lz77_length_uint: Some(HybridUint::new(8, 0, 0)),
-            uint_configs,
-            log_alpha_size: 15,
-            context_map,
-            lz_dist_cluster,
-            codes,
-        }
+    pub fn is_rle(&self) -> bool {
+        let lz_dist_cluster = self.lz_dist_cluster as usize;
+        let lz_conf = &self.uint_configs[lz_dist_cluster];
+        self.codes.single_symbol(lz_dist_cluster) == Some(1) && lz_conf.is_split_exponent_zero()
+    }
+
+    pub(crate) fn lz77_params(&self) -> Lz77Params {
+        self.lz77_params
+    }
+    pub(crate) fn lz77_length_uint(&self) -> HybridUint {
+        self.lz77_length_uint.unwrap()
+    }
+    pub(crate) fn uint(&self, cluster: usize) -> HybridUint {
+        self.uint_configs[cluster]
     }
 }
 
@@ -711,10 +597,6 @@ enum StateCheckpoint<const N: usize> {
         num_decoded: u32,
         window: [u32; N],
     },
-    Rle {
-        last_sym: Option<u32>,
-        repeat_count: u32,
-    },
 }
 
 #[derive(Debug)]
@@ -722,68 +604,4 @@ pub struct Checkpoint<const N: usize> {
     state: StateCheckpoint<N>,
     ans_reader: AnsReader,
     errors: ErrorState,
-}
-
-#[cfg(test)]
-mod test {
-    use std::ops::ControlFlow;
-
-    use test_log::test;
-
-    use super::*;
-
-    #[test]
-    fn rle_arb() {
-        let histograms = Histograms::rle(1, 240, 3);
-
-        arbtest::arbtest(|u| {
-            let width = u.int_in_range(1usize..=256)?;
-
-            let mut bitstream = Vec::new();
-            let mut expected_bytes = Vec::new();
-            u.arbitrary_loop(None, None, |u| {
-                let do_repeat = !expected_bytes.is_empty() && u.ratio(1, 4)?;
-                let range = if do_repeat { 240u8..=255 } else { 0u8..=239 };
-                let byte = u.int_in_range(range)?;
-                bitstream.push(byte);
-
-                if do_repeat {
-                    let count = byte as usize - 237;
-                    let sym = *expected_bytes.last().unwrap();
-                    for _ in 0..count {
-                        expected_bytes.push(sym);
-                    }
-                } else {
-                    expected_bytes.push(byte);
-                }
-
-                Ok(if expected_bytes.len() >= 256 {
-                    ControlFlow::Break(())
-                } else {
-                    ControlFlow::Continue(())
-                })
-            })?;
-            for b in &mut bitstream {
-                *b = b.reverse_bits();
-            }
-
-            // Read RLE
-            let mut br = BitReader::new(&bitstream);
-            let mut reader = SymbolReader::new(&histograms, &mut br, Some(width)).unwrap();
-
-            for expected in expected_bytes {
-                let actual = reader.read_unsigned_clustered(&histograms, &mut br, 0);
-                assert_eq!(actual, expected as u32);
-            }
-
-            let SymbolReaderState::Rle(rle_state) = &reader.state else {
-                panic!()
-            };
-            assert_eq!(rle_state.repeat_count, 0);
-            assert!(reader.check_final_state(&histograms, &mut br).is_ok());
-            assert_eq!(br.total_bits_available(), 0);
-
-            Ok(())
-        });
-    }
 }

--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -436,24 +436,6 @@ impl SymbolReader {
         self.read_signed_clustered_inline(histograms, br, cluster)
     }
 
-    /// Fast path for reads without LZ77.
-    /// Preconditions: histograms has LZ77 disabled and reader state is None.
-    #[inline(always)]
-    pub fn read_signed_clustered_no_lz77(
-        &mut self,
-        histograms: &Histograms,
-        br: &mut BitReader,
-        cluster: usize,
-    ) -> i32 {
-        debug_assert!(matches!(self.state, SymbolReaderState::None));
-        let token = match &histograms.codes {
-            Codes::Huffman(hc) => hc.read(br, cluster),
-            Codes::Ans(ans) => self.ans_reader.read(ans, br, cluster),
-        };
-        let unsigned = histograms.uint_configs[cluster].read(token, br);
-        unpack_signed(unsigned)
-    }
-
     /// Specialized fast path for when all HybridUint configs are 420.
     ///
     /// # Preconditions
@@ -672,11 +654,6 @@ impl Histograms {
 
     pub fn single_symbol(&self, ctx: usize) -> Option<u32> {
         self.codes.single_symbol(ctx)
-    }
-
-    /// Returns true when LZ77 is disabled.
-    pub fn has_no_lz77(&self) -> bool {
-        !self.lz77_params.enabled
     }
 }
 

--- a/jxl/src/entropy_coding/huffman.rs
+++ b/jxl/src/entropy_coding/huffman.rs
@@ -30,7 +30,7 @@ impl Debug for TableEntry {
 }
 
 #[derive(Debug)]
-struct Table {
+pub(crate) struct Table {
     entries: Vec<TableEntry>,
 }
 
@@ -441,7 +441,7 @@ impl Table {
         Ok(Table { entries })
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn read(&self, br: &mut BitReader) -> u32 {
         let mut pos = br.peek(TABLE_BITS) as usize;
         let mut n_bits = self.entries[pos].bits as usize;
@@ -451,8 +451,9 @@ impl Table {
             pos += self.entries[pos].value as usize;
             pos += br.peek(n_bits) as usize;
         }
-        br.consume_optimistic(self.entries[pos].bits as usize);
-        self.entries[pos].value as u32
+        let entry = self.entries[pos];
+        br.consume_optimistic(entry.bits as usize);
+        entry.value as u32
     }
 }
 
@@ -489,20 +490,9 @@ impl HuffmanCodes {
             None
         }
     }
-}
 
-#[cfg(test)]
-impl Table {
-    fn new_single_symbol(sym: u16) -> Table {
-        Table {
-            entries: vec![
-                TableEntry {
-                    bits: 0,
-                    value: sym
-                };
-                TABLE_SIZE
-            ],
-        }
+    pub(crate) fn table(&self, ctx: usize) -> &Table {
+        &self.tables[ctx]
     }
 }
 
@@ -512,12 +502,6 @@ impl HuffmanCodes {
     pub(super) fn byte_histogram() -> HuffmanCodes {
         let mut br = BitReader::new(&[0b11101111, 0b00111111, 0, 1, 0, 0b10100000, 0b0110]);
         HuffmanCodes::decode(1, &mut br).unwrap()
-    }
-
-    pub(super) fn byte_histogram_rle() -> HuffmanCodes {
-        let mut histogram = Self::byte_histogram();
-        histogram.tables.push(Table::new_single_symbol(1));
-        histogram
     }
 }
 

--- a/jxl/src/entropy_coding/hybrid_uint.rs
+++ b/jxl/src/entropy_coding/hybrid_uint.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 
 use crate::util::CeilLog2;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct HybridUint {
     split_token: u32,
     split_exponent: u32,

--- a/jxl/src/frame/modular/decode/bitstream.rs
+++ b/jxl/src/frame/modular/decode/bitstream.rs
@@ -6,11 +6,128 @@
 use super::channel::decode_modular_channel;
 use crate::{
     bit_reader::BitReader,
-    entropy_coding::decode::SymbolReader,
+    entropy_coding::decode::{Codes, SymbolReader, unpack_signed},
     error::{Error, Result},
-    frame::modular::{ModularChannel, Tree, transforms::apply::meta_apply_local_transforms},
+    frame::modular::{
+        IMAGE_OFFSET, ModularChannel, Predictor, Tree, predict::clamped_gradient,
+        transforms::apply::meta_apply_local_transforms, tree::TreeNode,
+    },
     headers::{JxlHeader, modular::GroupHeader},
 };
+
+fn can_decode_fast_lossless(tree: &Tree) -> bool {
+    if !tree.nodes.iter().all(|n| {
+        matches!(
+            n,
+            TreeNode::Split { property: 0, .. }
+                | TreeNode::Leaf {
+                    predictor: Predictor::Gradient,
+                    offset: 0,
+                    multiplier: 1,
+                    ..
+                }
+        )
+    }) {
+        return false;
+    }
+
+    if !tree.histograms.is_rle() {
+        return false;
+    }
+
+    matches!(tree.histograms.codes(), Codes::Huffman(_))
+}
+
+#[inline(never)]
+fn decode_fast_lossless(
+    buffers: Vec<&mut ModularChannel>,
+    tree: &Tree,
+    br: &mut BitReader,
+    partial_decoded_buffers: Option<&mut usize>,
+) -> Result<()> {
+    let mut rle_len: usize = 0;
+    let mut rle_sym = 0;
+
+    for (c, buf) in buffers.into_iter().enumerate() {
+        let (w, h) = buf.data.size();
+        if w == 0 || h == 0 {
+            continue;
+        }
+        let TreeNode::Leaf { id, .. } = tree.walk(&[c as i32]) else {
+            unreachable!();
+        };
+        let Codes::Huffman(codes) = tree.histograms.codes() else {
+            unreachable!();
+        };
+
+        let table = codes.table(tree.histograms.map_context_to_cluster(id as usize));
+        let min_sym = tree.histograms.lz77_params().min_symbol.unwrap();
+        let min_len = tree.histograms.lz77_params().min_length.unwrap() as usize;
+        let sym_conf = tree
+            .histograms
+            .uint(tree.histograms.map_context_to_cluster(id as usize));
+        let lz_conf = tree.histograms.lz77_length_uint();
+
+        let buf = &mut buf.data;
+
+        let mut decode = {
+            #[inline(always)]
+            || {
+                if rle_len > 0 {
+                    rle_len -= 1;
+                } else {
+                    let sym = table.read(br);
+                    if let Some(token) = sym.checked_sub(min_sym) {
+                        let count = lz_conf.read(token, br) as usize;
+                        // If this calculation overflows, the bitstream is invalid (it would be rejected
+                        // on the LZ77 path), but we don't report an error.
+                        rle_len = count.wrapping_add(min_len - 1);
+                    } else {
+                        rle_sym = unpack_signed(sym_conf.read(sym, br));
+                    }
+                };
+                rle_sym
+            }
+        };
+
+        let mut last = 0i32;
+        for p in buf.row_mut(0) {
+            // clamped gradient == left on the first row.
+            *p = last.wrapping_add(decode());
+            last = *p;
+        }
+
+        for y in 1..h {
+            let [row, row_top] =
+                buf.distinct_full_rows_mut([y + IMAGE_OFFSET.1, y + IMAGE_OFFSET.1 - 1]);
+
+            let mut left = row_top[0];
+            let mut topleft = left;
+            for (top, p) in row_top
+                .iter()
+                .copied()
+                .zip(row.iter_mut())
+                .skip(IMAGE_OFFSET.0)
+                .take(w)
+            {
+                let pred = clamped_gradient(left as i64, top as i64, topleft as i64);
+                *p = (pred + decode() as i64) as i32;
+                left = *p;
+                topleft = top;
+            }
+        }
+
+        if let Err(e) = br.check_for_error() {
+            if let Some(p) = partial_decoded_buffers {
+                buf.fill(0);
+                *p = c;
+            }
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}
 
 // This function will decode a header and apply local transforms if a header is not given.
 // The intended use of passing a header is for the DcGlobal section.
@@ -78,29 +195,34 @@ pub fn decode_modular_subbitstream(
         .map(|info| info.channel_info().size.0)
         .max()
         .unwrap_or(0);
-    let mut reader = SymbolReader::new(&tree.histograms, br, Some(image_width))?;
 
-    for i in 0..buffers.len() {
-        // Keep channel numbering stable, but skip actually decoding empty channels.
-        // This matches libjxl, which continues the loop without renumbering.
-        let (w, h) = buffers[i].data.size();
-        if w == 0 || h == 0 {
-            continue;
-        }
-        if let Err(e) =
-            decode_modular_channel(&mut buffers, i, stream_id, &header, tree, &mut reader, br)
-        {
-            if let Some(p) = partial_decoded_buffers {
-                buffers[i].data.fill(0);
-                *p = i;
+    if can_decode_fast_lossless(tree) {
+        decode_fast_lossless(buffers, tree, br, partial_decoded_buffers)?
+    } else {
+        let mut reader = SymbolReader::new(&tree.histograms, br, Some(image_width))?;
+
+        for i in 0..buffers.len() {
+            // Keep channel numbering stable, but skip actually decoding empty channels.
+            // This matches libjxl, which continues the loop without renumbering.
+            let (w, h) = buffers[i].data.size();
+            if w == 0 || h == 0 {
+                continue;
             }
-            return Err(e);
+            if let Err(e) =
+                decode_modular_channel(&mut buffers, i, stream_id, &header, tree, &mut reader, br)
+            {
+                if let Some(p) = partial_decoded_buffers {
+                    buffers[i].data.fill(0);
+                    *p = i;
+                }
+                return Err(e);
+            }
         }
+
+        reader.check_final_state(&tree.histograms, br)?;
+
+        drop(buffers);
     }
-
-    reader.check_final_state(&tree.histograms, br)?;
-
-    drop(buffers);
 
     for step in transform_steps.iter().rev() {
         step.local_apply(&mut buffer_storage)?;

--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -14,7 +14,7 @@ use crate::{
         predict::{PredictionData, WeightedPredictorState},
         tree::{NUM_NONREF_PROPERTIES, PROPERTIES_PER_PREVCHAN, predict},
     },
-    headers::modular::GroupHeader,
+    headers::modular::{GroupHeader, WeightedHeader},
     image::Image,
     util::tracing_wrappers::*,
 };
@@ -31,14 +31,12 @@ pub(super) trait ModularChannelDecoder {
 
     fn decode_one(
         &mut self,
-        _prediction_data: PredictionData,
-        _pos: (usize, usize),
-        _reader: &mut SymbolReader,
-        _br: &mut BitReader,
-        _histograms: &Histograms,
-    ) -> i32 {
-        0
-    }
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        reader: &mut SymbolReader,
+        br: &mut BitReader,
+        histograms: &Histograms,
+    ) -> i32;
 
     #[allow(clippy::too_many_arguments)]
     #[inline(never)]
@@ -78,87 +76,133 @@ pub(super) trait ModularChannelDecoder {
             }
         };
 
-        if y < 2 {
-            for x in 0..xsize {
+        let (x0, x1) = if y < 2 { (0, 0) } else { (2, xsize - 2) };
+
+        let mut last = 0;
+        let mut prediction_data = PredictionData::default();
+        for x in 0..x0 {
+            (prediction_data, last) =
                 do_decode_cold(self, row, row_top, row_toptop, (x, y), reader, br);
-            }
-        } else {
-            let mut last = 0;
-            let mut prediction_data = PredictionData::default();
-            for x in 0..2 {
-                (prediction_data, last) =
-                    do_decode_cold(self, row, row_top, row_toptop, (x, y), reader, br);
-            }
-            for (x, r) in row.iter_mut().enumerate().skip(2).take(xsize - 4) {
-                prediction_data = prediction_data.update_for_interior_row(
-                    row_top,
-                    row_toptop,
-                    x,
-                    last,
-                    self.needs_toptop(),
-                );
-                let val = self.decode_one(prediction_data, (x, y), reader, br, histograms);
-                *r = val;
-                last = val;
-            }
-            for x in xsize - 2..xsize {
-                do_decode_cold(self, row, row_top, row_toptop, (x, y), reader, br);
-            }
+        }
+        for (x, r) in row.iter_mut().enumerate().skip(x0).take(x1 - x0) {
+            prediction_data = prediction_data.update_for_interior_row(
+                row_top,
+                row_toptop,
+                x,
+                last,
+                self.needs_toptop(),
+            );
+            let val = self.decode_one(prediction_data, (x, y), reader, br, histograms);
+            *r = val;
+            last = val;
+        }
+        for x in x1..xsize {
+            do_decode_cold(self, row, row_top, row_toptop, (x, y), reader, br);
         }
     }
 }
 
-// General case decoder, for small buffers for which it's not worth trying to detect tree special cases.
+struct FullTree<'a> {
+    tree: &'a Tree,
+    references: Image<i32>,
+    property_buffer: Box<[i32; 256]>,
+    wp_state: WeightedPredictorState,
+}
+
+impl<'a> FullTree<'a> {
+    fn new(
+        tree: &'a Tree,
+        wp_header: &WeightedHeader,
+        channel: usize,
+        stream: usize,
+        xsize: usize,
+    ) -> Result<Self> {
+        let num_ref_props = tree
+            .num_properties
+            .saturating_sub(NUM_NONREF_PROPERTIES)
+            .next_multiple_of(PROPERTIES_PER_PREVCHAN);
+        let references = Image::<i32>::new((num_ref_props, xsize))?;
+        let mut property_buffer = Box::new([0; 256]);
+
+        property_buffer[0] = channel as i32;
+        property_buffer[1] = stream as i32;
+
+        Ok(Self {
+            tree,
+            references,
+            property_buffer,
+            wp_state: WeightedPredictorState::new(wp_header, xsize),
+        })
+    }
+}
+
+impl<'a> ModularChannelDecoder for FullTree<'a> {
+    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
+        precompute_references(buffers, chan, y, &mut self.references);
+        self.property_buffer[9] = 0;
+    }
+
+    fn decode_one(
+        &mut self,
+        _prediction_data: PredictionData,
+        _pos: (usize, usize),
+        _reader: &mut SymbolReader,
+        _br: &mut BitReader,
+        _histograms: &Histograms,
+    ) -> i32 {
+        unreachable!()
+    }
+
+    fn decode_row(
+        &mut self,
+        buffers: &mut [&mut ModularChannel],
+        chan: usize,
+        histograms: &Histograms,
+        reader: &mut SymbolReader,
+        br: &mut BitReader,
+        y: usize,
+        xsize: usize,
+    ) {
+        self.init_row(buffers, chan, y);
+        const { assert!(IMAGE_OFFSET.1 == 2) };
+        let [row, row_top, row_toptop] =
+            buffers[chan].data.distinct_full_rows_mut([y + 2, y + 1, y]);
+        let row = &mut row[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + xsize];
+        let row_top = &mut row_top[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + xsize];
+        let row_toptop = &mut row_toptop[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + xsize];
+        for x in 0..xsize {
+            let prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
+            let prediction_result = predict(
+                &self.tree.nodes,
+                prediction_data,
+                Some(&mut self.wp_state),
+                x,
+                y,
+                &self.references,
+                &mut self.property_buffer[..],
+            );
+            let dec = reader.read_signed(histograms, br, prediction_result.context as usize);
+            let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
+            self.wp_state.update_errors(val, (x, y));
+            row[x] = val;
+        }
+    }
+}
+
 #[inline(never)]
-fn decode_modular_channel_small(
+fn decode_modular_channel_impl(
+    t: &mut dyn ModularChannelDecoder,
     buffers: &mut [&mut ModularChannel],
     chan: usize,
-    stream_id: usize,
-    header: &GroupHeader,
-    tree: &Tree,
+    histo: &Histograms,
     reader: &mut SymbolReader,
     br: &mut BitReader,
 ) -> Result<()> {
     let size = buffers[chan].data.size();
-    let mut wp_state = WeightedPredictorState::new(&header.wp_header, size.0);
-    let mut num_ref_props = tree
-        .max_property_count()
-        .saturating_sub(NUM_NONREF_PROPERTIES);
-    // The precompute_references function stores 4 values per reference property (offset + 0,1,2,3)
-    num_ref_props = num_ref_props.div_ceil(PROPERTIES_PER_PREVCHAN) * PROPERTIES_PER_PREVCHAN;
-    let mut references = Image::<i32>::new((num_ref_props, size.0))?;
-    let num_properties = NUM_NONREF_PROPERTIES + num_ref_props;
-
-    const { assert!(IMAGE_OFFSET.1 == 2) };
-
+    let xsize = size.0;
     for y in 0..size.1 {
-        precompute_references(buffers, chan, y, &mut references);
-        let mut property_buffer: Vec<i32> = vec![0; num_properties];
-        property_buffer[0] = chan as i32;
-        property_buffer[1] = stream_id as i32;
-        let [row, row_top, row_toptop] =
-            buffers[chan].data.distinct_full_rows_mut([y + 2, y + 1, y]);
-        let row = &mut row[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + size.0];
-        let row_top = &mut row_top[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + size.0];
-        let row_toptop = &mut row_toptop[IMAGE_OFFSET.0..IMAGE_OFFSET.0 + size.0];
-        for x in 0..size.0 {
-            let prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
-            let prediction_result = predict(
-                &tree.nodes,
-                prediction_data,
-                Some(&mut wp_state),
-                x,
-                y,
-                &references,
-                &mut property_buffer,
-            );
-            let dec = reader.read_signed(&tree.histograms, br, prediction_result.context as usize);
-            let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
-            row[x] = val;
-            wp_state.update_errors(val, (x, y));
-        }
+        t.decode_row(buffers, chan, histo, reader, br, y, xsize);
     }
-
     Ok(())
 }
 
@@ -179,7 +223,15 @@ pub(super) fn decode_modular_channel(
         || size.1 <= IMAGE_PADDING.1
         || size.0 * size.1 <= SMALL_CHANNEL_THRESHOLD
     {
-        return decode_modular_channel_small(buffers, chan, stream_id, header, tree, reader, br);
+        let mut decoder = FullTree::new(tree, &header.wp_header, chan, stream_id, size.0)?;
+        return decode_modular_channel_impl(
+            &mut decoder,
+            buffers,
+            chan,
+            &tree.histograms,
+            reader,
+            br,
+        );
     }
 
     assert_eq!(buffers[chan].data.padding().1, IMAGE_PADDING.1);
@@ -188,16 +240,7 @@ pub(super) fn decode_modular_channel(
 
     // We now know the channel has size at least IMAGE_PADDING.
     run_on_specialized_tree(tree, chan, stream_id, size.0, header, {
-        #[inline(never)]
-        |t| {
-            let size = buffers[chan].data.size();
-            debug_assert!(size.0 >= 4);
-            debug_assert!(size.1 >= 2);
-            for y in 0..size.1 {
-                t.decode_row(buffers, chan, &tree.histograms, reader, br, y, size.0);
-            }
-            Ok(())
-        }
+        |t| decode_modular_channel_impl(t, buffers, chan, &tree.histograms, reader, br)
     })?;
     br.check_for_error()
 }

--- a/jxl/src/frame/modular/decode/channel.rs
+++ b/jxl/src/frame/modular/decode/channel.rs
@@ -173,7 +173,7 @@ impl<'a> ModularChannelDecoder for FullTree<'a> {
         for x in 0..xsize {
             let prediction_data = PredictionData::get_rows(row, row_top, row_toptop, x, y);
             let prediction_result = predict(
-                &self.tree.nodes,
+                self.tree,
                 prediction_data,
                 Some(&mut self.wp_state),
                 x,

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -17,27 +17,121 @@ use crate::{
         },
         flat_tree::{FlatTreeNode, predict_flat},
         predict::{PredictionData, WeightedPredictorState, clamped_gradient},
-        tree::{NUM_NONREF_PROPERTIES, PROPERTIES_PER_PREVCHAN, TreeNode},
+        tree::{NUM_NONREF_PROPERTIES, PROPERTIES_PER_PREVCHAN, PredictionResult, TreeNode},
     },
     headers::modular::GroupHeader,
     image::Image,
 };
 
-pub struct NoWpTree {
-    flat_nodes: Vec<FlatTreeNode>,
-    references: Image<i32>,
-    property_buffer: Box<[i32; 256]>,
-    single_value: Option<i32>,
+trait MaybeWeightedPredictor: Sized {
+    fn predict(
+        &mut self,
+        nodes: &[FlatTreeNode],
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        references: &Image<i32>,
+        prop_buffer: &mut [i32; 256],
+    ) -> PredictionResult;
+    fn update_errors(&mut self, _val: i32, _pos: (usize, usize)) {}
 }
 
-impl NoWpTree {
+impl MaybeWeightedPredictor for () {
+    #[inline(always)]
+    fn predict(
+        &mut self,
+        nodes: &[FlatTreeNode],
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        references: &Image<i32>,
+        prop_buffer: &mut [i32; 256],
+    ) -> PredictionResult {
+        predict_flat(nodes, prediction_data, None, pos, references, prop_buffer)
+    }
+}
+
+impl MaybeWeightedPredictor for WeightedPredictorState {
+    #[inline(always)]
+    fn predict(
+        &mut self,
+        nodes: &[FlatTreeNode],
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        references: &Image<i32>,
+        prop_buffer: &mut [i32; 256],
+    ) -> PredictionResult {
+        predict_flat(
+            nodes,
+            prediction_data,
+            Some(self),
+            pos,
+            references,
+            prop_buffer,
+        )
+    }
+    #[inline(always)]
+    fn update_errors(&mut self, val: i32, pos: (usize, usize)) {
+        self.update_errors(val, pos);
+    }
+}
+
+trait Reader: Sized {
+    fn read(
+        &self,
+        reader: &mut SymbolReader,
+        histograms: &Histograms,
+        br: &mut BitReader,
+        cluster: usize,
+    ) -> i32;
+}
+
+impl Reader for i32 {
+    #[inline(always)]
+    fn read(&self, _: &mut SymbolReader, _: &Histograms, _: &mut BitReader, _: usize) -> i32 {
+        *self
+    }
+}
+
+struct Reader420NoLz;
+impl Reader for Reader420NoLz {
+    #[inline(always)]
+    fn read(
+        &self,
+        reader: &mut SymbolReader,
+        histograms: &Histograms,
+        br: &mut BitReader,
+        cluster: usize,
+    ) -> i32 {
+        reader.read_signed_clustered_config_420(histograms, br, cluster)
+    }
+}
+
+struct ReaderGeneric;
+impl Reader for ReaderGeneric {
+    #[inline(always)]
+    fn read(
+        &self,
+        reader: &mut SymbolReader,
+        histograms: &Histograms,
+        br: &mut BitReader,
+        cluster: usize,
+    ) -> i32 {
+        reader.read_signed_clustered_inline(histograms, br, cluster)
+    }
+}
+
+struct FlatTreeInner {
+    nodes: Vec<FlatTreeNode>,
+    references: Image<i32>,
+    property_buffer: Box<[i32; 256]>,
+}
+
+impl FlatTreeInner {
     fn new(
         nodes: Vec<TreeNode>,
         max_property_count: usize,
         channel: usize,
         stream: usize,
         xsize: usize,
-        single_symbol: Option<u32>,
     ) -> Result<Self> {
         let num_ref_props = max_property_count
             .saturating_sub(NUM_NONREF_PROPERTIES)
@@ -48,155 +142,34 @@ impl NoWpTree {
         property_buffer[0] = channel as i32;
         property_buffer[1] = stream as i32;
 
-        let flat_nodes = Tree::build_flat_tree(&nodes)?;
-
         Ok(Self {
-            flat_nodes,
+            nodes: Tree::build_flat_tree(&nodes)?,
             references,
             property_buffer,
-            single_value: single_symbol.map(unpack_signed),
         })
     }
 }
 
-impl ModularChannelDecoder for NoWpTree {
-    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
-        precompute_references(buffers, chan, y, &mut self.references);
-        self.property_buffer[9] = 0;
-    }
-
-    #[inline(always)]
-    fn decode_one(
-        &mut self,
-        prediction_data: PredictionData,
-        pos: (usize, usize),
-        reader: &mut SymbolReader,
-        br: &mut BitReader,
-        histograms: &Histograms,
-    ) -> i32 {
-        let prediction_result = predict_flat(
-            &self.flat_nodes,
-            prediction_data,
-            None,
-            pos.0,
-            pos.1,
-            &self.references,
-            &mut self.property_buffer,
-        );
-        let dec = if let Some(sv) = self.single_value {
-            sv
-        } else {
-            reader.read_signed_clustered(histograms, br, prediction_result.context as usize)
-        };
-        make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
-    }
+struct FlatTree<WP: MaybeWeightedPredictor, R: Reader> {
+    inner: FlatTreeInner,
+    reader: R,
+    wp_state: WP,
 }
 
-struct NoWpTreeNoLz77(NoWpTree);
-
-impl ModularChannelDecoder for NoWpTreeNoLz77 {
-    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
-        self.0.init_row(buffers, chan, y);
-    }
-
-    #[inline(always)]
-    fn decode_one(
-        &mut self,
-        prediction_data: PredictionData,
-        pos: (usize, usize),
-        reader: &mut SymbolReader,
-        br: &mut BitReader,
-        histograms: &Histograms,
-    ) -> i32 {
-        let prediction_result = predict_flat(
-            &self.0.flat_nodes,
-            prediction_data,
-            None,
-            pos.0,
-            pos.1,
-            &self.0.references,
-            &mut self.0.property_buffer,
-        );
-        let dec = if let Some(sv) = self.0.single_value {
-            sv
-        } else {
-            reader.read_signed_clustered_no_lz77(histograms, br, prediction_result.context as usize)
-        };
-        make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
-    }
-}
-
-struct NoWpTreeConfig420(NoWpTree);
-
-impl ModularChannelDecoder for NoWpTreeConfig420 {
-    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
-        self.0.init_row(buffers, chan, y);
-    }
-
-    #[inline(always)]
-    fn decode_one(
-        &mut self,
-        prediction_data: PredictionData,
-        pos: (usize, usize),
-        reader: &mut SymbolReader,
-        br: &mut BitReader,
-        histograms: &Histograms,
-    ) -> i32 {
-        let prediction_result = predict_flat(
-            &self.0.flat_nodes,
-            prediction_data,
-            None,
-            pos.0,
-            pos.1,
-            &self.0.references,
-            &mut self.0.property_buffer,
-        );
-        let dec = if let Some(sv) = self.0.single_value {
-            sv
-        } else {
-            reader.read_signed_clustered_config_420(
-                histograms,
-                br,
-                prediction_result.context as usize,
-            )
-        };
-        make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
-    }
-}
-
-pub struct GeneralTree {
-    no_wp_tree: NoWpTree,
-    wp_state: WeightedPredictorState,
-}
-
-impl GeneralTree {
-    fn new(
-        nodes: Vec<TreeNode>,
-        max_property_count: usize,
-        header: &GroupHeader,
-        channel: usize,
-        stream: usize,
-        xsize: usize,
-        single_symbol: Option<u32>,
-    ) -> Result<Self> {
-        let wp_state = WeightedPredictorState::new(&header.wp_header, xsize);
-        Ok(Self {
-            no_wp_tree: NoWpTree::new(
-                nodes,
-                max_property_count,
-                channel,
-                stream,
-                xsize,
-                single_symbol,
-            )?,
+impl<WP: MaybeWeightedPredictor, R: Reader> FlatTree<WP, R> {
+    fn new(inner: FlatTreeInner, reader: R, wp_state: WP) -> Self {
+        Self {
+            inner,
+            reader,
             wp_state,
-        })
+        }
     }
 }
 
-impl ModularChannelDecoder for GeneralTree {
+impl<WP: MaybeWeightedPredictor, R: Reader> ModularChannelDecoder for FlatTree<WP, R> {
     fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
-        self.no_wp_tree.init_row(buffers, chan, y);
+        precompute_references(buffers, chan, y, &mut self.inner.references);
+        self.inner.property_buffer[GRADIENT_PROPERTY as usize] = 0;
     }
 
     #[inline(always)]
@@ -208,98 +181,18 @@ impl ModularChannelDecoder for GeneralTree {
         br: &mut BitReader,
         histograms: &Histograms,
     ) -> i32 {
-        let prediction_result = predict_flat(
-            &self.no_wp_tree.flat_nodes,
+        let prediction_result = self.wp_state.predict(
+            &self.inner.nodes,
             prediction_data,
-            Some(&mut self.wp_state),
-            pos.0,
-            pos.1,
-            &self.no_wp_tree.references,
-            &mut self.no_wp_tree.property_buffer,
+            pos,
+            &self.inner.references,
+            &mut self.inner.property_buffer,
         );
-        let dec = if let Some(sv) = self.no_wp_tree.single_value {
-            sv
-        } else {
-            reader.read_signed_clustered(histograms, br, prediction_result.context as usize)
-        };
+        let dec = self
+            .reader
+            .read(reader, histograms, br, prediction_result.context as usize);
         let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
         self.wp_state.update_errors(val, pos);
-        val
-    }
-}
-
-struct GeneralTreeNoLz77(GeneralTree);
-
-impl ModularChannelDecoder for GeneralTreeNoLz77 {
-    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
-        self.0.init_row(buffers, chan, y);
-    }
-
-    #[inline(always)]
-    fn decode_one(
-        &mut self,
-        prediction_data: PredictionData,
-        pos: (usize, usize),
-        reader: &mut SymbolReader,
-        br: &mut BitReader,
-        histograms: &Histograms,
-    ) -> i32 {
-        let prediction_result = predict_flat(
-            &self.0.no_wp_tree.flat_nodes,
-            prediction_data,
-            Some(&mut self.0.wp_state),
-            pos.0,
-            pos.1,
-            &self.0.no_wp_tree.references,
-            &mut self.0.no_wp_tree.property_buffer,
-        );
-        let dec = if let Some(sv) = self.0.no_wp_tree.single_value {
-            sv
-        } else {
-            reader.read_signed_clustered_no_lz77(histograms, br, prediction_result.context as usize)
-        };
-        let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
-        self.0.wp_state.update_errors(val, pos);
-        val
-    }
-}
-
-struct GeneralTreeConfig420(GeneralTree);
-
-impl ModularChannelDecoder for GeneralTreeConfig420 {
-    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
-        self.0.init_row(buffers, chan, y);
-    }
-
-    #[inline(always)]
-    fn decode_one(
-        &mut self,
-        prediction_data: PredictionData,
-        pos: (usize, usize),
-        reader: &mut SymbolReader,
-        br: &mut BitReader,
-        histograms: &Histograms,
-    ) -> i32 {
-        let prediction_result = predict_flat(
-            &self.0.no_wp_tree.flat_nodes,
-            prediction_data,
-            Some(&mut self.0.wp_state),
-            pos.0,
-            pos.1,
-            &self.0.no_wp_tree.references,
-            &mut self.0.no_wp_tree.property_buffer,
-        );
-        let dec = if let Some(sv) = self.0.no_wp_tree.single_value {
-            sv
-        } else {
-            reader.read_signed_clustered_config_420(
-                histograms,
-                br,
-                prediction_result.context as usize,
-            )
-        };
-        let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
-        self.0.wp_state.update_errors(val, pos);
         val
     }
 }
@@ -358,30 +251,25 @@ fn make_lut(tree: &[TreeNode]) -> Option<[u8; LUT_TABLE_SIZE]> {
     Some(ans)
 }
 
-/// Specialized WpOnlyLookup for when all HybridUint configs are 420
-/// This allows using the fast-path entropy decoder
-pub struct WpOnlyLookupConfig420 {
+struct WpOnly<R: Reader> {
     lut: [u8; LUT_TABLE_SIZE],
     wp_state: WeightedPredictorState,
+    reader: R,
 }
 
-impl WpOnlyLookupConfig420 {
-    fn new(
-        tree: &[TreeNode],
-        histograms: &Histograms,
-        header: &GroupHeader,
-        xsize: usize,
-    ) -> Option<Self> {
-        if !histograms.can_use_config_420_fast_path() {
-            return None;
-        }
+impl<R: Reader> WpOnly<R> {
+    fn new(tree: &[TreeNode], header: &GroupHeader, xsize: usize, reader: R) -> Option<Self> {
         let wp_state = WeightedPredictorState::new(&header.wp_header, xsize);
         let lut = make_lut(tree)?;
-        Some(Self { lut, wp_state })
+        Some(Self {
+            lut,
+            wp_state,
+            reader,
+        })
     }
 }
 
-impl ModularChannelDecoder for WpOnlyLookupConfig420 {
+impl<R: Reader> ModularChannelDecoder for WpOnly<R> {
     #[inline(always)]
     fn decode_one(
         &mut self,
@@ -394,8 +282,7 @@ impl ModularChannelDecoder for WpOnlyLookupConfig420 {
         let (wp_pred, property) = self.wp_state.predict_and_property(pos, &prediction_data);
         let ctx = self.lut[(property as i64 - LUT_MIN_SPLITVAL as i64)
             .clamp(0, LUT_TABLE_SIZE as i64 - 1) as usize];
-        // Use the specialized 420 fast path
-        let dec = reader.read_signed_clustered_config_420(histograms, br, ctx as usize);
+        let dec = self.reader.read(reader, histograms, br, ctx as usize);
         let val = dec.wrapping_add(wp_pred as i32);
         self.wp_state.update_errors(val, pos);
         val
@@ -404,41 +291,21 @@ impl ModularChannelDecoder for WpOnlyLookupConfig420 {
 
 /// Property 9 is the "gradient property": left + top - topleft
 const GRADIENT_PROPERTY: u8 = 9;
+const WEIGHTED_PROPERTY: u8 = 15;
 
-/// Config 420 specialized version of gradient lookup for trees that split only on property 9.
-/// This uses the specialized entropy decoder for config 420 + no LZ77.
-pub struct GradientLookupConfig420 {
+struct GradientOnly<R: Reader> {
     lut: [u8; LUT_TABLE_SIZE],
+    reader: R,
 }
 
-fn make_gradient_lut_config_420(
-    tree: &[TreeNode],
-    histograms: &Histograms,
-) -> Option<GradientLookupConfig420> {
-    if !histograms.can_use_config_420_fast_path() {
-        return None;
+impl<R: Reader> GradientOnly<R> {
+    fn new(tree: &[TreeNode], reader: R) -> Option<Self> {
+        let lut = make_lut(tree)?;
+        Some(Self { lut, reader })
     }
-    // Verify all splits are on property 9 and all leaves have Gradient predictor
-    for node in tree {
-        match node {
-            TreeNode::Split { property, .. } => {
-                if *property != GRADIENT_PROPERTY {
-                    return None;
-                }
-            }
-            TreeNode::Leaf { predictor, .. } => {
-                if *predictor != Predictor::Gradient {
-                    return None;
-                }
-            }
-        }
-    }
-
-    let lut = make_lut(tree)?;
-    Some(GradientLookupConfig420 { lut })
 }
 
-impl ModularChannelDecoder for GradientLookupConfig420 {
+impl<R: Reader> ModularChannelDecoder for GradientOnly<R> {
     #[inline(always)]
     fn needs_toptop(&self) -> bool {
         false
@@ -468,17 +335,17 @@ impl ModularChannelDecoder for GradientLookupConfig420 {
             prediction_data.topleft as i64,
         );
 
-        // Use the specialized config 420 fast path
-        let dec = reader.read_signed_clustered_config_420(histograms, br, cluster as usize);
+        let dec = self.reader.read(reader, histograms, br, cluster as usize);
         dec.wrapping_add(pred as i32)
     }
 }
 
-pub struct SingleGradientOnly {
+struct SingleGradientOnly<R: Reader> {
     clustered_ctx: usize,
+    reader: R,
 }
 
-impl ModularChannelDecoder for SingleGradientOnly {
+impl<R: Reader> ModularChannelDecoder for SingleGradientOnly<R> {
     #[inline(always)]
     fn needs_toptop(&self) -> bool {
         false
@@ -498,17 +365,28 @@ impl ModularChannelDecoder for SingleGradientOnly {
             prediction_data.top as i64,
             prediction_data.topleft as i64,
         );
-        let dec = reader.read_signed_clustered_inline(histograms, br, self.clustered_ctx);
+        let dec = self.reader.read(reader, histograms, br, self.clustered_ctx);
         dec.wrapping_add(pred as i32)
     }
 }
 
-pub struct NoTree {
+struct NoTreeZero {
     clustered_ctx: usize,
     single_value: Option<i32>,
 }
 
-impl ModularChannelDecoder for NoTree {
+impl ModularChannelDecoder for NoTreeZero {
+    #[inline(never)]
+    fn decode_one(
+        &mut self,
+        _prediction_data: PredictionData,
+        _pos: (usize, usize),
+        _reader: &mut SymbolReader,
+        _br: &mut BitReader,
+        _histograms: &Histograms,
+    ) -> i32 {
+        unreachable!()
+    }
     #[inline(never)]
     fn decode_row(
         &mut self,
@@ -549,6 +427,8 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
 
     let mut uses_wp = false;
     let mut uses_non_wp = false;
+    let mut max_property_count = 0;
+    let mut uses_non_gradient = false;
 
     // If, after pruning the tree, `is_single_symbol` is true, then `single_symbol` is the
     // only symbol that could possibly be decoded by this tree.
@@ -578,9 +458,10 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
                 left,
                 right,
             } => {
-                // WeightedPredictor property.
-                uses_wp |= property == 15;
-                uses_non_wp |= property != 15;
+                uses_wp |= property == WEIGHTED_PROPERTY;
+                uses_non_wp |= property != WEIGHTED_PROPERTY;
+                uses_non_gradient |= property != GRADIENT_PROPERTY;
+                max_property_count = max_property_count.max(property as usize + 1);
                 let base = (queue.len() + pruned_tree.len() + 1) as u32;
                 pruned_tree.push(TreeNode::Split {
                     property,
@@ -594,6 +475,7 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
             TreeNode::Leaf { predictor, .. } => {
                 uses_wp |= predictor == Predictor::Weighted;
                 uses_non_wp |= predictor != Predictor::Weighted;
+                uses_non_gradient |= predictor != Predictor::Gradient;
                 let TreeNode::Leaf { id, .. } = &mut node else {
                     unreachable!()
                 };
@@ -628,7 +510,7 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
         },
     ] = &*pruned_tree
     {
-        return run(&mut NoTree {
+        return run(&mut NoTreeZero {
             clustered_ctx: *id as usize,
             single_value: single_symbol.map(unpack_signed),
         });
@@ -645,85 +527,46 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
     {
         return run(&mut SingleGradientOnly {
             clustered_ctx: *id as usize,
+            reader: ReaderGeneric,
         });
     }
 
-    if !uses_non_wp {
-        // Try the specialized 420 config version (fast path for effort 3 encoded images)
-        if let Some(mut wp) =
-            WpOnlyLookupConfig420::new(&pruned_tree, &tree.histograms, header, xsize)
-        {
+    let uses_non420 = !tree.histograms.can_use_config_420_fast_path();
+
+    if !uses_non_wp && !uses_non420 {
+        if let Some(mut wp) = WpOnly::new(&pruned_tree, header, xsize, Reader420NoLz) {
             return run(&mut wp);
         }
     }
 
+    if !uses_non_gradient && !uses_non420 {
+        if let Some(mut grad) = GradientOnly::new(&pruned_tree, Reader420NoLz) {
+            return run(&mut grad);
+        }
+    }
+
+    let single_symbol = single_symbol.map(unpack_signed);
+
+    let inner = FlatTreeInner::new(pruned_tree, max_property_count, channel, stream, xsize)?;
+
     // Non-WP trees (includes effort 2 encoding and some groups in effort > 3)
     if !uses_wp {
-        // Try config 420 specialized gradient LUT version (fast path for effort 2 encoded images)
-        if let Some(mut gl) = make_gradient_lut_config_420(&pruned_tree, &tree.histograms) {
-            return run(&mut gl);
+        if let Some(ss) = single_symbol {
+            return run(&mut FlatTree::new(inner, ss, ()));
         }
-        if tree.histograms.can_use_config_420_fast_path() {
-            return run(&mut NoWpTreeConfig420(NoWpTree::new(
-                pruned_tree,
-                tree.max_property_count(),
-                channel,
-                stream,
-                xsize,
-                single_symbol,
-            )?));
+        if !uses_non420 {
+            return run(&mut FlatTree::new(inner, Reader420NoLz, ()));
         }
-        if tree.histograms.has_no_lz77() {
-            return run(&mut NoWpTreeNoLz77(NoWpTree::new(
-                pruned_tree,
-                tree.max_property_count(),
-                channel,
-                stream,
-                xsize,
-                single_symbol,
-            )?));
-        }
-        return run(&mut NoWpTree::new(
-            pruned_tree,
-            tree.max_property_count(),
-            channel,
-            stream,
-            xsize,
-            single_symbol,
-        )?);
+        return run(&mut FlatTree::new(inner, ReaderGeneric, ()));
     }
 
-    if tree.histograms.can_use_config_420_fast_path() {
-        return run(&mut GeneralTreeConfig420(GeneralTree::new(
-            pruned_tree,
-            tree.max_property_count(),
-            header,
-            channel,
-            stream,
-            xsize,
-            single_symbol,
-        )?));
-    }
+    let wp_state = WeightedPredictorState::new(&header.wp_header, xsize);
 
-    if tree.histograms.has_no_lz77() {
-        return run(&mut GeneralTreeNoLz77(GeneralTree::new(
-            pruned_tree,
-            tree.max_property_count(),
-            header,
-            channel,
-            stream,
-            xsize,
-            single_symbol,
-        )?));
+    if let Some(ss) = single_symbol {
+        return run(&mut FlatTree::new(inner, ss, wp_state));
     }
-
-    run(&mut GeneralTree::new(
-        pruned_tree,
-        tree.max_property_count(),
-        header,
-        channel,
-        stream,
-        xsize,
-        single_symbol,
-    )?)
+    if !uses_non420 {
+        return run(&mut FlatTree::new(inner, Reader420NoLz, wp_state));
+    }
+    run(&mut FlatTree::new(inner, ReaderGeneric, wp_state))
 }

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -92,6 +92,74 @@ impl ModularChannelDecoder for NoWpTree {
     }
 }
 
+struct NoWpTreeNoLz77(NoWpTree);
+
+impl ModularChannelDecoder for NoWpTreeNoLz77 {
+    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
+        self.0.init_row(buffers, chan, y);
+    }
+
+    #[inline(always)]
+    fn decode_one(
+        &mut self,
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        reader: &mut SymbolReader,
+        br: &mut BitReader,
+        histograms: &Histograms,
+    ) -> i32 {
+        let prediction_result = predict_flat(
+            &self.0.flat_nodes,
+            prediction_data,
+            None,
+            pos.0,
+            pos.1,
+            &self.0.references,
+            &mut self.0.property_buffer,
+        );
+        let dec = if let Some(sv) = self.0.single_value {
+            sv
+        } else {
+            reader.read_signed_clustered_no_lz77(histograms, br, prediction_result.context as usize)
+        };
+        make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
+    }
+}
+
+struct NoWpTreeConfig420(NoWpTree);
+
+impl ModularChannelDecoder for NoWpTreeConfig420 {
+    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
+        self.0.init_row(buffers, chan, y);
+    }
+
+    #[inline(always)]
+    fn decode_one(
+        &mut self,
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        reader: &mut SymbolReader,
+        br: &mut BitReader,
+        histograms: &Histograms,
+    ) -> i32 {
+        let prediction_result = predict_flat(
+            &self.0.flat_nodes,
+            prediction_data,
+            None,
+            pos.0,
+            pos.1,
+            &self.0.references,
+            &mut self.0.property_buffer,
+        );
+        let dec = if let Some(sv) = self.0.single_value {
+            sv
+        } else {
+            reader.read_signed_clustered_config_420(histograms, br, prediction_result.context as usize)
+        };
+        make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
+    }
+}
+
 pub struct GeneralTree {
     no_wp_tree: NoWpTree,
     wp_state: WeightedPredictorState,
@@ -152,6 +220,78 @@ impl ModularChannelDecoder for GeneralTree {
         };
         let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
         self.wp_state.update_errors(val, pos);
+        val
+    }
+}
+
+struct GeneralTreeNoLz77(GeneralTree);
+
+impl ModularChannelDecoder for GeneralTreeNoLz77 {
+    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
+        self.0.init_row(buffers, chan, y);
+    }
+
+    #[inline(always)]
+    fn decode_one(
+        &mut self,
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        reader: &mut SymbolReader,
+        br: &mut BitReader,
+        histograms: &Histograms,
+    ) -> i32 {
+        let prediction_result = predict_flat(
+            &self.0.no_wp_tree.flat_nodes,
+            prediction_data,
+            Some(&mut self.0.wp_state),
+            pos.0,
+            pos.1,
+            &self.0.no_wp_tree.references,
+            &mut self.0.no_wp_tree.property_buffer,
+        );
+        let dec = if let Some(sv) = self.0.no_wp_tree.single_value {
+            sv
+        } else {
+            reader.read_signed_clustered_no_lz77(histograms, br, prediction_result.context as usize)
+        };
+        let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
+        self.0.wp_state.update_errors(val, pos);
+        val
+    }
+}
+
+struct GeneralTreeConfig420(GeneralTree);
+
+impl ModularChannelDecoder for GeneralTreeConfig420 {
+    fn init_row(&mut self, buffers: &mut [&mut ModularChannel], chan: usize, y: usize) {
+        self.0.init_row(buffers, chan, y);
+    }
+
+    #[inline(always)]
+    fn decode_one(
+        &mut self,
+        prediction_data: PredictionData,
+        pos: (usize, usize),
+        reader: &mut SymbolReader,
+        br: &mut BitReader,
+        histograms: &Histograms,
+    ) -> i32 {
+        let prediction_result = predict_flat(
+            &self.0.no_wp_tree.flat_nodes,
+            prediction_data,
+            Some(&mut self.0.wp_state),
+            pos.0,
+            pos.1,
+            &self.0.no_wp_tree.references,
+            &mut self.0.no_wp_tree.property_buffer,
+        );
+        let dec = if let Some(sv) = self.0.no_wp_tree.single_value {
+            sv
+        } else {
+            reader.read_signed_clustered_config_420(histograms, br, prediction_result.context as usize)
+        };
+        let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
+        self.0.wp_state.update_errors(val, pos);
         val
     }
 }
@@ -515,6 +655,26 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
         if let Some(mut gl) = make_gradient_lut_config_420(&pruned_tree, &tree.histograms) {
             return run(&mut gl);
         }
+        if tree.histograms.can_use_config_420_fast_path() {
+            return run(&mut NoWpTreeConfig420(NoWpTree::new(
+                pruned_tree,
+                tree.max_property_count(),
+                channel,
+                stream,
+                xsize,
+                single_symbol,
+            )?));
+        }
+        if tree.histograms.has_no_lz77() {
+            return run(&mut NoWpTreeNoLz77(NoWpTree::new(
+                pruned_tree,
+                tree.max_property_count(),
+                channel,
+                stream,
+                xsize,
+                single_symbol,
+            )?));
+        }
         return run(&mut NoWpTree::new(
             pruned_tree,
             tree.max_property_count(),
@@ -523,6 +683,30 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
             xsize,
             single_symbol,
         )?);
+    }
+
+    if tree.histograms.can_use_config_420_fast_path() {
+        return run(&mut GeneralTreeConfig420(GeneralTree::new(
+            pruned_tree,
+            tree.max_property_count(),
+            header,
+            channel,
+            stream,
+            xsize,
+            single_symbol,
+        )?));
+    }
+
+    if tree.histograms.has_no_lz77() {
+        return run(&mut GeneralTreeNoLz77(GeneralTree::new(
+            pruned_tree,
+            tree.max_property_count(),
+            header,
+            channel,
+            stream,
+            xsize,
+            single_symbol,
+        )?));
     }
 
     run(&mut GeneralTree::new(

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -150,7 +150,7 @@ impl FlatTreeInner {
     }
 }
 
-struct FlatTree<WP: MaybeWeightedPredictor, R: Reader> {
+struct FlatTree<WP, R> {
     inner: FlatTreeInner,
     reader: R,
     wp_state: WP,
@@ -251,7 +251,7 @@ fn make_lut(tree: &[TreeNode]) -> Option<[u8; LUT_TABLE_SIZE]> {
     Some(ans)
 }
 
-struct WpOnly<R: Reader> {
+struct WpOnly<R> {
     lut: [u8; LUT_TABLE_SIZE],
     wp_state: WeightedPredictorState,
     reader: R,
@@ -293,7 +293,7 @@ impl<R: Reader> ModularChannelDecoder for WpOnly<R> {
 const GRADIENT_PROPERTY: u8 = 9;
 const WEIGHTED_PROPERTY: u8 = 15;
 
-struct GradientOnly<R: Reader> {
+struct GradientOnly<R> {
     lut: [u8; LUT_TABLE_SIZE],
     reader: R,
 }
@@ -340,7 +340,7 @@ impl<R: Reader> ModularChannelDecoder for GradientOnly<R> {
     }
 }
 
-struct SingleGradientOnly<R: Reader> {
+struct SingleGradientOnly<R> {
     clustered_ctx: usize,
     reader: R,
 }
@@ -533,16 +533,18 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
 
     let uses_non420 = !tree.histograms.can_use_config_420_fast_path();
 
-    if !uses_non_wp && !uses_non420 {
-        if let Some(mut wp) = WpOnly::new(&pruned_tree, header, xsize, Reader420NoLz) {
-            return run(&mut wp);
-        }
+    if !uses_non_wp
+        && !uses_non420
+        && let Some(mut wp) = WpOnly::new(&pruned_tree, header, xsize, Reader420NoLz)
+    {
+        return run(&mut wp);
     }
 
-    if !uses_non_gradient && !uses_non420 {
-        if let Some(mut grad) = GradientOnly::new(&pruned_tree, Reader420NoLz) {
-            return run(&mut grad);
-        }
+    if !uses_non_gradient
+        && !uses_non420
+        && let Some(mut grad) = GradientOnly::new(&pruned_tree, Reader420NoLz)
+    {
+        return run(&mut grad);
     }
 
     let single_symbol = single_symbol.map(unpack_signed);

--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -154,7 +154,11 @@ impl ModularChannelDecoder for NoWpTreeConfig420 {
         let dec = if let Some(sv) = self.0.single_value {
             sv
         } else {
-            reader.read_signed_clustered_config_420(histograms, br, prediction_result.context as usize)
+            reader.read_signed_clustered_config_420(
+                histograms,
+                br,
+                prediction_result.context as usize,
+            )
         };
         make_pixel(dec, prediction_result.multiplier, prediction_result.guess)
     }
@@ -288,7 +292,11 @@ impl ModularChannelDecoder for GeneralTreeConfig420 {
         let dec = if let Some(sv) = self.0.no_wp_tree.single_value {
             sv
         } else {
-            reader.read_signed_clustered_config_420(histograms, br, prediction_result.context as usize)
+            reader.read_signed_clustered_config_420(
+                histograms,
+                br,
+                prediction_result.context as usize,
+            )
         };
         let val = make_pixel(dec, prediction_result.multiplier, prediction_result.guess);
         self.0.wp_state.update_errors(val, pos);

--- a/jxl/src/frame/modular/flat_tree.rs
+++ b/jxl/src/frame/modular/flat_tree.rs
@@ -40,12 +40,18 @@ pub(super) fn predict_flat(
     flat_tree: &[FlatTreeNode],
     prediction_data: PredictionData,
     wp_state: Option<&mut WeightedPredictorState>,
-    x: usize,
-    y: usize,
+    pos: (usize, usize),
     references: &Image<i32>,
     property_buffer: &mut [i32; 256],
 ) -> PredictionResult {
-    let wp_pred = compute_properties(prediction_data, wp_state, x, y, references, property_buffer);
+    let wp_pred = compute_properties(
+        prediction_data,
+        wp_state,
+        pos.0,
+        pos.1,
+        references,
+        property_buffer,
+    );
 
     let mut pos = 0;
     loop {

--- a/jxl/src/frame/modular/predict.rs
+++ b/jxl/src/frame/modular/predict.rs
@@ -63,7 +63,7 @@ pub struct PredictionData {
 }
 
 impl PredictionData {
-    #[inline]
+    #[inline(always)]
     pub fn update_for_interior_row(
         self,
         row_top: &[i32],
@@ -92,6 +92,7 @@ impl PredictionData {
         }
     }
 
+    #[inline]
     pub fn get_rows(row: &[i32], row_top: &[i32], row_toptop: &[i32], x: usize, y: usize) -> Self {
         let left = if x > 0 {
             row[x - 1]

--- a/jxl/src/frame/modular/tree.rs
+++ b/jxl/src/frame/modular/tree.rs
@@ -246,11 +246,10 @@ pub(super) fn compute_properties(
 
 /// Prediction using standard tree traversal.
 /// Used for small channels where building a flat tree isn't worth it.
-#[inline]
 #[instrument(level = "trace", ret)]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn predict(
-    tree: &[TreeNode],
+    tree: &Tree,
     prediction_data: PredictionData,
     wp_state: Option<&mut WeightedPredictorState>,
     x: usize,
@@ -262,37 +261,12 @@ pub(super) fn predict(
 
     trace!(?property_buffer, "new properties");
 
-    let mut tree_node = 0;
-    while let TreeNode::Split {
-        property,
-        val,
-        left,
-        right,
-    } = tree[tree_node]
-    {
-        if property_buffer[property as usize] > val {
-            trace!(
-                "left at node {tree_node} [{} > {val}]",
-                property_buffer[property as usize]
-            );
-            tree_node = left as usize;
-        } else {
-            trace!(
-                "right at node {tree_node} [{} <= {val}]",
-                property_buffer[property as usize]
-            );
-            tree_node = right as usize;
-        }
-    }
-
-    trace!(leaf = ?tree[tree_node]);
-
     let TreeNode::Leaf {
         predictor,
         offset,
         multiplier,
         id,
-    } = tree[tree_node]
+    } = tree.walk(property_buffer)
     else {
         unreachable!();
     };
@@ -386,5 +360,33 @@ impl Tree {
             histograms,
             num_properties,
         })
+    }
+
+    pub(super) fn walk(&self, properties: &[i32]) -> TreeNode {
+        let mut tree_node = 0;
+        while let TreeNode::Split {
+            property,
+            val,
+            left,
+            right,
+        } = self.nodes[tree_node]
+        {
+            if properties[property as usize] > val {
+                trace!(
+                    "left at node {tree_node} [{} > {val}]",
+                    properties[property as usize]
+                );
+                tree_node = left as usize;
+            } else {
+                trace!(
+                    "right at node {tree_node} [{} <= {val}]",
+                    properties[property as usize]
+                );
+                tree_node = right as usize;
+            }
+        }
+
+        trace!(leaf = ?self.nodes[tree_node]);
+        self.nodes[tree_node]
     }
 }

--- a/jxl/src/frame/modular/tree.rs
+++ b/jxl/src/frame/modular/tree.rs
@@ -34,6 +34,7 @@ pub enum TreeNode {
 pub struct Tree {
     pub nodes: Vec<TreeNode>,
     pub histograms: Histograms,
+    pub num_properties: usize,
 }
 
 fn validate_tree(tree: &[TreeNode], num_properties: usize) -> Result<()> {
@@ -383,24 +384,7 @@ impl Tree {
         Ok(Tree {
             nodes: tree,
             histograms,
+            num_properties,
         })
-    }
-
-    pub fn max_property_count(&self) -> usize {
-        self.nodes
-            .iter()
-            .map(|x| match x {
-                TreeNode::Leaf { .. } => 0,
-                TreeNode::Split { property, .. } => *property,
-            })
-            .max()
-            .unwrap_or_default() as usize
-            + 1
-    }
-
-    pub fn num_prev_channels(&self) -> usize {
-        self.max_property_count()
-            .saturating_sub(NUM_NONREF_PROPERTIES)
-            .div_ceil(PROPERTIES_PER_PREVCHAN)
     }
 }


### PR DESCRIPTION
Also moves the RLE entropy coder special case to be used only for fast_lossless.


General 1-2% speedup of modular images, ~20% speedup of fast_lossless.

Includes improvements from #718 .

```
main, green queen:
Decoded 77394600 pixels in 4.464 seconds: 17.336 MP/s
Decoded 77394600 pixels in 4.545 seconds: 17.029 MP/s
Decoded 77394600 pixels in 4.487 seconds: 17.248 MP/s

main, sunset:
Decoded 64033200 pixels in 5.611 seconds: 11.412 MP/s
Decoded 64033200 pixels in 5.500 seconds: 11.643 MP/s
Decoded 64033200 pixels in 5.504 seconds: 11.634 MP/s

main, artificial e1:
Decoded 314572800 pixels in 4.818 seconds: 65.286 MP/s
Decoded 314572800 pixels in 4.795 seconds: 65.601 MP/s
Decoded 314572800 pixels in 4.835 seconds: 65.066 MP/s

new, green queen:
Decoded 77394600 pixels in 4.427 seconds: 17.484 MP/s
Decoded 77394600 pixels in 4.412 seconds: 17.541 MP/s
Decoded 77394600 pixels in 4.424 seconds: 17.495 MP/s

new, sunset:
Decoded 64033200 pixels in 5.394 seconds: 11.870 MP/s
Decoded 64033200 pixels in 5.298 seconds: 12.087 MP/s
Decoded 64033200 pixels in 5.390 seconds: 11.881 MP/s

main, artificial e1:
Decoded 314572800 pixels in 4.019 seconds: 78.266 MP/s
Decoded 314572800 pixels in 3.890 seconds: 80.864 MP/s
Decoded 314572800 pixels in 3.946 seconds: 79.711 MP/s
```