### PR TITLE
Render the full LF preview on its first flush.

### DIFF
--- a/jxl/src/frame/lf_preview.rs
+++ b/jxl/src/frame/lf_preview.rs
@@ -280,7 +280,7 @@ impl Frame {
         &mut self,
         pixel_format: &JxlPixelFormat,
         output_buffers: &mut [JxlOutputBuffer<'_>],
-        changed_regions: Option<&[Rect]>,
+        changed_regions: &[Rect],
         output_profile: &JxlColorProfile,
     ) -> Result<bool> {
         if self.header.needs_blending() {
@@ -326,24 +326,16 @@ impl Frame {
             // We only render color data, and only to 3- or 4- channel output buffers.
             return Ok(false);
         }
-        // We already have a fully-rendered frame and we are not requesting to re-render
-        // specific regions.
-        if self.decoder_state.lf_frame_was_rendered && changed_regions.is_none() {
-            return Ok(false);
-        }
-        if changed_regions.is_none() {
-            self.decoder_state.lf_frame_was_rendered = true;
-        }
-
         let sz = &self.decoder_state.file_header.size;
         let xsize = sz.xsize() as usize;
         let ysize = sz.ysize() as usize;
 
+        // Render the whole image the first time, then only the changed regions.
         let mut regions_storage;
-
-        let regions = if let Some(regions) = changed_regions {
-            regions
+        let regions = if self.decoder_state.lf_frame_was_rendered {
+            changed_regions
         } else {
+            self.decoder_state.lf_frame_was_rendered = true;
             regions_storage = vec![];
             for i in (0..xsize.div_ceil(8)).step_by(256) {
                 let x0 = i;

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -300,7 +300,7 @@ impl Frame {
                 return self.maybe_preview_lf_frame(
                     pixel_format,
                     buffers,
-                    Some(&regions[..]),
+                    &regions[..],
                     output_profile,
                 );
             } else if self.incomplete_groups == 0 {


### PR DESCRIPTION
`maybe_preview_lf_frame` rendered the whole image only when called with
`changed_regions = None`, otherwise just those regions. Its only caller always
passed `Some(&regions[..])`, so the full-image path was never taken and
`lf_frame_was_rendered` (only set in the `None` branch) was never set.

Streaming still looks right because the per-flush changed regions accumulate in
the retained output buffer. But a truncated / one-shot decode only flushes once,
so the preview covers a few regions and the rest stays at the buffer's init
(black).

Render the whole image on the first flush of an LF frame and only the changed
regions afterwards (keyed on `lf_frame_was_rendered`), and drop the now-unused
`Option` parameter. Truncated decodes now show the full LF preview; full decodes
are unchanged.

Repro: a `three-pass.jxl` truncated to 220 KB decoded with
`jxl_cli --allow-partial-files` shows mostly black before / the full blurry
preview after. Full (untruncated) decode is byte-identical (PSNR ∞).
