### PR TITLE
srgb_to_linear, srgb_to_linear_simd: Multiply by reciprocal instead of dividing

### DIFF
--- a/jxl/src/color/tf.rs
+++ b/jxl/src/color/tf.rs
@@ -65,7 +65,7 @@ pub fn srgb_to_linear(samples: &mut [f32]) {
     for x in samples {
         let a = x.abs();
         *x = if a <= 0.04045 {
-            a / 12.92
+            a * (1.0 / 12.92)
         } else {
             eval_rational_poly(a, P, Q)
         }
@@ -99,7 +99,7 @@ pub fn srgb_to_linear_simd<D: SimdDescriptor>(d: D, samples: &mut [f32]) {
         D::F32Vec::splat(d, 0.04045)
             .gt(a)
             .if_then_else_f32(
-                a / D::F32Vec::splat(d, 12.92),
+                a * D::F32Vec::splat(d, 1.0 / 12.92),
                 eval_rational_poly_simd(d, a, P, Q),
             )
             .copysign(x)


### PR DESCRIPTION
This should result in a minor speedup for `srgb_to_linear_simd` (I only see the non-SIMD function called in a test). `cargo test` doesn't show any regressions compared to the main branch.