### PR TITLE
Add flake.nix for Nix dev shell and checks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,115 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1784407669,
+        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1784361593,
+        "narHash": "sha256-K1ym8vyrGxSZ8/SgQVyXWlBysVuJyEC5L25jPaq6PwQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "480c95c3c9ca478e857f7153639010fb54ec73e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784275547,
+        "narHash": "sha256-VFi+Fy9hYOcA75NayRMOjkWfg1bxIQRZ/N/4Kv9Z7sc=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "1649637a9c68a8f371d2e1326bbd15d36a8a74a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,129 @@
+{
+  inputs = {
+    crane.url = "github:ipetkov/crane";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    {
+      self,
+      crane,
+      fenix,
+      flake-utils,
+      nixpkgs,
+      ...
+    }:
+
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        fenix' = fenix.packages.${system};
+
+        rustBuildToolchain = fenix'.stable.withComponents [
+          "cargo"
+          "clippy"
+          "rustc"
+          "rustfmt"
+          "rust-src"
+        ];
+
+        rustDevToolchain = fenix'.combine [
+          rustBuildToolchain
+          fenix'.rust-analyzer # nightly rust-analyzer
+        ];
+
+        rustMiriToolchain = fenix'.complete.withComponents [
+          "cargo"
+          "clippy"
+          "miri"
+          "rustc"
+          "rustfmt"
+          "rust-analyzer"
+          "rust-src"
+        ];
+
+        mkCraneLib = (crane.mkLib pkgs).overrideToolchain;
+
+        mkShellForToolchain =
+          toolchain:
+          (mkCraneLib toolchain).devShell {
+            checks = self.checks.${system};
+
+            packages = with pkgs; [
+              pkg-config
+              nixfmt
+              nixfmt-tree
+              rustPlatform.bindgenHook
+            ];
+          };
+
+        buildCraneLib = mkCraneLib rustBuildToolchain;
+
+        jxlFilter = path: type: builtins.match ".*jxl$" path != null;
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type: (jxlFilter path type) || (buildCraneLib.filterCargoSources path type);
+          name = "source";
+        };
+
+        commonBuildArgs = {
+          pname = "jxl-rs-workspace";
+          version = "0.0.0";
+
+          inherit src;
+          strictDeps = true;
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            rustPlatform.bindgenHook
+          ];
+        };
+        cargoArtifacts = buildCraneLib.buildDepsOnly commonBuildArgs;
+      in
+      {
+        checks = {
+          jxl-rs-clippy-all-features = buildCraneLib.cargoClippy (
+            commonBuildArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets --all-features --tests --all -- -D warnings";
+            }
+          );
+
+          jxl-rs-clippy-no-features = buildCraneLib.cargoClippy (
+            commonBuildArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets --no-default-features --tests --all -- -D warnings";
+            }
+          );
+
+          jxl-rs-nextest = buildCraneLib.cargoNextest (
+            commonBuildArgs
+            // {
+              inherit cargoArtifacts;
+            }
+          );
+
+          jxl-rs-fmt = buildCraneLib.cargoFmt {
+            pname = "jxl-rs-workspace";
+            version = "0.0.0";
+
+            inherit src;
+          };
+        };
+
+        # Setup fenix binary cache (https://app.cachix.org/cache/fenix) for faster builds
+        devShells = {
+          default = mkShellForToolchain rustDevToolchain;
+          miri = mkShellForToolchain rustMiriToolchain;
+        };
+      }
+    );
+}


### PR DESCRIPTION
Upstreaming changes I was using personally.

Devshell should start without local binary builds, if fenix cache is set up correctly. `nix flake check` can be used for linting and testing locally.