### PR TITLE
Fix group border detection in render pipeline

### DIFF
--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -254,7 +254,9 @@ impl LowMemoryRenderPipeline {
 
             let y1 = match (gy + 1 == self.shared.group_count.1, yrange.end) {
                 (true, 3) => group_rect.end().1,
-                (false, 3) => group_rect.end().1 + self.border_size.1,
+                (false, 3) => {
+                    (group_rect.end().1 + self.border_size.1).min(self.shared.input_size.1)
+                }
                 (_, 2) => group_rect.end().1 - self.border_size.1,
                 // (_, 1)
                 _ => group_rect.origin.1 + self.border_size.1,
@@ -262,7 +264,9 @@ impl LowMemoryRenderPipeline {
 
             let x1 = match (gx + 1 == self.shared.group_count.0, xrange.end) {
                 (true, 3) => group_rect.end().0,
-                (false, 3) => group_rect.end().0 + self.border_size.0,
+                (false, 3) => {
+                    (group_rect.end().0 + self.border_size.0).min(self.shared.input_size.0)
+                }
                 (_, 2) => group_rect.end().0 - self.border_size.0,
                 // (_, 1)
                 _ => group_rect.origin.0 + self.border_size.0,

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -300,7 +300,7 @@ impl LowMemoryRenderPipeline {
                         let borderx = s.border().0 as usize;
                         let bordery = s.border().1 as isize;
                         // Apply x padding.
-                        if gx == 0 && borderx != 0 {
+                        if (gx == 0 || image_area.origin.0 == 0) && borderx != 0 {
                             for (si, ci) in self.stage_input_buffer_index[i].iter() {
                                 for iy in -bordery..=bordery {
                                     let y = mirror(y as isize + iy, shifted_ysize);
@@ -315,7 +315,10 @@ impl LowMemoryRenderPipeline {
                                 }
                             }
                         }
-                        if gx + 1 == self.shared.group_count.0 && borderx != 0 {
+                        if (gx + 1 == self.shared.group_count.0
+                            || image_area.end().0 == self.shared.input_size.0)
+                            && borderx != 0
+                        {
                             for (si, ci) in self.stage_input_buffer_index[i].iter() {
                                 for iy in -bordery..=bordery {
                                     let y = mirror(y as isize + iy, shifted_ysize);


### PR DESCRIPTION
The second-to-last group in a row could still include the image border if the amount of border is greater than the last group.

This PR makes the computation of "are we on a border" more precise.