### PR TITLE
Return error when flushing without pixel format

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -2034,6 +2034,16 @@ pub(crate) mod tests {
         }
     }
 
+    /// Regression test for Chromium ClusterFuzz issue 526010666.
+    #[test]
+    fn test_flush_pixels_without_pixel_format_no_panic_526010666() {
+        let mut decoder = JxlDecoderInner::new(JxlDecoderOptions::default());
+        let mut pixels = [0u8; 4];
+        let output = JxlOutputBuffer::new(&mut pixels, 1, 4);
+        let err = decoder.flush_pixels(&mut [output]).unwrap_err();
+        assert!(matches!(err, crate::error::Error::PixelFormatNotSet));
+    }
+
     /// Small regression test for issue #728: squeeze transform boundary bug.
     #[test]
     fn test_squeeze_boundary_minimal() {

--- a/jxl/src/api/inner/codestream_parser/mod.rs
+++ b/jxl/src/api/inner/codestream_parser/mod.rs
@@ -385,7 +385,9 @@ impl CodestreamParser {
         do_flush: bool,
     ) -> Result<()> {
         if let Some(output_buffers) = &output_buffers {
-            let px = self.pixel_format.as_ref().unwrap();
+            let Some(px) = self.pixel_format.as_ref() else {
+                return Err(Error::PixelFormatNotSet);
+            };
             let expected_len = std::iter::once(&px.color_data_format)
                 .chain(px.extra_channel_format.iter())
                 .filter(|x| x.is_some())

--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -263,6 +263,8 @@ pub enum Error {
     IccTableSizeExceeded(usize),
     #[error("I/O error: {0}")]
     IOError(#[from] std::io::Error),
+    #[error("Output pixel format is not set")]
+    PixelFormatNotSet,
     #[error("Wrong buffer count: {0} buffers given, {1} buffers expected")]
     WrongBufferCount(usize, usize),
     #[error("Image is not grayscale, but grayscale output was requested")]


### PR DESCRIPTION
Chromium's blink_jxl_decoder_fuzzer found that `flush_pixels` can be reached before the inner decoder has reached the point where the output pixel format is set. That path panicked at `pixel_format.unwrap()` instead of returning a decoder error.

Return a normal `PixelFormatNotSet` error instead, which callers can already handle as decode failure. The regression test covers `flush_pixels` before pixel format setup.

https://issues.chromium.org/issues/526010666