### PR TITLE
do two TODOs

### DIFF
--- a/jxl/src/color/tf.rs
+++ b/jxl/src/color/tf.rs
@@ -452,8 +452,7 @@ pub fn scene_to_hlg_precise(samples: &mut [f32]) {
         let y = if a <= 1.0 / 12.0 {
             (3.0 * a).sqrt()
         } else {
-            // TODO(tirr-c): maybe use mul_add?
-            HLG_A * (12.0 * a - HLG_B).ln() + HLG_C
+            HLG_A.mul_add((12.0 * a - HLG_B).ln(), HLG_C)
         };
         *s = (y as f32).copysign(*s);
     }
@@ -484,10 +483,9 @@ pub fn scene_to_hlg(samples: &mut [f32]) {
         let y = if a <= 1.0 / 12.0 {
             (3.0 * a).sqrt()
         } else {
-            // TODO(tirr-c): maybe use mul_add?
             let log = crate::util::fast_log2f(12.0 * a - HLG_B as f32);
             // log2 x = ln x / ln 2, therefore ln x = (ln 2)(log2 x)
-            (HLG_A * std::f64::consts::LN_2) as f32 * log + HLG_C as f32
+            ((HLG_A * std::f64::consts::LN_2) as f32).mul_add(log, HLG_C as f32)
         };
         *s = y.copysign(*s);
     }
@@ -512,8 +510,7 @@ pub fn hlg_to_scene(samples: &mut [f32]) {
             // Constant: 0.003_639_807_079_052_639
             const MUL: f32 = 0.003_639_807;
 
-            // TODO(OneDeuxTriSeiGo): maybe use mul_add?
-            crate::util::fast_pow2f(a * POW) * MUL + ADD
+            crate::util::fast_pow2f(a * POW).mul_add(MUL, ADD)
         };
         *s = y.copysign(*s);
     }

--- a/jxl/src/entropy_coding/ans.rs
+++ b/jxl/src/entropy_coding/ans.rs
@@ -25,6 +25,7 @@ struct AnsHistogram {
     bucket_mask: u32,
     // For optimizing fast-lossless case.
     single_symbol: Option<u32>,
+    alphabet_size: usize,
 }
 
 // log_alphabet_size <= 8 and log_bucket_size <= 7, so u8 is sufficient for symbols and cutoffs.
@@ -310,6 +311,7 @@ impl AnsHistogram {
             log_bucket_size,
             bucket_mask,
             single_symbol,
+            alphabet_size,
         })
     }
 
@@ -414,6 +416,11 @@ impl AnsCodes {
 
     pub fn single_symbol(&self, ctx: usize) -> Option<u32> {
         self.histograms[ctx].single_symbol()
+    }
+
+    /// Returns the largest symbol that can appear in this cluster's histogram.
+    pub fn max_symbol_for_cluster(&self, cluster: usize) -> u32 {
+        self.histograms[cluster].alphabet_size.saturating_sub(1) as u32
     }
 }
 

--- a/jxl/src/entropy_coding/ans.rs
+++ b/jxl/src/entropy_coding/ans.rs
@@ -418,7 +418,6 @@ impl AnsCodes {
         self.histograms[ctx].single_symbol()
     }
 
-    /// Returns the largest symbol that can appear in this cluster's histogram.
     pub fn max_symbol_for_cluster(&self, cluster: usize) -> u32 {
         self.histograms[cluster].alphabet_size.saturating_sub(1) as u32
     }

--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -577,10 +577,6 @@ impl Histograms {
         self.codes.single_symbol(lz_dist_cluster) == Some(1) && lz_conf.is_split_exponent_zero()
     }
 
-    /// Returns the maximum number of bits any decoded value can require across all clusters.
-    ///
-    /// Returns `usize::MAX` conservatively for Huffman-coded streams. Mirrors libjxl's
-    /// `max_num_bits` field in `AnsCodes` / `dec_ans.cc`.
     pub fn max_num_bits(&self) -> usize {
         match &self.codes {
             Codes::Ans(ans) => (0..self.uint_configs.len())

--- a/jxl/src/entropy_coding/decode.rs
+++ b/jxl/src/entropy_coding/decode.rs
@@ -577,6 +577,23 @@ impl Histograms {
         self.codes.single_symbol(lz_dist_cluster) == Some(1) && lz_conf.is_split_exponent_zero()
     }
 
+    /// Returns the maximum number of bits any decoded value can require across all clusters.
+    ///
+    /// Returns `usize::MAX` conservatively for Huffman-coded streams. Mirrors libjxl's
+    /// `max_num_bits` field in `AnsCodes` / `dec_ans.cc`.
+    pub fn max_num_bits(&self) -> usize {
+        match &self.codes {
+            Codes::Ans(ans) => (0..self.uint_configs.len())
+                .map(|i| {
+                    let max_sym = ans.max_symbol_for_cluster(i);
+                    self.uint_configs[i].max_bits_for_symbol(max_sym)
+                })
+                .max()
+                .unwrap_or(0),
+            Codes::Huffman(_) => usize::MAX,
+        }
+    }
+
     pub(crate) fn lz77_params(&self) -> Lz77Params {
         self.lz77_params
     }

--- a/jxl/src/entropy_coding/hybrid_uint.rs
+++ b/jxl/src/entropy_coding/hybrid_uint.rs
@@ -53,6 +53,21 @@ impl HybridUint {
         })
     }
 
+    /// Returns the maximum number of output bits for the given maximum input symbol.
+    ///
+    /// Mirrors libjxl's `UpdateMaxNumBits` from `dec_ans.cc`.
+    pub fn max_bits_for_symbol(&self, max_symbol: u32) -> usize {
+        if max_symbol < self.split_token {
+            self.split_exponent as usize
+        } else {
+            let bits_in_token = self.lsb_in_token + self.msb_in_token;
+            // split_exponent >= bits_in_token is guaranteed by decode() validation
+            let n_extra = self.split_exponent - bits_in_token
+                + ((max_symbol - self.split_token) >> bits_in_token);
+            (bits_in_token + n_extra + 1) as usize
+        }
+    }
+
     /// Returns true if this config matches the 420 pattern (common in e3 images):
     /// split_exponent=4, msb_in_token=2, lsb_in_token=0
     #[inline(always)]

--- a/jxl/src/entropy_coding/hybrid_uint.rs
+++ b/jxl/src/entropy_coding/hybrid_uint.rs
@@ -53,9 +53,6 @@ impl HybridUint {
         })
     }
 
