### PR TITLE
Remove flush_output from modular decoding.

### DIFF
--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -259,7 +259,6 @@ impl Frame {
             was_flushed_once: false,
             vardct_buffers: None,
             groups_to_flush: BTreeSet::new(),
-            changed_since_last_flush: BTreeSet::new(),
             patches: Arc::new(AtomicRefCell::new(PatchesDictionary::new(
                 num_extra_channels,
             ))),

--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -175,14 +175,6 @@ pub struct HfMetadata {
     used_hf_types: u32,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum RenderUnit {
-    /// VarDCT data
-    VarDCT,
-    /// Modular channel with the given index
-    Modular(usize),
-}
-
 pub struct Frame {
     header: FrameHeader,
     toc: Toc,
@@ -208,7 +200,6 @@ pub struct Frame {
     last_rendered_pass: Vec<Option<usize>>,
     // Groups that should be rendered on the next call to flush().
     groups_to_flush: BTreeSet<usize>,
-    changed_since_last_flush: BTreeSet<(usize, RenderUnit)>,
     incomplete_groups: usize,
     patches: Arc<AtomicRefCell<PatchesDictionary>>,
     splines: Arc<AtomicRefCell<Splines>>,

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -970,27 +970,6 @@ impl FullModularImage {
         }
     }
 
-    pub fn flush_output(
-        &mut self,
-        group: usize,
-        chan: usize,
-        pass_to_pipeline: &mut dyn FnMut(usize, usize, bool, Image<i32>) -> Result<()>,
-    ) -> Result<()> {
-        if !self.can_do_partial_render() || !self.has_decoded_data {
-            return Ok(());
-        }
-        let buf_idx = self.buffers_for_channels[chan];
-        // Skip channels that don't have a real buffer assignment.
-        // buffers_for_channels is zero-filled on resize, so intermediate channels
-        // (e.g. G/B when modular_color_channels==1) may alias buffer 0 incorrectly.
-        if self.buffer_info[buf_idx].info.output_channel_idx != Some(chan) {
-            return Ok(());
-        }
-        self.maybe_output(buf_idx, group, false, &mut |chan, grid, complete, img| {
-            pass_to_pipeline(chan, grid, complete, img.unwrap())
-        })
-    }
-
     pub fn zero_fill_empty_channels(
         &mut self,
         num_passes: usize,

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -13,7 +13,6 @@ use crate::features::epf::SigmaSource;
 use crate::features::noise::Noise;
 use crate::features::patches::PatchesDictionary;
 use crate::features::spline::Splines;
-use crate::frame::RenderUnit;
 use crate::frame::color_correlation_map::ColorCorrelationParams;
 use crate::frame::quantizer::LfQuantFactors;
 use crate::headers::frame_header::Encoding;
@@ -150,6 +149,11 @@ impl Frame {
             buffers_from_api!(None);
         }
 
+        // TODO(veluca): extend this condition to other safe situations.
+        if self.header.encoding == Encoding::VarDCT && self.header.num_extra_channels == 0 {
+            pipeline!(self, p, p.allow_clearing_partial_buffers());
+        }
+
         // Temporarily remove the reference/lf frames to be saved; we will move them back once
         // rendering is done.
         let mut reference_frame_data = std::mem::take(&mut self.reference_frame_data);
@@ -208,7 +212,22 @@ impl Frame {
         // VarDCT data to be rendered.
         for (g, _) in groups.iter() {
             self.groups_to_flush.insert(*g);
-            pipeline!(self, p, p.mark_group_to_rerender(*g));
+            // mark color and noise channels, if any.
+            for c in 0..3 {
+                pipeline!(self, p, p.mark_group_channel_to_rerender(*g, c));
+            }
+            if self.header.has_noise() {
+                for nc in 0..3 {
+                    pipeline!(
+                        self,
+                        p,
+                        p.mark_group_channel_to_rerender(
+                            *g,
+                            self.header.num_extra_channels as usize + 3 + nc
+                        )
+                    );
+                }
+            }
         }
         // Modular data to be re-rendered.
         {
@@ -218,9 +237,9 @@ impl Frame {
                     modular_global.mark_group_to_be_read(2 + *pass, *group);
                 }
             }
-            let mut pass_to_pipeline = |_, group, _, _| {
+            let mut pass_to_pipeline = |c, group, _, _| {
                 self.groups_to_flush.insert(group);
-                pipeline!(self, p, p.mark_group_to_rerender(group));
+                pipeline!(self, p, p.mark_group_channel_to_rerender(group, c));
                 Ok(())
             };
             modular_global.process_output(&self.header, true, &mut pass_to_pipeline)?;
@@ -228,10 +247,7 @@ impl Frame {
 
         // STEP 3: decode the groups, eagerly rendering VarDCT channels and noise.
         for (group, mut passes) in groups {
-            if self.decode_hf_group(group, &mut passes, &mut buffer_splitter, do_flush)? {
-                self.changed_since_last_flush
-                    .insert((group, RenderUnit::VarDCT));
-            }
+            self.decode_hf_group(group, &mut passes, &mut buffer_splitter, do_flush)?;
         }
 
         // STEP 4: process all modular transforms that can now be processed,
@@ -240,8 +256,6 @@ impl Frame {
         if self.incomplete_groups == 0 || do_flush {
             let modular_global = &mut self.lf_global.as_mut().unwrap().modular_global;
             let mut pass_to_pipeline = |chan, group, complete, image: Option<Image<i32>>| {
-                self.changed_since_last_flush
-                    .insert((group, RenderUnit::Modular(chan)));
                 pipeline!(
                     self,
                     p,
@@ -256,37 +270,6 @@ impl Frame {
                 Ok(())
             };
             modular_global.process_output(&self.header, false, &mut pass_to_pipeline)?;
-
-            // STEP 5: re-render VarDCT/noise data in rendered groups for which it was
-            // not rendered, or re-send to pipeline modular channels that were not
-            // updated in those groups.
-            for g in std::mem::take(&mut self.groups_to_flush) {
-                if self
-                    .changed_since_last_flush
-                    .take(&(g, RenderUnit::VarDCT))
-                    .is_none()
-                {
-                    self.decode_hf_group(g, &mut [], &mut buffer_splitter, true)?;
-                }
-                let modular_global = &mut self.lf_global.as_mut().unwrap().modular_global;
-                let mut pass_to_pipeline = |chan, group, complete, image| {
-                    pipeline!(
-                        self,
-                        p,
-                        p.set_buffer_for_group(chan, group, complete, image, &mut buffer_splitter)?
-                    );
-                    Ok(())
-                };
-                for c in modular_global.channel_range() {
-                    if self
-                        .changed_since_last_flush
-                        .take(&(g, RenderUnit::Modular(c)))
-                        .is_none()
-                    {
-                        modular_global.flush_output(g, c, &mut pass_to_pipeline)?;
-                    }
-                }
-            }
         }
 
         let regions = buffer_splitter.into_changed_regions();

--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -19,17 +19,27 @@ pub(super) struct InputBuffer {
     pub(super) leftright: Vec<Option<OwnedRawImage>>,
     // Storage for top/bottom borders. Includes corners.
     pub(super) topbottom: Vec<Option<OwnedRawImage>>,
-    // Number of ready channels in the current pass.
+    // Bitmask of ready channels for the current render.
+    channel_is_ready: Vec<bool>,
     ready_channels: usize,
-    pub(super) is_ready: bool,
+    is_ready: bool,
     num_completed_groups_3x3: usize,
 }
 
 impl InputBuffer {
     pub(super) fn set_buffer(&mut self, chan: usize, buf: OwnedRawImage) {
-        assert!(self.data[chan].is_none());
         self.data[chan] = Some(buf);
-        self.ready_channels += 1;
+        if !self.channel_is_ready[chan] {
+            self.ready_channels += 1;
+        }
+        self.channel_is_ready[chan] = true;
+    }
+
+    pub(super) fn mark_not_ready(&mut self, chan: usize) {
+        if self.channel_is_ready[chan] {
+            self.ready_channels -= 1;
+        }
+        self.channel_is_ready[chan] = false;
     }
 
     pub(super) fn new(num_channels: usize) -> Self {
@@ -38,6 +48,7 @@ impl InputBuffer {
             data: b(),
             leftright: b(),
             topbottom: b(),
+            channel_is_ready: vec![false; num_channels],
             ready_channels: 0,
             is_ready: false,
             num_completed_groups_3x3: 0,
@@ -119,6 +130,7 @@ impl LowMemoryRenderPipeline {
     pub(super) fn render_with_new_group(
         &mut self,
         g: usize,
+        allow_clearing_partial_buffers: bool,
         buffer_splitter: &mut BufferSplitter,
     ) -> Result<()> {
         let buf = &mut self.input_buffers[g];
@@ -126,7 +138,6 @@ impl LowMemoryRenderPipeline {
         if buf.ready_channels != self.shared.num_used_channels() {
             return Ok(());
         }
-        buf.ready_channels = 0;
         let (gx, gy) = self.shared.group_position(g);
         debug!("new data ready for group {gx},{gy}");
 
@@ -279,16 +290,22 @@ impl LowMemoryRenderPipeline {
             Ok(())
         })?;
 
-        for c in 0..self.input_buffers[g].data.len() {
-            if let Some(b) = std::mem::take(&mut self.input_buffers[g].data[c]) {
-                self.store_scratch_buffer(c, 0, b);
+        let complete = self.shared.group_chan_complete[g].iter().all(|x| *x);
+
+        if allow_clearing_partial_buffers || complete {
+            self.input_buffers[g].ready_channels = 0;
+            self.input_buffers[g].channel_is_ready.fill(false);
+            for c in 0..self.input_buffers[g].data.len() {
+                if let Some(b) = std::mem::take(&mut self.input_buffers[g].data[c]) {
+                    self.store_scratch_buffer(c, 0, b);
+                }
             }
         }
 
         // Clear border buffers that will not be used again.
         // This is certainly the case if *all* the groups in the 3x3 group area around
         // the current group are complete.
-        if self.shared.group_chan_complete[g].iter().all(|x| *x) {
+        if complete {
             for g in [
                 gym1 * gw + gxm1,
                 gym1 * gw + gx,

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -61,6 +61,7 @@ pub struct LowMemoryRenderPipeline {
     // could be reused to store group data for that channel.
     // Indexed by [3*channel] = center, [3*channel+1] = topbottom, [3*channel+2] = leftright.
     scratch_channel_buffers: Vec<Vec<OwnedRawImage>>,
+    allow_clearing_partial_buffers: bool,
 }
 
 impl RenderPipeline for LowMemoryRenderPipeline {
@@ -282,7 +283,12 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             opaque_alpha_buffers,
             sorted_buffer_indices,
             scratch_channel_buffers: (0..nc * 3).map(|_| vec![]).collect(),
+            allow_clearing_partial_buffers: false,
         })
+    }
+
+    fn allow_clearing_partial_buffers(&mut self) {
+        self.allow_clearing_partial_buffers = true;
     }
 
     #[instrument(skip_all, err)]
@@ -312,7 +318,11 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             self.input_buffers[group_id].set_buffer(channel, buf.into_raw());
             self.shared.group_chan_complete[group_id][channel] = complete;
 
-            self.render_with_new_group(group_id, buffer_splitter)?;
+            self.render_with_new_group(
+                group_id,
+                self.allow_clearing_partial_buffers,
+                buffer_splitter,
+            )?;
         }
         Ok(())
     }
@@ -416,8 +426,8 @@ impl RenderPipeline for LowMemoryRenderPipeline {
         Ok(())
     }
 
-    fn mark_group_to_rerender(&mut self, g: usize) {
-        self.input_buffers[g].is_ready = false;
+    fn mark_group_channel_to_rerender(&mut self, g: usize, c: usize) {
+        self.input_buffers[g].mark_not_ready(c);
     }
 
     fn box_inout_stage<S: super::RenderPipelineInOutStage>(

--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -119,13 +119,20 @@ pub(crate) trait RenderPipeline: Sized {
 
     fn new_from_shared(shared: RenderPipelineShared<Self::Buffer>) -> Result<Self>;
 
+    /// Informs the pipeline that it is allowed to clear partial buffers after rendering
+    /// a group. By default, that only happens once the known-last render happens for
+    /// a certain group.
+    /// This should only be set if we know that we cannot ask to render only a subset
+    /// of the channels for a group in a single render pass.
+    fn allow_clearing_partial_buffers(&mut self);
+
     /// Obtains a buffer suitable for storing the input in channel `channel`.
     /// This *might* be a buffer that was used to store that channel for that group in a previous
     /// pass, a new buffer, or a re-used buffer from i.e. previously decoded frames.
     fn get_buffer<T: ImageDataType>(&mut self, channel: usize) -> Result<Image<T>>;
 
     /// Gives back the buffer for a channel and group to the render pipeline, marking whether
-    /// this will be the last time that this function is called for this group.
+    /// this will be the last time that this function is called for this group and channel.
     fn set_buffer_for_group<T: ImageDataType>(
         &mut self,
         channel: usize,
@@ -143,8 +150,8 @@ pub(crate) trait RenderPipeline: Sized {
     /// implementation to ensure rendering only happens once.
     fn render_outside_frame(&mut self, buffer_splitter: &mut BufferSplitter) -> Result<()>;
 
-    // Marks a group for being re-rendered later.
-    fn mark_group_to_rerender(&mut self, g: usize);
+    // Marks a group and channel for needing to be updated before the next re-render.
+    fn mark_group_channel_to_rerender(&mut self, g: usize, c: usize);
 
     fn box_inout_stage<S: RenderPipelineInOutStage>(
         stage: S,

--- a/jxl/src/render/simple_pipeline/mod.rs
+++ b/jxl/src/render/simple_pipeline/mod.rs
@@ -199,7 +199,9 @@ impl RenderPipeline for SimpleRenderPipeline {
         Ok(())
     }
 
-    fn mark_group_to_rerender(&mut self, _g: usize) {}
+    fn mark_group_channel_to_rerender(&mut self, _g: usize, _c: usize) {}
+
+    fn allow_clearing_partial_buffers(&mut self) {}
 
     fn box_inout_stage<S: RenderPipelineInOutStage>(
         stage: S,


### PR DESCRIPTION
This modifies the render pipeline buffer clearing logic to remove the need for calling flush_output. This will allow simplifying the modular buffer handling logic in a later PR.