-    /// Returns the maximum number of output bits for the given maximum input symbol.
-    ///
-    /// Mirrors libjxl's `UpdateMaxNumBits` from `dec_ans.cc`.
     pub fn max_bits_for_symbol(&self, max_symbol: u32) -> usize {
         if max_symbol < self.split_token {
             self.split_exponent as usize

--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -518,8 +518,6 @@ impl Frame {
                     .can_do_partial_render()
                     && self.header.num_extra_channels > 0);
 
-            // Use i16 storage when the histogram guarantees all values fit: mirrors libjxl's
-            // dec_frame.cc `use_16_bit` check (max_num_bits + CeilLog2Nonzero(num_passes) < 16).
             let max_bits = passes
                 .iter()
                 .map(|p| p.histograms.max_num_bits())

--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -32,7 +32,8 @@ use crate::{
     error::Result,
     features::{noise::Noise, patches::PatchesDictionary, spline::Splines},
     frame::{
-        DecoderState, Frame, HfGlobalState, HfMetadata, LfGlobalState, PassState, coeff_order,
+        DecoderState, Frame, HfCoefficients, HfGlobalState, HfMetadata, LfGlobalState, PassState,
+        coeff_order,
     },
     headers::{
         color_encoding::ColorSpace,
@@ -508,24 +509,47 @@ impl Frame {
             // keep around the coefficients, so allocate coefficients under those conditions
             // too.
             // TODO(veluca): evaluate whether we can make this check more precise.
-            let hf_coefficients = if passes.len() <= 1
-                && !(self
+            let need_hf_coefficients = passes.len() > 1
+                || (self
                     .lf_global
                     .as_mut()
                     .unwrap()
                     .modular_global
                     .can_do_partial_render()
-                    && self.header.num_extra_channels > 0)
-            {
+                    && self.header.num_extra_channels > 0);
+
+            // Use i16 storage when the histogram guarantees all values fit: mirrors libjxl's
+            // dec_frame.cc `use_16_bit` check (max_num_bits + CeilLog2Nonzero(num_passes) < 16).
+            let max_bits = passes
+                .iter()
+                .map(|p| p.histograms.max_num_bits())
+                .max()
+                .unwrap_or(0);
+            let pass_log = if passes.len() <= 1 {
+                0
+            } else {
+                (passes.len() - 1).ilog2() as usize + 1
+            };
+            let use_i16 = max_bits.saturating_add(pass_log) < 16;
+
+            let hf_coefficients = if !need_hf_coefficients {
                 None
             } else {
                 let xs = GROUP_DIM * GROUP_DIM;
                 let ys = self.header.num_groups();
-                Some((
-                    Image::new((xs, ys))?,
-                    Image::new((xs, ys))?,
-                    Image::new((xs, ys))?,
-                ))
+                if use_i16 {
+                    Some(HfCoefficients::I16(
+                        Image::new((xs, ys))?,
+                        Image::new((xs, ys))?,
+                        Image::new((xs, ys))?,
+                    ))
+                } else {
+                    Some(HfCoefficients::I32(
+                        Image::new((xs, ys))?,
+                        Image::new((xs, ys))?,
+                        Image::new((xs, ys))?,
+                    ))
+                }
             };
 
             self.hf_global = Some(HfGlobalState {

--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -531,22 +531,22 @@ impl Frame {
             let use_i16 = max_bits.saturating_add(pass_log) < 16;
 
             let hf_coefficients = if !need_hf_coefficients {
-                None
+                HfCoefficients::None
             } else {
                 let xs = GROUP_DIM * GROUP_DIM;
                 let ys = self.header.num_groups();
                 if use_i16 {
-                    Some(HfCoefficients::I16(
+                    HfCoefficients::I16([
                         Image::new((xs, ys))?,
                         Image::new((xs, ys))?,
                         Image::new((xs, ys))?,
-                    ))
+                    ])
                 } else {
-                    Some(HfCoefficients::I32(
+                    HfCoefficients::I32([
                         Image::new((xs, ys))?,
                         Image::new((xs, ys))?,
                         Image::new((xs, ys))?,
-                    ))
+                    ])
                 }
             };
 

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -76,8 +76,6 @@ fn predict_num_nonzeros(nzeros_map: &Image<u32>, bx: usize, by: usize) -> usize 
     }
 }
 
-/// Abstraction over coefficient slice types (i32 or i16) for zero-copy SIMD dequant.
-/// Implemented for both `&[i32]` (direct) and `&[i16]` (sign-extend via load_from_i16).
 trait CoeffSlice<D: SimdDescriptor>: Copy {
     fn load_vec(self, d: D, k: usize) -> D::I32Vec;
 }
@@ -498,9 +496,7 @@ pub fn decode_vardct_group(
     let raw_quant_map = hf_meta.raw_quant_map.get_rect(block_group_rect);
     let quant_lf_rect = quant_lf.get_rect(block_group_rect);
     let block_context_map = lf_global.block_context_map.as_mut().unwrap();
-    // Coefficient storage: i16 when the histogram guarantees all values fit (saves ~50% RAM for
-    // persistent multi-pass coefficients). In the i16 case we expand per block before dequant
-    // using the scratch coeffs_storage buffer (which is unused in multi-pass mode).
+
     let mut coeffs_i16: Option<[&mut [i16]; 3]>;
     let mut coeffs_i32: Option<[&mut [i32]; 3]>;
     match hf_global.hf_coefficients.as_mut() {

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -82,14 +82,14 @@ trait CoeffSlice<D: SimdDescriptor>: Copy {
     fn load_vec(self, d: D, k: usize) -> D::I32Vec;
 }
 
-impl<'a, D: SimdDescriptor> CoeffSlice<D> for &'a [i32] {
+impl<D: SimdDescriptor> CoeffSlice<D> for &[i32] {
     #[inline(always)]
     fn load_vec(self, d: D, k: usize) -> D::I32Vec {
         D::I32Vec::load(d, &self[k..])
     }
 }
 
-impl<'a, D: SimdDescriptor> CoeffSlice<D> for &'a [i16] {
+impl<D: SimdDescriptor> CoeffSlice<D> for &[i16] {
     #[inline(always)]
     fn load_vec(self, d: D, k: usize) -> D::I32Vec {
         D::I32Vec::load_from_i16(d, &self[k..])
@@ -515,8 +515,7 @@ pub fn decode_vardct_group(
         None => {
             // Use pooled buffer (already reset to zero in buffers.reset() above)
             coeffs_i16 = None;
-            let (coeffs_x, coeffs_y_b) =
-                buffers.coeffs_storage.split_at_mut(GROUP_DIM * GROUP_DIM);
+            let (coeffs_x, coeffs_y_b) = buffers.coeffs_storage.split_at_mut(GROUP_DIM * GROUP_DIM);
             let (coeffs_y, coeffs_b) = coeffs_y_b.split_at_mut(GROUP_DIM * GROUP_DIM);
             coeffs_i32 = Some([coeffs_x, coeffs_y, coeffs_b]);
         }
@@ -669,13 +668,12 @@ pub fn decode_vardct_group(
                             }
                             let ctx = histo_offset
                                 + zero_density_context(nonzeros, k, log_num_blocks, prev);
-                            let coeff = reader.read_signed_inline(&pass_info.histograms, br, ctx)
-                                << *shift;
+                            let coeff =
+                                reader.read_signed_inline(&pass_info.histograms, br, ctx) << *shift;
                             prev = if coeff != 0 { 1 } else { 0 };
                             nonzeros -= prev;
                             let coeff_index = permutation[k] as usize;
-                            current[coeff_index] =
-                                current[coeff_index].wrapping_add(coeff as i16);
+                            current[coeff_index] = current[coeff_index].wrapping_add(coeff as i16);
                         }
                     } else {
                         let current = &mut coeffs_i32.as_mut().unwrap()[c]
@@ -687,8 +685,8 @@ pub fn decode_vardct_group(
                             }
                             let ctx = histo_offset
                                 + zero_density_context(nonzeros, k, log_num_blocks, prev);
-                            let coeff = reader.read_signed_inline(&pass_info.histograms, br, ctx)
-                                << *shift;
+                            let coeff =
+                                reader.read_signed_inline(&pass_info.histograms, br, ctx) << *shift;
                             prev = if coeff != 0 { 1 } else { 0 };
                             nonzeros -= prev;
                             let coeff_index = permutation[k] as usize;

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -13,7 +13,7 @@ use crate::{
     entropy_coding::decode::SymbolReader,
     error::{Error, Result},
     frame::{
-        HfGlobalState, HfMetadata, LfGlobalState, block_context_map::*,
+        HfCoefficients, HfGlobalState, HfMetadata, LfGlobalState, block_context_map::*,
         color_correlation_map::COLOR_TILE_DIM_IN_BLOCKS, quant_weights::DequantMatrices,
     },
     headers::frame_header::FrameHeader,
@@ -76,6 +76,26 @@ fn predict_num_nonzeros(nzeros_map: &Image<u32>, bx: usize, by: usize) -> usize 
     }
 }
 
+/// Abstraction over coefficient slice types (i32 or i16) for zero-copy SIMD dequant.
+/// Implemented for both `&[i32]` (direct) and `&[i16]` (sign-extend via load_from_i16).
+trait CoeffSlice<D: SimdDescriptor>: Copy {
+    fn load_vec(self, d: D, k: usize) -> D::I32Vec;
+}
+
+impl<'a, D: SimdDescriptor> CoeffSlice<D> for &'a [i32] {
+    #[inline(always)]
+    fn load_vec(self, d: D, k: usize) -> D::I32Vec {
+        D::I32Vec::load(d, &self[k..])
+    }
+}
+
+impl<'a, D: SimdDescriptor> CoeffSlice<D> for &'a [i16] {
+    #[inline(always)]
+    fn load_vec(self, d: D, k: usize) -> D::I32Vec {
+        D::I32Vec::load_from_i16(d, &self[k..])
+    }
+}
+
 #[inline(always)]
 fn adjust_quant_bias<D: SimdDescriptor>(
     d: D,
@@ -92,7 +112,7 @@ fn adjust_quant_bias<D: SimdDescriptor>(
 
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-fn dequant_lane<D: SimdDescriptor>(
+fn dequant_lane<D: SimdDescriptor, C: CoeffSlice<D>>(
     d: D,
     scaled_dequant_x: f32,
     scaled_dequant_y: f32,
@@ -103,7 +123,7 @@ fn dequant_lane<D: SimdDescriptor>(
     x_cc_mul: f32,
     b_cc_mul: f32,
     biases: &[f32; 4],
-    qblock: &[&[i32]; 3],
+    qblock: [C; 3],
     block: &mut [Vec<f32>; 3],
 ) {
     let x_mul = D::F32Vec::load(d, &dequant_matrices[k..]) * D::F32Vec::splat(d, scaled_dequant_x);
@@ -112,9 +132,9 @@ fn dequant_lane<D: SimdDescriptor>(
     let b_mul = D::F32Vec::load(d, &dequant_matrices[2 * size + k..])
         * D::F32Vec::splat(d, scaled_dequant_b);
 
-    let quantized_x = D::I32Vec::load(d, &qblock[0][k..]);
-    let quantized_y = D::I32Vec::load(d, &qblock[1][k..]);
-    let quantized_b = D::I32Vec::load(d, &qblock[2][k..]);
+    let quantized_x = qblock[0].load_vec(d, k);
+    let quantized_y = qblock[1].load_vec(d, k);
+    let quantized_b = qblock[2].load_vec(d, k);
 
     let dequant_x_cc = adjust_quant_bias(d, 0, quantized_x, biases) * x_mul;
     let dequant_y = adjust_quant_bias(d, 1, quantized_y, biases) * y_mul;
@@ -129,7 +149,7 @@ fn dequant_lane<D: SimdDescriptor>(
 
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-fn dequant_block<D: SimdDescriptor>(
+fn dequant_block<D: SimdDescriptor, C: CoeffSlice<D>>(
     d: D,
     hf_type: HfTransformType,
     inv_global_scale: f32,
@@ -142,7 +162,7 @@ fn dequant_block<D: SimdDescriptor>(
     dequant_matrices: &DequantMatrices,
     covered_blocks: usize,
     biases: &[f32; 4],
-    qblock: &[&[i32]; 3],
+    qblock: [C; 3],
     block: &mut [Vec<f32>; 3],
 ) {
     let scaled_dequant_y = inv_global_scale / (quant as f32);
@@ -154,7 +174,7 @@ fn dequant_block<D: SimdDescriptor>(
 
     assert!(BLOCK_SIZE.is_multiple_of(D::F32Vec::LEN));
     for k in (0..covered_blocks * BLOCK_SIZE).step_by(D::F32Vec::LEN) {
-        dequant_lane(
+        dequant_lane::<D, C>(
             d,
             scaled_dequant_x,
             scaled_dequant_y,
@@ -173,7 +193,7 @@ fn dequant_block<D: SimdDescriptor>(
 
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-fn dequant_and_transform_to_pixels<D: SimdDescriptor>(
+fn dequant_and_transform_to_pixels<D: SimdDescriptor, C: CoeffSlice<D>>(
     d: D,
     quant_biases: &[f32; 4],
     x_dm_multiplier: f32,
@@ -196,10 +216,10 @@ fn dequant_and_transform_to_pixels<D: SimdDescriptor>(
     block_rect: Rect,
     num_blocks: usize,
     num_coeffs: usize,
-    qblock: &[&[i32]; 3],
+    qblock: [C; 3],
     dequant_matrices: &DequantMatrices,
 ) -> Result<(), Error> {
-    dequant_block::<D>(
+    dequant_block::<D, C>(
         d,
         transform_type,
         inv_global_scale,
@@ -276,7 +296,7 @@ simd_function!(
         qblock: &[&[i32]; 3],
         dequant_matrices: &DequantMatrices,
     ) -> Result<(), Error> {
-        dequant_and_transform_to_pixels(
+        dequant_and_transform_to_pixels::<D, &[i32]>(
             d,
             quant_biases,
             x_dm_multiplier,
@@ -299,7 +319,65 @@ simd_function!(
             block_rect,
             num_blocks,
             num_coeffs,
-            qblock,
+            [qblock[0], qblock[1], qblock[2]],
+            dequant_matrices,
+        )
+    }
+);
+
+simd_function!(
+    dequant_and_transform_to_pixels_dispatch_i16,
+    d: D,
+    #[allow(clippy::too_many_arguments)]
+    pub fn dequant_and_transform_to_pixels_fwd_i16(
+        quant_biases: &[f32; 4],
+        x_dm_multiplier: f32,
+        b_dm_multiplier: f32,
+        pixels: &mut [Image<f32>; 3],
+        scratch: &mut [f32],
+        inv_global_scale: f32,
+        transform_buffer: &mut [Vec<f32>; 3],
+        hshift: [usize; 3],
+        vshift: [usize; 3],
+        by: usize,
+        sby: [usize; 3],
+        bx: usize,
+        sbx: [usize; 3],
+        x_cc_mul: f32,
+        b_cc_mul: f32,
+        raw_quant: u32,
+        lf_rects: &Option<[ImageRect<f32>; 3]>,
+        transform_type: HfTransformType,
+        block_rect: Rect,
+        num_blocks: usize,
+        num_coeffs: usize,
+        qblock: &[&[i16]; 3],
+        dequant_matrices: &DequantMatrices,
+    ) -> Result<(), Error> {
+        dequant_and_transform_to_pixels::<D, &[i16]>(
+            d,
+            quant_biases,
+            x_dm_multiplier,
+            b_dm_multiplier,
+            pixels,
+            scratch,
+            inv_global_scale,
+            transform_buffer,
+            hshift,
+            vshift,
+            by,
+            sby,
+            bx,
+            sbx,
+            x_cc_mul,
+            b_cc_mul,
+            raw_quant,
+            lf_rects,
+            transform_type,
+            block_rect,
+            num_blocks,
+            num_coeffs,
+            [qblock[0], qblock[1], qblock[2]],
             dequant_matrices,
         )
     }
@@ -420,20 +498,29 @@ pub fn decode_vardct_group(
     let raw_quant_map = hf_meta.raw_quant_map.get_rect(block_group_rect);
     let quant_lf_rect = quant_lf.get_rect(block_group_rect);
     let block_context_map = lf_global.block_context_map.as_mut().unwrap();
-    // TODO(veluca): improve coefficient storage (smaller allocations, use 16 bits if possible).
-    let coeffs = match hf_global.hf_coefficients.as_mut() {
-        Some(hf_coefficients) => [
-            hf_coefficients.0.row_mut(group),
-            hf_coefficients.1.row_mut(group),
-            hf_coefficients.2.row_mut(group),
-        ],
+    // Coefficient storage: i16 when the histogram guarantees all values fit (saves ~50% RAM for
+    // persistent multi-pass coefficients). In the i16 case we expand per block before dequant
+    // using the scratch coeffs_storage buffer (which is unused in multi-pass mode).
+    let mut coeffs_i16: Option<[&mut [i16]; 3]>;
+    let mut coeffs_i32: Option<[&mut [i32]; 3]>;
+    match hf_global.hf_coefficients.as_mut() {
+        Some(HfCoefficients::I16(c0, c1, c2)) => {
+            coeffs_i16 = Some([c0.row_mut(group), c1.row_mut(group), c2.row_mut(group)]);
+            coeffs_i32 = None;
+        }
+        Some(HfCoefficients::I32(c0, c1, c2)) => {
+            coeffs_i16 = None;
+            coeffs_i32 = Some([c0.row_mut(group), c1.row_mut(group), c2.row_mut(group)]);
+        }
         None => {
             // Use pooled buffer (already reset to zero in buffers.reset() above)
-            let (coeffs_x, coeffs_y_b) = buffers.coeffs_storage.split_at_mut(GROUP_DIM * GROUP_DIM);
+            coeffs_i16 = None;
+            let (coeffs_x, coeffs_y_b) =
+                buffers.coeffs_storage.split_at_mut(GROUP_DIM * GROUP_DIM);
             let (coeffs_y, coeffs_b) = coeffs_y_b.split_at_mut(GROUP_DIM * GROUP_DIM);
-            [coeffs_x, coeffs_y, coeffs_b]
+            coeffs_i32 = Some([coeffs_x, coeffs_y, coeffs_b]);
         }
-    };
+    }
     let mut coeffs_offset = 0;
     let transform_buffer = &mut buffers.transform_buffer;
 
@@ -571,22 +658,42 @@ pub fn decode_vardct_group(
                         + context_offset;
                     let mut prev = if nonzeros > num_coeffs / 16 { 0 } else { 1 };
                     let permutation = &pass_info.coeff_orders[shape_id * 3 + c];
-                    let current_coeffs = &mut coeffs[c][coeffs_offset..coeffs_offset + num_coeffs];
                     // Asserting once lets the compiler elide the bounds check on
                     // `permutation[k]` inside the loop given `k < num_coeffs`.
-                    assert!(permutation.len() >= num_coeffs);
-                    for k in num_blocks..num_coeffs {
-                        if nonzeros == 0 {
-                            break;
+                    if let Some(ref mut ci16) = coeffs_i16 {
+                        let current = &mut ci16[c][coeffs_offset..coeffs_offset + num_coeffs];
+                        assert!(permutation.len() >= num_coeffs);
+                        for k in num_blocks..num_coeffs {
+                            if nonzeros == 0 {
+                                break;
+                            }
+                            let ctx = histo_offset
+                                + zero_density_context(nonzeros, k, log_num_blocks, prev);
+                            let coeff = reader.read_signed_inline(&pass_info.histograms, br, ctx)
+                                << *shift;
+                            prev = if coeff != 0 { 1 } else { 0 };
+                            nonzeros -= prev;
+                            let coeff_index = permutation[k] as usize;
+                            current[coeff_index] =
+                                current[coeff_index].wrapping_add(coeff as i16);
                         }
-                        let ctx =
-                            histo_offset + zero_density_context(nonzeros, k, log_num_blocks, prev);
-                        let coeff =
-                            reader.read_signed_inline(&pass_info.histograms, br, ctx) << *shift;
-                        prev = if coeff != 0 { 1 } else { 0 };
-                        nonzeros -= prev;
-                        let coeff_index = permutation[k] as usize;
-                        current_coeffs[coeff_index] += coeff;
+                    } else {
+                        let current = &mut coeffs_i32.as_mut().unwrap()[c]
+                            [coeffs_offset..coeffs_offset + num_coeffs];
+                        assert!(permutation.len() >= num_coeffs);
+                        for k in num_blocks..num_coeffs {
+                            if nonzeros == 0 {
+                                break;
+                            }
+                            let ctx = histo_offset
+                                + zero_density_context(nonzeros, k, log_num_blocks, prev);
+                            let coeff = reader.read_signed_inline(&pass_info.histograms, br, ctx)
+                                << *shift;
+                            prev = if coeff != 0 { 1 } else { 0 };
+                            nonzeros -= prev;
+                            let coeff_index = permutation[k] as usize;
+                            current[coeff_index] += coeff;
+                        }
                     }
                     if nonzeros != 0 {
                         return Err(Error::EndOfBlockResidualNonZeros(nonzeros));
@@ -594,37 +701,71 @@ pub fn decode_vardct_group(
                 }
             }
             if let Some(pixels) = pixels {
-                let qblock = [
-                    &coeffs[0][coeffs_offset..],
-                    &coeffs[1][coeffs_offset..],
-                    &coeffs[2][coeffs_offset..],
-                ];
                 let dequant_matrices = &hf_global.dequant_matrices;
-                dequant_and_transform_to_pixels_dispatch(
-                    quant_biases,
-                    x_dm_multiplier,
-                    b_dm_multiplier,
-                    pixels,
-                    scratch,
-                    inv_global_scale,
-                    transform_buffer,
-                    hshift,
-                    vshift,
-                    by,
-                    sby,
-                    bx,
-                    sbx,
-                    x_cc_mul,
-                    b_cc_mul,
-                    raw_quant,
-                    &lf_rects,
-                    transform_type,
-                    block_rect,
-                    num_blocks,
-                    num_coeffs,
-                    &qblock,
-                    dequant_matrices,
-                )?;
+                if let Some(ref ci16) = coeffs_i16 {
+                    let qblock = [
+                        &ci16[0][coeffs_offset..],
+                        &ci16[1][coeffs_offset..],
+                        &ci16[2][coeffs_offset..],
+                    ];
+                    dequant_and_transform_to_pixels_dispatch_i16(
+                        quant_biases,
+                        x_dm_multiplier,
+                        b_dm_multiplier,
+                        pixels,
+                        scratch,
+                        inv_global_scale,
+                        transform_buffer,
+                        hshift,
+                        vshift,
+                        by,
+                        sby,
+                        bx,
+                        sbx,
+                        x_cc_mul,
+                        b_cc_mul,
+                        raw_quant,
+                        &lf_rects,
+                        transform_type,
+                        block_rect,
+                        num_blocks,
+                        num_coeffs,
+                        &qblock,
+                        dequant_matrices,
+                    )?;
+                } else {
+                    let ci32 = coeffs_i32.as_ref().unwrap();
+                    let qblock = [
+                        &ci32[0][coeffs_offset..],
+                        &ci32[1][coeffs_offset..],
+                        &ci32[2][coeffs_offset..],
+                    ];
+                    dequant_and_transform_to_pixels_dispatch(
+                        quant_biases,
+                        x_dm_multiplier,
+                        b_dm_multiplier,
+                        pixels,
+                        scratch,
+                        inv_global_scale,
+                        transform_buffer,
+                        hshift,
+                        vshift,
+                        by,
+                        sby,
+                        bx,
+                        sbx,
+                        x_cc_mul,
+                        b_cc_mul,
+                        raw_quant,
+                        &lf_rects,
+                        transform_type,
+                        block_rect,
+                        num_blocks,
+                        num_coeffs,
+                        &qblock,
+                        dequant_matrices,
+                    )?;
+                }
             }
             coeffs_offset += num_coeffs;
         }

--- a/jxl/src/frame/group.rs
+++ b/jxl/src/frame/group.rs
@@ -28,7 +28,7 @@ const LF_BUFFER_SIZE: usize = 32 * 32;
 pub struct VarDctBuffers {
     pub scratch: Vec<f32>,
     pub transform_buffer: [Vec<f32>; 3],
-    /// Coefficient storage for single-pass decoding (when hf_coefficients is None)
+    /// Coefficient storage for single-pass decoding (when hf_coefficients is HfCoefficients::None)
     pub coeffs_storage: Vec<i32>,
 }
 
@@ -189,9 +189,14 @@ fn dequant_block<D: SimdDescriptor, C: CoeffSlice<D>>(
     }
 }
 
+enum QBlock<'a> {
+    I32([&'a [i32]; 3]),
+    I16([&'a [i16]; 3]),
+}
+
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-fn dequant_and_transform_to_pixels<D: SimdDescriptor, C: CoeffSlice<D>>(
+fn dequant_and_transform_to_pixels<D: SimdDescriptor>(
     d: D,
     quant_biases: &[f32; 4],
     x_dm_multiplier: f32,
@@ -214,25 +219,43 @@ fn dequant_and_transform_to_pixels<D: SimdDescriptor, C: CoeffSlice<D>>(
     block_rect: Rect,
     num_blocks: usize,
     num_coeffs: usize,
-    qblock: [C; 3],
+    qblock: QBlock<'_>,
     dequant_matrices: &DequantMatrices,
 ) -> Result<(), Error> {
-    dequant_block::<D, C>(
-        d,
-        transform_type,
-        inv_global_scale,
-        raw_quant,
-        x_dm_multiplier,
-        b_dm_multiplier,
-        x_cc_mul,
-        b_cc_mul,
-        num_coeffs,
-        dequant_matrices,
-        num_blocks,
-        quant_biases,
-        qblock,
-        transform_buffer,
-    );
+    match qblock {
+        QBlock::I32(q) => dequant_block::<D, &[i32]>(
+            d,
+            transform_type,
+            inv_global_scale,
+            raw_quant,
+            x_dm_multiplier,
+            b_dm_multiplier,
+            x_cc_mul,
+            b_cc_mul,
+            num_coeffs,
+            dequant_matrices,
+            num_blocks,
+            quant_biases,
+            q,
+            transform_buffer,
+        ),
+        QBlock::I16(q) => dequant_block::<D, &[i16]>(
+            d,
+            transform_type,
+            inv_global_scale,
+            raw_quant,
+            x_dm_multiplier,
+            b_dm_multiplier,
+            x_cc_mul,
+            b_cc_mul,
+            num_coeffs,
+            dequant_matrices,
+            num_blocks,
+            quant_biases,
+            q,
+            transform_buffer,
+        ),
+    };
     for c in [1, 0, 2] {
         if (sbx[c] << hshift[c]) != bx || (sby[c] << vshift[c] != by) {
             continue;
@@ -291,10 +314,10 @@ simd_function!(
         block_rect: Rect,
         num_blocks: usize,
         num_coeffs: usize,
-        qblock: &[&[i32]; 3],
+        qblock: QBlock<'_>,
         dequant_matrices: &DequantMatrices,
     ) -> Result<(), Error> {
-        dequant_and_transform_to_pixels::<D, &[i32]>(
+        dequant_and_transform_to_pixels(
             d,
             quant_biases,
             x_dm_multiplier,
@@ -317,65 +340,7 @@ simd_function!(
             block_rect,
             num_blocks,
             num_coeffs,
-            [qblock[0], qblock[1], qblock[2]],
-            dequant_matrices,
-        )
-    }
-);
-
-simd_function!(
-    dequant_and_transform_to_pixels_dispatch_i16,
-    d: D,
-    #[allow(clippy::too_many_arguments)]
-    pub fn dequant_and_transform_to_pixels_fwd_i16(
-        quant_biases: &[f32; 4],
-        x_dm_multiplier: f32,
-        b_dm_multiplier: f32,
-        pixels: &mut [Image<f32>; 3],
-        scratch: &mut [f32],
-        inv_global_scale: f32,
-        transform_buffer: &mut [Vec<f32>; 3],
-        hshift: [usize; 3],
-        vshift: [usize; 3],
-        by: usize,
-        sby: [usize; 3],
-        bx: usize,
-        sbx: [usize; 3],
-        x_cc_mul: f32,
-        b_cc_mul: f32,
-        raw_quant: u32,
-        lf_rects: &Option<[ImageRect<f32>; 3]>,
-        transform_type: HfTransformType,
-        block_rect: Rect,
-        num_blocks: usize,
-        num_coeffs: usize,
-        qblock: &[&[i16]; 3],
-        dequant_matrices: &DequantMatrices,
-    ) -> Result<(), Error> {
-        dequant_and_transform_to_pixels::<D, &[i16]>(
-            d,
-            quant_biases,
-            x_dm_multiplier,
-            b_dm_multiplier,
-            pixels,
-            scratch,
-            inv_global_scale,
-            transform_buffer,
-            hshift,
-            vshift,
-            by,
-            sby,
-            bx,
-            sbx,
-            x_cc_mul,
-            b_cc_mul,
-            raw_quant,
-            lf_rects,
-            transform_type,
-            block_rect,
-            num_blocks,
-            num_coeffs,
-            [qblock[0], qblock[1], qblock[2]],
+            qblock,
             dequant_matrices,
         )
     }
@@ -497,25 +462,23 @@ pub fn decode_vardct_group(
     let quant_lf_rect = quant_lf.get_rect(block_group_rect);
     let block_context_map = lf_global.block_context_map.as_mut().unwrap();
 
-    let mut coeffs_i16: Option<[&mut [i16]; 3]>;
-    let mut coeffs_i32: Option<[&mut [i32]; 3]>;
-    match hf_global.hf_coefficients.as_mut() {
-        Some(HfCoefficients::I16(c0, c1, c2)) => {
-            coeffs_i16 = Some([c0.row_mut(group), c1.row_mut(group), c2.row_mut(group)]);
-            coeffs_i32 = None;
+    enum CoeffsMut<'a> {
+        I16([&'a mut [i16]; 3]),
+        I32([&'a mut [i32]; 3]),
+    }
+    let mut coeffs = match &mut hf_global.hf_coefficients {
+        HfCoefficients::I16([c0, c1, c2]) => {
+            CoeffsMut::I16([c0.row_mut(group), c1.row_mut(group), c2.row_mut(group)])
         }
-        Some(HfCoefficients::I32(c0, c1, c2)) => {
-            coeffs_i16 = None;
-            coeffs_i32 = Some([c0.row_mut(group), c1.row_mut(group), c2.row_mut(group)]);
+        HfCoefficients::I32([c0, c1, c2]) => {
+            CoeffsMut::I32([c0.row_mut(group), c1.row_mut(group), c2.row_mut(group)])
         }
-        None => {
-            // Use pooled buffer (already reset to zero in buffers.reset() above)
-            coeffs_i16 = None;
+        HfCoefficients::None => {
             let (coeffs_x, coeffs_y_b) = buffers.coeffs_storage.split_at_mut(GROUP_DIM * GROUP_DIM);
             let (coeffs_y, coeffs_b) = coeffs_y_b.split_at_mut(GROUP_DIM * GROUP_DIM);
-            coeffs_i32 = Some([coeffs_x, coeffs_y, coeffs_b]);
+            CoeffsMut::I32([coeffs_x, coeffs_y, coeffs_b])
         }
-    }
+    };
     let mut coeffs_offset = 0;
     let transform_buffer = &mut buffers.transform_buffer;
 
@@ -655,38 +618,39 @@ pub fn decode_vardct_group(
                     let permutation = &pass_info.coeff_orders[shape_id * 3 + c];
                     // Asserting once lets the compiler elide the bounds check on
                     // `permutation[k]` inside the loop given `k < num_coeffs`.
-                    if let Some(ref mut ci16) = coeffs_i16 {
-                        let current = &mut ci16[c][coeffs_offset..coeffs_offset + num_coeffs];
-                        assert!(permutation.len() >= num_coeffs);
-                        for k in num_blocks..num_coeffs {
-                            if nonzeros == 0 {
-                                break;
+                    assert!(permutation.len() >= num_coeffs);
+                    match &mut coeffs {
+                        CoeffsMut::I16(c_arr) => {
+                            let current = &mut c_arr[c][coeffs_offset..coeffs_offset + num_coeffs];
+                            for k in num_blocks..num_coeffs {
+                                if nonzeros == 0 {
+                                    break;
+                                }
+                                let ctx = histo_offset
+                                    + zero_density_context(nonzeros, k, log_num_blocks, prev);
+                                let coeff =
+                                    reader.read_signed_inline(&pass_info.histograms, br, ctx)
+                                        << *shift;
+                                prev = if coeff != 0 { 1 } else { 0 };
+                                nonzeros -= prev;
+                                current[permutation[k] as usize] += coeff as i16;
                             }
-                            let ctx = histo_offset
-                                + zero_density_context(nonzeros, k, log_num_blocks, prev);
-                            let coeff =
-                                reader.read_signed_inline(&pass_info.histograms, br, ctx) << *shift;
-                            prev = if coeff != 0 { 1 } else { 0 };
-                            nonzeros -= prev;
-                            let coeff_index = permutation[k] as usize;
-                            current[coeff_index] = current[coeff_index].wrapping_add(coeff as i16);
                         }
-                    } else {
-                        let current = &mut coeffs_i32.as_mut().unwrap()[c]
-                            [coeffs_offset..coeffs_offset + num_coeffs];
-                        assert!(permutation.len() >= num_coeffs);
-                        for k in num_blocks..num_coeffs {
-                            if nonzeros == 0 {
-                                break;
+                        CoeffsMut::I32(c_arr) => {
+                            let current = &mut c_arr[c][coeffs_offset..coeffs_offset + num_coeffs];
+                            for k in num_blocks..num_coeffs {
+                                if nonzeros == 0 {
+                                    break;
+                                }
+                                let ctx = histo_offset
+                                    + zero_density_context(nonzeros, k, log_num_blocks, prev);
+                                let coeff =
+                                    reader.read_signed_inline(&pass_info.histograms, br, ctx)
+                                        << *shift;
+                                prev = if coeff != 0 { 1 } else { 0 };
+                                nonzeros -= prev;
+                                current[permutation[k] as usize] += coeff;
                             }
-                            let ctx = histo_offset
-                                + zero_density_context(nonzeros, k, log_num_blocks, prev);
-                            let coeff =
-                                reader.read_signed_inline(&pass_info.histograms, br, ctx) << *shift;
-                            prev = if coeff != 0 { 1 } else { 0 };
-                            nonzeros -= prev;
-                            let coeff_index = permutation[k] as usize;
-                            current[coeff_index] += coeff;
                         }
                     }
                     if nonzeros != 0 {
@@ -695,71 +659,44 @@ pub fn decode_vardct_group(
                 }
             }
             if let Some(pixels) = pixels {
+                let qblock = match &coeffs {
+                    CoeffsMut::I16(c) => QBlock::I16([
+                        &c[0][coeffs_offset..],
+                        &c[1][coeffs_offset..],
+                        &c[2][coeffs_offset..],
+                    ]),
+                    CoeffsMut::I32(c) => QBlock::I32([
+                        &c[0][coeffs_offset..],
+                        &c[1][coeffs_offset..],
+                        &c[2][coeffs_offset..],
+                    ]),
+                };
                 let dequant_matrices = &hf_global.dequant_matrices;
-                if let Some(ref ci16) = coeffs_i16 {
-                    let qblock = [
-                        &ci16[0][coeffs_offset..],
-                        &ci16[1][coeffs_offset..],
-                        &ci16[2][coeffs_offset..],
-                    ];
-                    dequant_and_transform_to_pixels_dispatch_i16(
-                        quant_biases,
-                        x_dm_multiplier,
-                        b_dm_multiplier,
-                        pixels,
-                        scratch,
-                        inv_global_scale,
-                        transform_buffer,
-                        hshift,
-                        vshift,
-                        by,
-                        sby,
-                        bx,
-                        sbx,
-                        x_cc_mul,
-                        b_cc_mul,
-                        raw_quant,
-                        &lf_rects,
-                        transform_type,
-                        block_rect,
-                        num_blocks,
-                        num_coeffs,
-                        &qblock,
-                        dequant_matrices,
-                    )?;
-                } else {
-                    let ci32 = coeffs_i32.as_ref().unwrap();
-                    let qblock = [
-                        &ci32[0][coeffs_offset..],
-                        &ci32[1][coeffs_offset..],
-                        &ci32[2][coeffs_offset..],
-                    ];
-                    dequant_and_transform_to_pixels_dispatch(
-                        quant_biases,
-                        x_dm_multiplier,
-                        b_dm_multiplier,
-                        pixels,
-                        scratch,
-                        inv_global_scale,
-                        transform_buffer,
-                        hshift,
-                        vshift,
-                        by,
-                        sby,
-                        bx,
-                        sbx,
-                        x_cc_mul,
-                        b_cc_mul,
-                        raw_quant,
-                        &lf_rects,
-                        transform_type,
-                        block_rect,
-                        num_blocks,
-                        num_coeffs,
-                        &qblock,
-                        dequant_matrices,
-                    )?;
-                }
+                dequant_and_transform_to_pixels_dispatch(
+                    quant_biases,
+                    x_dm_multiplier,
+                    b_dm_multiplier,
+                    pixels,
+                    scratch,
+                    inv_global_scale,
+                    transform_buffer,
+                    hshift,
+                    vshift,
+                    by,
+                    sby,
+                    bx,
+                    sbx,
+                    x_cc_mul,
+                    b_cc_mul,
+                    raw_quant,
+                    &lf_rects,
+                    transform_type,
+                    block_rect,
+                    num_blocks,
+                    num_coeffs,
+                    qblock,
+                    dequant_matrices,
+                )?;
             }
             coeffs_offset += num_coeffs;
         }

--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -67,15 +67,16 @@ pub struct PassState {
 }
 
 pub(super) enum HfCoefficients {
-    I32(Image<i32>, Image<i32>, Image<i32>),
-    I16(Image<i16>, Image<i16>, Image<i16>),
+    None,
+    I32([Image<i32>; 3]),
+    I16([Image<i16>; 3]),
 }
 
 pub struct HfGlobalState {
     num_histograms: u32,
     passes: Vec<PassState>,
     dequant_matrices: DequantMatrices,
-    pub(super) hf_coefficients: Option<HfCoefficients>,
+    pub(super) hf_coefficients: HfCoefficients,
 }
 
 #[derive(Debug)]

--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -66,11 +66,16 @@ pub struct PassState {
     histograms: Histograms,
 }
 
+pub(super) enum HfCoefficients {
+    I32(Image<i32>, Image<i32>, Image<i32>),
+    I16(Image<i16>, Image<i16>, Image<i16>),
+}
+
 pub struct HfGlobalState {
     num_histograms: u32,
     passes: Vec<PassState>,
     dequant_matrices: DequantMatrices,
-    hf_coefficients: Option<(Image<i32>, Image<i32>, Image<i32>)>,
+    pub(super) hf_coefficients: Option<HfCoefficients>,
 }
 
 #[derive(Debug)]

--- a/jxl_simd/src/aarch64/neon.rs
+++ b/jxl_simd/src/aarch64/neon.rs
@@ -627,6 +627,15 @@ impl I32SimdVec for I32VecNeon {
     }
 
     #[inline(always)]
+    fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
+        // from the safety invariant on `d`. vld1_s16 loads 4 i16 values; vmovl_s16 sign-extends
+        // them to 4 i32 values.
+        Self(unsafe { vmovl_s16(vld1_s16(mem.as_ptr())) }, d)
+    }
+
+    #[inline(always)]
     fn store(&self, mem: &mut [i32]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available

--- a/jxl_simd/src/aarch64/neon.rs
+++ b/jxl_simd/src/aarch64/neon.rs
@@ -630,8 +630,7 @@ impl I32SimdVec for I32VecNeon {
     fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know neon is available
-        // from the safety invariant on `d`. vld1_s16 loads 4 i16 values; vmovl_s16 sign-extends
-        // them to 4 i32 values.
+        // from the safety invariant on `d`.
         Self(unsafe { vmovl_s16(vld1_s16(mem.as_ptr())) }, d)
     }
 

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -273,6 +273,10 @@ pub trait I32SimdVec:
     fn load(d: Self::Descriptor, mem: &[i32]) -> Self;
 
     // Requires `mem.len() >= Self::LEN` or it will panic.
+    // Sign-extends LEN i16 values from `mem` to Self.
+    fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self;
+
+    // Requires `mem.len() >= Self::LEN` or it will panic.
     fn store(&self, mem: &mut [i32]);
 
     fn abs(self) -> Self;

--- a/jxl_simd/src/scalar.rs
+++ b/jxl_simd/src/scalar.rs
@@ -240,6 +240,11 @@ impl I32SimdVec for Wrapping<i32> {
     }
 
     #[inline(always)]
+    fn load_from_i16(_d: Self::Descriptor, mem: &[i16]) -> Self {
+        Wrapping(mem[0] as i32)
+    }
+
+    #[inline(always)]
     fn store(&self, mem: &mut [i32]) {
         mem[0] = self.0;
     }

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -614,8 +614,7 @@ impl I32SimdVec for I32VecSimd128 {
     #[inline(always)]
     fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
         assert!(mem.len() >= Self::LEN);
-        // SAFETY: we just checked that `mem` has enough space. v128_load64_zero loads 8 bytes
-        // (4 i16) into the lower 64 bits; i32x4_extend_low_i16x8 sign-extends them to i32x4.
+        // SAFETY: we just checked that `mem` has enough space.
         Self(
             unsafe { i32x4_extend_low_i16x8(v128_load64_zero(mem.as_ptr().cast())) },
             d,

--- a/jxl_simd/src/wasm32/simd128.rs
+++ b/jxl_simd/src/wasm32/simd128.rs
@@ -612,6 +612,17 @@ impl I32SimdVec for I32VecSimd128 {
     }
 
     #[inline(always)]
+    fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space. v128_load64_zero loads 8 bytes
+        // (4 i16) into the lower 64 bits; i32x4_extend_low_i16x8 sign-extends them to i32x4.
+        Self(
+            unsafe { i32x4_extend_low_i16x8(v128_load64_zero(mem.as_ptr().cast())) },
+            d,
+        )
+    }
+
+    #[inline(always)]
     fn store(&self, mem: &mut [i32]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space.

--- a/jxl_simd/src/x86_64/avx.rs
+++ b/jxl_simd/src/x86_64/avx.rs
@@ -796,8 +796,7 @@ impl I32SimdVec for I32VecAvx {
     fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx2 is available
-        // from the safety invariant on `d`. _mm_loadu_si128 loads 16 bytes (8 i16);
-        // _mm256_cvtepi16_epi32 sign-extends them to 8 i32 values (AVX2).
+        // from the safety invariant on `d`.
         Self(
             unsafe { _mm256_cvtepi16_epi32(_mm_loadu_si128(mem.as_ptr().cast())) },
             d,

--- a/jxl_simd/src/x86_64/avx.rs
+++ b/jxl_simd/src/x86_64/avx.rs
@@ -793,6 +793,18 @@ impl I32SimdVec for I32VecAvx {
     }
 
     #[inline(always)]
+    fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx2 is available
+        // from the safety invariant on `d`. _mm_loadu_si128 loads 16 bytes (8 i16);
+        // _mm256_cvtepi16_epi32 sign-extends them to 8 i32 values (AVX2).
+        Self(
+            unsafe { _mm256_cvtepi16_epi32(_mm_loadu_si128(mem.as_ptr().cast())) },
+            d,
+        )
+    }
+
+    #[inline(always)]
     fn store(&self, mem: &mut [i32]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx is available

--- a/jxl_simd/src/x86_64/avx512.rs
+++ b/jxl_simd/src/x86_64/avx512.rs
@@ -979,8 +979,7 @@ impl I32SimdVec for I32VecAvx512 {
     fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available
-        // from the safety invariant on `d`. _mm256_loadu_si256 loads 32 bytes (16 i16);
-        // _mm512_cvtepi16_epi32 sign-extends them to 16 i32 values (AVX512F+BW).
+        // from the safety invariant on `d`.
         Self(
             unsafe { _mm512_cvtepi16_epi32(_mm256_loadu_si256(mem.as_ptr().cast())) },
             d,

--- a/jxl_simd/src/x86_64/avx512.rs
+++ b/jxl_simd/src/x86_64/avx512.rs
@@ -976,6 +976,18 @@ impl I32SimdVec for I32VecAvx512 {
     }
 
     #[inline(always)]
+    fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available
+        // from the safety invariant on `d`. _mm256_loadu_si256 loads 32 bytes (16 i16);
+        // _mm512_cvtepi16_epi32 sign-extends them to 16 i32 values (AVX512F+BW).
+        Self(
+            unsafe { _mm512_cvtepi16_epi32(_mm256_loadu_si256(mem.as_ptr().cast())) },
+            d,
+        )
+    }
+
+    #[inline(always)]
     fn store(&self, mem: &mut [i32]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know avx512f is available

--- a/jxl_simd/src/x86_64/sse42.rs
+++ b/jxl_simd/src/x86_64/sse42.rs
@@ -732,8 +732,7 @@ impl I32SimdVec for I32VecSse42 {
     fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available
-        // from the safety invariant on `d`. _mm_loadl_epi64 loads 8 bytes (4 i16) into the lower
-        // 64 bits; _mm_cvtepi16_epi32 sign-extends them to 4 i32 values.
+        // from the safety invariant on `d`.
         Self(
             unsafe { _mm_cvtepi16_epi32(_mm_loadl_epi64(mem.as_ptr().cast())) },
             d,

--- a/jxl_simd/src/x86_64/sse42.rs
+++ b/jxl_simd/src/x86_64/sse42.rs
@@ -729,6 +729,18 @@ impl I32SimdVec for I32VecSse42 {
     }
 
     #[inline(always)]
+    fn load_from_i16(d: Self::Descriptor, mem: &[i16]) -> Self {
+        assert!(mem.len() >= Self::LEN);
+        // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available
+        // from the safety invariant on `d`. _mm_loadl_epi64 loads 8 bytes (4 i16) into the lower
+        // 64 bits; _mm_cvtepi16_epi32 sign-extends them to 4 i32 values.
+        Self(
+            unsafe { _mm_cvtepi16_epi32(_mm_loadl_epi64(mem.as_ptr().cast())) },
+            d,
+        )
+    }
+
+    #[inline(always)]
     fn store(&self, mem: &mut [i32]) {
         assert!(mem.len() >= Self::LEN);
         // SAFETY: we just checked that `mem` has enough space. Moreover, we know sse4.2 is available


### PR DESCRIPTION
Does two TODOs, one small one in tf.rs, and a bigger one to use 16-bit HF coeff buffers (only relevant in case of progressive passes) instead of 32-bit ones.

Gives only an almost immeasurable speedup on my laptop, but a substantial memory reduction in case of multiple HF passes:

Before:
```
Decoded 333921030 pixels in 6.153 seconds: 54.271 MP/s
        6.39s real              6.35s user              0.02s sys
           236355584  maximum resident set size
```

After:
```
Decoded 333921030 pixels in 6.147 seconds: 54.322 MP/s
        6.38s real              6.35s user              0.01s sys
           154320896  maximum resident set size
```