### PR TITLE
Improve handling of input buffers in the render pipeline

### DIFF
--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -293,6 +293,14 @@ impl Frame {
             }
         }
 
+        if self.header.encoding == Encoding::VarDCT {
+            for (group, _) in groups.iter() {
+                if self.group_status.channel_status[*group][0] == DataStatus::Final {
+                    pipeline!(self, p, p.mark_group_to_rerender(*group));
+                }
+            }
+        }
+
         // STEP 3: Run all the transforms that could be run already.
         // We do this because some modular images might not have coded channels in HF, so
         // all the coded channels were already decoded and the modular decoder does not
@@ -310,7 +318,7 @@ impl Frame {
                 },
             );
             self.group_status.need_vardct_flush.insert(g);
-            if should_render_non_final {
+            if should_render_non_final || is_final {
                 pipeline!(self, p, p.mark_group_to_rerender(g));
             }
         });

--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::ops::Range;
+use std::sync::atomic::Ordering;
 
 use crate::error::Result;
 use crate::image::{OwnedRawImage, Rect};
@@ -11,39 +12,6 @@ use crate::render::LowMemoryRenderPipeline;
 use crate::render::buffer_splitter::BufferSplitter;
 use crate::render::internal::{ChannelInfo, Stage};
 use crate::util::tracing_wrappers::*;
-
-pub(super) struct InputBuffer {
-    // One buffer per channel.
-    pub(super) data: Vec<Option<OwnedRawImage>>,
-    // Storage for left/right borders. Includes corners.
-    pub(super) leftright: Vec<Option<OwnedRawImage>>,
-    // Storage for top/bottom borders. Includes corners.
-    pub(super) topbottom: Vec<Option<OwnedRawImage>>,
-    // Number of ready channels in the current pass.
-    ready_channels: usize,
-    pub(super) is_ready: bool,
-    num_completed_groups_3x3: usize,
-}
-
-impl InputBuffer {
-    pub(super) fn set_buffer(&mut self, chan: usize, buf: OwnedRawImage) {
-        assert!(self.data[chan].is_none(), "chan: {chan}");
-        self.data[chan] = Some(buf);
-        self.ready_channels += 1;
-    }
-
-    pub(super) fn new(num_channels: usize) -> Self {
-        let b = || (0..num_channels).map(|_| None).collect();
-        Self {
-            data: b(),
-            leftright: b(),
-            topbottom: b(),
-            ready_channels: 0,
-            is_ready: false,
-            num_completed_groups_3x3: 0,
-        }
-    }
-}
 
 // Finds a small set of rectangles that cover all the "true" values in `ready_mask`,
 // and calls `f` on each such rectangle.
@@ -134,9 +102,9 @@ impl LowMemoryRenderPipeline {
         g: usize,
         buffer_splitter: &mut BufferSplitter,
     ) -> Result<()> {
-        let buf = &mut self.input_buffers[g];
-        assert!(buf.ready_channels <= self.shared.num_used_channels());
-        if buf.ready_channels != self.shared.num_used_channels() {
+        let buf = self.input_buffers.get(g);
+        assert!(buf.ready_channels.load(Ordering::Relaxed) <= self.shared.num_used_channels());
+        if buf.ready_channels.load(Ordering::Relaxed) != self.shared.num_used_channels() {
             return Ok(());
         }
         let (gx, gy) = self.shared.group_position(g);
@@ -158,88 +126,59 @@ impl LowMemoryRenderPipeline {
         }
         .clip(self.shared.input_size);
 
-        {
-            for c in 0..self.shared.num_channels() {
-                if !self.shared.channel_is_used[c] {
-                    continue;
-                }
-                let (bx, by) = self.border_size;
-                let (sx, sy) = self.input_buffers[g].data[c].as_ref().unwrap().byte_size();
-                let ChannelInfo {
-                    ty,
-                    downsample: (dx, dy),
-                } = self.shared.channel_info[0][c];
-                let ty = ty.unwrap();
-                let bx = bx >> dx;
-                let by = by >> dy;
-                let mut topbottom = if let Some(b) = self.input_buffers[g].topbottom[c].take() {
-                    b
-                } else if let Some(b) = self.maybe_get_scratch_buffer(c, 1) {
-                    b
-                } else {
-                    let height = 4 * by;
-                    let width = (1 << self.shared.log_group_size) * ty.size();
-                    OwnedRawImage::new_zeroed_with_padding((width, height), (0, 0), (0, 0))?
-                };
-                let mut leftright = if let Some(b) = self.input_buffers[g].leftright[c].take() {
-                    b
-                } else if let Some(b) = self.maybe_get_scratch_buffer(c, 2) {
-                    b
-                } else {
-                    let height = 1 << self.shared.log_group_size;
-                    let width = 4 * bx * ty.size();
-                    OwnedRawImage::new_zeroed_with_padding((width, height), (0, 0), (0, 0))?
-                };
-                let input = self.input_buffers[g].data[c].as_ref().unwrap();
-                if by != 0 {
-                    for y in 0..(2 * by).min(sy) {
-                        topbottom.row_mut(y)[..sx].copy_from_slice(input.row(y));
-                        topbottom.row_mut(4 * by - 1 - y)[..sx]
-                            .copy_from_slice(input.row(sy - y - 1));
-                    }
-                }
-                if bx != 0 {
-                    let cs = (bx * 2 * ty.size()).min(sx);
-                    for y in 0..sy {
-                        let row_out = leftright.row_mut(y);
-                        let row_in = input.row(y);
-                        row_out[..cs].copy_from_slice(&row_in[..cs]);
-                        row_out[4 * bx * ty.size() - cs..].copy_from_slice(&row_in[sx - cs..]);
-                    }
-                }
-                self.input_buffers[g].leftright[c] = Some(leftright);
-                self.input_buffers[g].topbottom[c] = Some(topbottom);
+        for c in 0..self.shared.num_channels() {
+            if !self.shared.channel_is_used[c] {
+                continue;
             }
-            self.input_buffers[g].is_ready = true;
+            let (bx, by) = self.border_size;
+            let (sx, sy) = buf.data[c].borrow().as_ref().unwrap().byte_size();
+            let ChannelInfo {
+                ty,
+                downsample: (dx, dy),
+            } = self.shared.channel_info[0][c];
+            let ty = ty.unwrap();
+            let bx = bx >> dx;
+            let by = by >> dy;
+            let mut topbottom = if let Some(b) = buf.topbottom[c].borrow_mut().take() {
+                b
+            } else if let Some(b) = self.maybe_get_scratch_buffer(c, 1) {
+                b
+            } else {
+                let height = 4 * by;
+                let width = (1 << self.shared.log_group_size) * ty.size();
+                OwnedRawImage::new_zeroed_with_padding((width, height), (0, 0), (0, 0))?
+            };
+            let mut leftright = if let Some(b) = buf.leftright[c].borrow_mut().take() {
+                b
+            } else if let Some(b) = self.maybe_get_scratch_buffer(c, 2) {
+                b
+            } else {
+                let height = 1 << self.shared.log_group_size;
+                let width = 4 * bx * ty.size();
+                OwnedRawImage::new_zeroed_with_padding((width, height), (0, 0), (0, 0))?
+            };
+            let data = &buf.data[c].borrow();
+            let input = data.as_ref().unwrap();
+            if by != 0 {
+                for y in 0..(2 * by).min(sy) {
+                    topbottom.row_mut(y)[..sx].copy_from_slice(input.row(y));
+                    topbottom.row_mut(4 * by - 1 - y)[..sx].copy_from_slice(input.row(sy - y - 1));
+                }
+            }
+            if bx != 0 {
+                let cs = (bx * 2 * ty.size()).min(sx);
+                for y in 0..sy {
+                    let row_out = leftright.row_mut(y);
+                    let row_in = input.row(y);
+                    row_out[..cs].copy_from_slice(&row_in[..cs]);
+                    row_out[4 * bx * ty.size() - cs..].copy_from_slice(&row_in[sx - cs..]);
+                }
+            }
+            *buf.leftright[c].borrow_mut() = Some(leftright);
+            *buf.topbottom[c].borrow_mut() = Some(topbottom);
         }
 
-        let gxm1 = gx.saturating_sub(1);
-        let gym1 = gy.saturating_sub(1);
-        let gxp1 = (gx + 1).min(self.shared.group_count.0 - 1);
-        let gyp1 = (gy + 1).min(self.shared.group_count.1 - 1);
-        let gw = self.shared.group_count.0;
-        // TODO(veluca): this code probably needs to be adapted for multithreading.
-        let mut ready_mask = [
-            self.input_buffers[gym1 * gw + gxm1].is_ready,
-            self.input_buffers[gym1 * gw + gx].is_ready,
-            self.input_buffers[gym1 * gw + gxp1].is_ready,
-            self.input_buffers[gy * gw + gxm1].is_ready,
-            self.input_buffers[gy * gw + gx].is_ready, // should be guaranteed to be 1.
-            self.input_buffers[gy * gw + gxp1].is_ready,
-            self.input_buffers[gyp1 * gw + gxm1].is_ready,
-            self.input_buffers[gyp1 * gw + gx].is_ready,
-            self.input_buffers[gyp1 * gw + gxp1].is_ready,
-        ];
-        // We can only render a corner if we have all the 4 adjacent groups. Thus, mask out corners if
-        // the corresponding side buffers are not ready.
-        ready_mask[0] &= ready_mask[1];
-        ready_mask[0] &= ready_mask[3];
-        ready_mask[2] &= ready_mask[1];
-        ready_mask[2] &= ready_mask[5];
-        ready_mask[6] &= ready_mask[3];
-        ready_mask[6] &= ready_mask[7];
-        ready_mask[8] &= ready_mask[5];
-        ready_mask[8] &= ready_mask[7];
+        let ready_mask = self.input_buffers.mark_ready(g);
 
         let mut data = self.per_thread_data.get();
         data.ensure_populated(self)?;
@@ -302,58 +241,10 @@ impl LowMemoryRenderPipeline {
             Ok(())
         })?;
 
-        drop(data);
-
-        let all_finalized = (0..self.shared.num_channels())
-            .filter(|&c| self.shared.channel_is_used[c])
-            .all(|c| self.shared.group_chan_complete[g][c]);
-
-        let mut preserved_count = 0;
-        for c in 0..self.input_buffers[g].data.len() {
-            if !self.shared.channel_is_used[c] {
-                continue;
-            }
-            let is_finalized = self.shared.group_chan_complete[g][c];
-            let preserve = is_finalized && !all_finalized;
-            if !preserve {
-                if let Some(b) = std::mem::take(&mut self.input_buffers[g].data[c]) {
-                    self.store_scratch_buffer(c, 0, b);
-                }
-            } else {
-                preserved_count += 1;
-            }
-        }
-        self.input_buffers[g].ready_channels = preserved_count;
-
-        // Clear border buffers that will not be used again.
-        // This is certainly the case if *all* the groups in the 3x3 group area around
-        // the current group are complete.
-        if self.shared.group_chan_complete[g].iter().all(|x| *x) {
-            for g in [
-                gym1 * gw + gxm1,
-                gym1 * gw + gx,
-                gym1 * gw + gxp1,
-                gy * gw + gxm1,
-                gy * gw + gx,
-                gy * gw + gxp1,
-                gyp1 * gw + gxm1,
-                gyp1 * gw + gx,
-                gyp1 * gw + gxp1,
-            ] {
-                self.input_buffers[g].num_completed_groups_3x3 += 1;
-                if self.input_buffers[g].num_completed_groups_3x3 != 9 {
-                    continue;
-                }
-                for c in 0..self.input_buffers[g].data.len() {
-                    if let Some(b) = std::mem::take(&mut self.input_buffers[g].topbottom[c]) {
-                        self.store_scratch_buffer(c, 1, b);
-                    }
-                    if let Some(b) = std::mem::take(&mut self.input_buffers[g].leftright[c]) {
-                        self.store_scratch_buffer(c, 2, b);
-                    }
-                }
-            }
-        }
+        self.input_buffers
+            .mark_done(g, &self.shared, |channel, kind, image| {
+                self.store_scratch_buffer(channel, kind, image)
+            });
 
         Ok(())
     }

--- a/jxl/src/render/low_memory_pipeline/input_buffers.rs
+++ b/jxl/src/render/low_memory_pipeline/input_buffers.rs
@@ -1,0 +1,211 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+
+use crate::error::Result;
+use crate::image::OwnedRawImage;
+use crate::render::internal::RenderPipelineShared;
+use crate::render::low_memory_pipeline::row_buffers::RowBuffer;
+use crate::util::{AtomicRefCell, NewWithCapacity};
+
+pub(super) struct InputBuffer {
+    // One buffer per channel.
+    pub(super) data: Vec<AtomicRefCell<Option<OwnedRawImage>>>,
+    // Storage for left/right borders. Includes corners.
+    pub(super) leftright: Vec<AtomicRefCell<Option<OwnedRawImage>>>,
+    // Storage for top/bottom borders. Includes corners.
+    pub(super) topbottom: Vec<AtomicRefCell<Option<OwnedRawImage>>>,
+    // Number of ready channels in the current pass.
+    pub(super) ready_channels: AtomicUsize,
+    is_ready: AtomicBool,
+}
+
+impl InputBuffer {
+    pub(super) fn set_buffer(&self, chan: usize, buf: OwnedRawImage) {
+        assert!(!self.is_ready.load(Ordering::Relaxed));
+        assert!(self.data[chan].borrow_mut().is_none(), "chan: {chan}");
+        *self.data[chan].borrow_mut() = Some(buf);
+        self.ready_channels.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(super) fn new(num_channels: usize) -> Self {
+        let b = || {
+            (0..num_channels)
+                .map(|_| AtomicRefCell::new(None))
+                .collect()
+        };
+        Self {
+            data: b(),
+            leftright: b(),
+            topbottom: b(),
+            ready_channels: AtomicUsize::new(0),
+            is_ready: AtomicBool::new(false),
+        }
+    }
+}
+
+pub(super) struct InputBuffers {
+    buffers: Vec<InputBuffer>,
+    // We use the cell that would map to the buffer itself to keep
+    // track of the number of complete groups in its neighbourhood.
+    remaining_flags: Vec<AtomicU8>,
+    size: (usize, usize),
+}
+
+impl InputBuffers {
+    fn increase_borders(flags: &[AtomicU8], (gx, gy): (usize, usize), (xs, _): (usize, usize)) {
+        let stride = xs * 2 + 1;
+        let center = (gy * 2 + 1) * stride + gx * 2 + 1;
+        flags[center - stride - 1].fetch_add(1, Ordering::Relaxed);
+        flags[center - stride].fetch_add(1, Ordering::Relaxed);
+        flags[center - stride + 1].fetch_add(1, Ordering::Relaxed);
+        flags[center - 1].fetch_add(1, Ordering::Relaxed);
+        flags[center + 1].fetch_add(1, Ordering::Relaxed);
+        flags[center + stride - 1].fetch_add(1, Ordering::Relaxed);
+        flags[center + stride].fetch_add(1, Ordering::Relaxed);
+        flags[center + stride + 1].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn mark_not_ready(&mut self, group: usize) {
+        if !self.buffers[group]
+            .is_ready
+            .fetch_and(false, Ordering::Relaxed)
+        {
+            return;
+        }
+        let gx = group % self.size.0;
+        let gy = group / self.size.0;
+        Self::increase_borders(&self.remaining_flags, (gx, gy), self.size);
+    }
+
+    pub fn mark_ready(&self, group: usize) -> [bool; 9] {
+        assert!(
+            !self.buffers[group]
+                .is_ready
+                .fetch_or(true, Ordering::Relaxed)
+        );
+        let gx = group % self.size.0;
+        let gy = group / self.size.0;
+        let stride = self.size.0 * 2 + 1;
+        let center = (gy * 2 + 1) * stride + gx * 2 + 1;
+        [
+            self.remaining_flags[center - stride - 1].fetch_sub(1, Ordering::AcqRel) == 1,
+            self.remaining_flags[center - stride].fetch_sub(1, Ordering::AcqRel) == 1,
+            self.remaining_flags[center - stride + 1].fetch_sub(1, Ordering::AcqRel) == 1,
+            self.remaining_flags[center - 1].fetch_sub(1, Ordering::AcqRel) == 1,
+            true,
+            self.remaining_flags[center + 1].fetch_sub(1, Ordering::AcqRel) == 1,
+            self.remaining_flags[center + stride - 1].fetch_sub(1, Ordering::AcqRel) == 1,
+            self.remaining_flags[center + stride].fetch_sub(1, Ordering::AcqRel) == 1,
+            self.remaining_flags[center + stride + 1].fetch_sub(1, Ordering::AcqRel) == 1,
+        ]
+    }
+
+    pub fn get(&self, group: usize) -> &InputBuffer {
+        &self.buffers[group]
+    }
+
+    pub fn mark_done(
+        &self,
+        group: usize,
+        shared: &RenderPipelineShared<RowBuffer>,
+        store_buf: impl Fn(usize, usize, OwnedRawImage),
+    ) {
+        let gx = group % self.size.0;
+        let gy = group / self.size.0;
+        let gxm1 = gx.saturating_sub(1);
+        let gym1 = gy.saturating_sub(1);
+        let gxp1 = (gx + 1).min(shared.group_count.0 - 1);
+        let gyp1 = (gy + 1).min(shared.group_count.1 - 1);
+        let gw = shared.group_count.0;
+
+        let all_finalized = (0..shared.num_channels())
+            .filter(|&c| shared.channel_is_used[c])
+            .all(|c| shared.group_chan_complete[group][c]);
+
+        {
+            let data = &self.buffers[group].data;
+            let mut preserved_count = 0;
+            for c in 0..data.len() {
+                if !shared.channel_is_used[c] {
+                    continue;
+                }
+                let is_finalized = shared.group_chan_complete[group][c];
+                let preserve = is_finalized && !all_finalized;
+                if !preserve {
+                    if let Some(b) = std::mem::take(&mut *data[c].borrow_mut()) {
+                        store_buf(c, 0, b);
+                    }
+                } else {
+                    preserved_count += 1;
+                }
+            }
+            self.buffers[group]
+                .ready_channels
+                .store(preserved_count, Ordering::Relaxed);
+        }
+
+        // Clear border buffers that will not be used again.
+        // This is certainly the case if *all* the groups in the 3x3 group area around
+        // the current group are complete.
+        if shared.group_chan_complete[group].iter().all(|x| *x) {
+            for g in [
+                gym1 * gw + gxm1,
+                gym1 * gw + gx,
+                gym1 * gw + gxp1,
+                gy * gw + gxm1,
+                gy * gw + gx,
+                gy * gw + gxp1,
+                gyp1 * gw + gxm1,
+                gyp1 * gw + gx,
+                gyp1 * gw + gxp1,
+            ] {
+                let gx = g % self.size.0;
+                let gy = g / self.size.0;
+                let idx = (gy * 2 + 1) * (2 * self.size.0 + 1) + gx * 2 + 1;
+                if self.remaining_flags[idx].fetch_add(1, Ordering::AcqRel) != 8 {
+                    continue;
+                }
+                for c in 0..self.buffers[g].data.len() {
+                    if let Some(b) = std::mem::take(&mut *self.buffers[g].topbottom[c].borrow_mut())
+                    {
+                        store_buf(c, 1, b);
+                    }
+                    if let Some(b) = std::mem::take(&mut *self.buffers[g].leftright[c].borrow_mut())
+                    {
+                        store_buf(c, 2, b);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn new(nc: usize, size: (usize, usize)) -> Result<Self> {
+        let bufs = size.0 * size.1;
+        let mut buffers = Vec::new_with_capacity(bufs)?;
+        for _ in 0..bufs {
+            buffers.push(InputBuffer::new(nc));
+        }
+
+        let grids = (2 * size.0 + 1) * (2 * size.1 + 1);
+        let mut remaining_flags = Vec::new_with_capacity(grids)?;
+        for _ in 0..grids {
+            remaining_flags.push(AtomicU8::new(0));
+        }
+
+        for gy in 0..size.1 {
+            for gx in 0..size.0 {
+                Self::increase_borders(&remaining_flags, (gx, gy), size);
+            }
+        }
+
+        Ok(Self {
+            buffers,
+            remaining_flags,
+            size,
+        })
+    }
+}

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -14,7 +14,7 @@ use crate::error::Result;
 use crate::image::{DataTypeTag, Image, ImageDataType, OwnedRawImage, Rect};
 use crate::render::buffer_splitter::{BufferSplitter, SaveStageBufferInfo};
 use crate::render::internal::Stage;
-use crate::render::low_memory_pipeline::group_scheduler::InputBuffer;
+use crate::render::low_memory_pipeline::input_buffers::InputBuffers;
 use crate::render::{ErasedLocalState, MAX_BORDER};
 use crate::util::{AtomicRefCell, PerThreadStorage, ShiftRightCeil, tracing_wrappers::*};
 
@@ -23,6 +23,7 @@ use super::internal::{RenderPipelineShared, RunInOutStage, RunInPlaceStage};
 
 mod group_scheduler;
 mod helpers;
+mod input_buffers;
 mod render_group;
 pub(crate) mod row_buffers;
 mod run_stage;
@@ -85,7 +86,7 @@ impl LowMemoryRenderPipelinePerThread {
 pub struct LowMemoryRenderPipeline {
     shared: RenderPipelineShared<RowBuffer>,
     per_thread_data: PerThreadStorage<LowMemoryRenderPipelinePerThread>,
-    input_buffers: Vec<InputBuffer>,
+    input_buffers: InputBuffers,
     next_border_and_cur_downsample: Vec<Vec<(u8, (u8, u8))>>,
     save_buffer_info: Vec<Option<SaveStageBufferInfo>>,
     // The input buffer that each channel of each stage should use.
@@ -122,11 +123,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
     type Buffer = RowBuffer;
 
     fn new_from_shared(shared: RenderPipelineShared<Self::Buffer>) -> Result<Self> {
-        let mut input_buffers = vec![];
         let nc = shared.num_channels();
-        for _ in 0..shared.group_chan_complete.len() {
-            input_buffers.push(InputBuffer::new(nc));
-        }
         let mut previous_inout: Vec<_> = (0..nc).map(|x| (0usize, x)).collect();
         let mut stage_input_buffer_index = vec![];
         let mut next_border_and_cur_downsample = vec![vec![]];
@@ -293,7 +290,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
         }
 
         Ok(Self {
-            input_buffers,
+            input_buffers: InputBuffers::new(nc, shared.group_count)?,
             stage_input_buffer_index,
             next_border_and_cur_downsample,
             per_thread_data: PerThreadStorage::new(|| LowMemoryRenderPipelinePerThread {
@@ -338,7 +335,9 @@ impl RenderPipeline for LowMemoryRenderPipeline {
                 channel,
                 T::DATA_TYPE_ID,
             );
-            self.input_buffers[group_id].set_buffer(channel, buf.into_raw());
+            self.input_buffers
+                .get(group_id)
+                .set_buffer(channel, buf.into_raw());
             self.shared.group_chan_complete[group_id][channel] = complete;
 
             self.render_with_new_group(group_id, buffer_splitter)?;
@@ -456,7 +455,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             .all(|c| self.shared.group_chan_complete[g][c]);
         // The caller will feed back in all the non-ready channels.
         if !all_finalized {
-            self.input_buffers[g].is_ready = false;
+            self.input_buffers.mark_not_ready(g);
         }
     }
 

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -15,7 +15,7 @@ use crate::{
             LowMemoryRenderPipelinePerThread, helpers::get_distinct_indices, run_stage::ExtraInfo,
         },
     },
-    util::{ChannelVec, ShiftRightCeil, mirror, tracing_wrappers::*},
+    util::{AtomicRef, AtomicRefCell, ChannelVec, ShiftRightCeil, mirror, tracing_wrappers::*},
 };
 
 use super::{LowMemoryRenderPipeline, row_buffers::RowBuffer};
@@ -71,7 +71,7 @@ struct BufferFiller<'a> {
     group_ysize: usize,
     top_y_offset: usize,
     bot_y_offset: usize,
-    images: [Option<&'a OwnedRawImage>; 9],
+    images: [Option<AtomicRef<'a, OwnedRawImage>>; 9],
     copy_byte_offset_initial: usize,
     src_byte_offset_left_topbottom: usize,
     src_byte_offset_left_center: usize,
@@ -147,7 +147,7 @@ impl<'a> BufferFiller<'a> {
 
         let gw = rp.shared.group_count.0;
 
-        let mut images: [Option<&'a OwnedRawImage>; 9] = [None; 9];
+        let mut images: [Option<AtomicRef<OwnedRawImage>>; 9] = std::array::from_fn(|_| None);
 
         let has_left = copy_x0 < group_x0;
         let has_right = copy_x1 > group_x1;
@@ -161,36 +161,42 @@ impl<'a> BufferFiller<'a> {
         let src_byte_offset_left_topbottom = group_xsize * ty.size() - to_copy_left;
         let src_byte_offset_left_center = 4 * (bx >> dx) * ty.size() - to_copy_left;
 
+        fn make_ref(
+            g: &AtomicRefCell<Option<OwnedRawImage>>,
+        ) -> Option<AtomicRef<'_, OwnedRawImage>> {
+            Some(AtomicRef::map(g.borrow(), |x| x.as_ref().unwrap()))
+        }
+
         if has_top {
             let base_gid = (gy - 1) * gw + gx;
             if has_left {
-                images[0] = rp.input_buffers[base_gid - 1].topbottom[c].as_ref();
+                images[0] = make_ref(&rp.input_buffers.get(base_gid - 1).topbottom[c]);
             }
-            images[1] = rp.input_buffers[base_gid].topbottom[c].as_ref();
+            images[1] = make_ref(&rp.input_buffers.get(base_gid).topbottom[c]);
             if has_right {
-                images[2] = rp.input_buffers[base_gid + 1].topbottom[c].as_ref();
+                images[2] = make_ref(&rp.input_buffers.get(base_gid + 1).topbottom[c]);
             }
         }
 
         if has_center {
             let base_gid = gy * gw + gx;
             if has_left {
-                images[3] = rp.input_buffers[base_gid - 1].leftright[c].as_ref();
+                images[3] = make_ref(&rp.input_buffers.get(base_gid - 1).leftright[c]);
             }
-            images[4] = rp.input_buffers[base_gid].data[c].as_ref();
+            images[4] = make_ref(&rp.input_buffers.get(base_gid).data[c]);
             if has_right {
-                images[5] = rp.input_buffers[base_gid + 1].leftright[c].as_ref();
+                images[5] = make_ref(&rp.input_buffers.get(base_gid + 1).leftright[c]);
             }
         }
 
         if has_bot {
             let base_gid = (gy + 1) * gw + gx;
             if has_left {
-                images[6] = rp.input_buffers[base_gid - 1].topbottom[c].as_ref();
+                images[6] = make_ref(&rp.input_buffers.get(base_gid - 1).topbottom[c]);
             }
-            images[7] = rp.input_buffers[base_gid].topbottom[c].as_ref();
+            images[7] = make_ref(&rp.input_buffers.get(base_gid).topbottom[c]);
             if has_right {
-                images[8] = rp.input_buffers[base_gid + 1].topbottom[c].as_ref();
+                images[8] = make_ref(&rp.input_buffers.get(base_gid + 1).topbottom[c]);
             }
         }
 
@@ -248,7 +254,7 @@ impl<'a> BufferFiller<'a> {
         let output_row = data.row_buffers[0][self.c].get_row_mut::<u8>(y);
         let mut copy_byte_offset = self.copy_byte_offset_initial;
 
-        if let Some(left_buf) = self.images[base] {
+        if let Some(left_buf) = &self.images[base] {
             let input_row = left_buf.row(input_y);
             let src_byte_offset = if row_idx != 1 {
                 self.src_byte_offset_left_topbottom
@@ -260,13 +266,13 @@ impl<'a> BufferFiller<'a> {
             copy_byte_offset += self.to_copy_left;
         }
 
-        let center_buf = self.images[base + 1].unwrap();
+        let center_buf = self.images[base + 1].as_ref().unwrap();
         let input_row = center_buf.row(input_y);
         output_row[copy_byte_offset..copy_byte_offset + self.to_copy_main]
             .copy_from_slice(&input_row[self.copy_start..self.copy_end]);
         copy_byte_offset += self.to_copy_main;
 
-        if let Some(right_buf) = self.images[base + 2] {
+        if let Some(right_buf) = &self.images[base + 2] {
             let input_row = right_buf.row(input_y);
             output_row[copy_byte_offset..copy_byte_offset + self.to_copy_right]
                 .copy_from_slice(&input_row[..self.to_copy_right]);

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use crate::{
     api::JxlOutputBuffer,
     error::Result,
-    image::{DataTypeTag, Rect},
+    image::{DataTypeTag, OwnedRawImage, Rect},
     render::{
         internal::{ChannelInfo, Stage},
         low_memory_pipeline::{
@@ -64,116 +64,220 @@ fn apply_x_padding(
     }
 }
 
-impl LowMemoryRenderPipeline {
-    fn fill_initial_buffers(
-        &self,
-        data: &mut LowMemoryRenderPipelinePerThread,
+struct BufferFiller<'a> {
+    c: usize,
+    ty: DataTypeTag,
+    group_y0: usize,
+    group_ysize: usize,
+    top_y_offset: usize,
+    bot_y_offset: usize,
+    images: [Option<&'a OwnedRawImage>; 9],
+    copy_byte_offset_initial: usize,
+    src_byte_offset_left_topbottom: usize,
+    src_byte_offset_left_center: usize,
+    to_copy_left: usize,
+    copy_start: usize,
+    copy_end: usize,
+    to_copy_main: usize,
+    to_copy_right: usize,
+    padding_range: Option<(isize, isize)>,
+}
+
+impl<'a> BufferFiller<'a> {
+    fn new(
+        rp: &'a LowMemoryRenderPipeline,
         c: usize,
-        y: usize,
         (x0, xsize): (usize, usize),
         (gx, gy): (usize, usize),
-    ) {
-        if !self.shared.channel_is_used[c] {
-            return;
+        vyrange: Range<usize>,
+    ) -> Option<Self> {
+        if !rp.shared.channel_is_used[c] || vyrange.is_empty() {
+            return None;
         }
         let ChannelInfo {
             ty,
             downsample: (dx, dy),
-        } = self.shared.channel_info[0][c];
+        } = rp.shared.channel_info[0][c];
         let ty = ty.expect("Channel info should be populated at this point");
-        let group_ysize = 1 << (self.shared.log_group_size - dy as usize);
-        let group_xsize = 1 << (self.shared.log_group_size - dx as usize);
 
-        let (bx, by) = self.border_size;
+        let scaled_y_border = rp.input_border_pixels[c].1 << dy;
+        let stage_vy_start = vyrange.start as isize - scaled_y_border as isize;
+        let stage_vy_end = (vyrange.end as isize - 1) + scaled_y_border as isize;
+        let min_y = stage_vy_start >> dy;
+        let max_y = stage_vy_end >> dy;
+        let max_valid_y = rp.shared.input_size.1.shrc(dy) as isize - 1;
 
-        let group_y0 = gy * group_ysize;
-        let group_x0 = gx << (self.shared.log_group_size - dx as usize);
-        let group_x1 = group_x0 + group_xsize;
-
-        let (input_y, igy, is_topbottom) = if y < group_y0 {
-            (y + (by >> dy) * 4 - group_y0, gy - 1, true)
-        } else if y >= group_y0 + group_ysize {
-            (y - group_y0 - group_ysize, gy + 1, true)
+        let yrange = if max_y < 0 || min_y > max_valid_y {
+            0..0
         } else {
-            (y - group_y0, gy, false)
+            let start = min_y.max(0) as usize;
+            let end = (max_y.min(max_valid_y) as usize) + 1;
+            start..end
         };
 
-        let output_row = data.row_buffers[0][c].get_row_mut::<u8>(y);
+        if yrange.is_empty() {
+            return None;
+        }
 
-        let copy_x0 = x0.saturating_sub(self.input_border_pixels[c].0);
+        let x0 = x0 >> dx;
+        let xsize = xsize >> dx;
+        let group_ysize = 1 << (rp.shared.log_group_size - dy as usize);
+        let group_xsize = 1 << (rp.shared.log_group_size - dx as usize);
+
+        let (bx, by) = rp.border_size;
+
+        let group_y0 = gy * group_ysize;
+        let group_x0 = gx << (rp.shared.log_group_size - dx as usize);
+        let group_x1 = group_x0 + group_xsize;
+
+        let top_y_offset = (by >> dy) * 4;
+        let bot_y_offset = group_y0 + group_ysize;
+
+        let has_top = yrange.start < group_y0;
+        let has_center = yrange.start < group_y0 + group_ysize && yrange.end > group_y0;
+        let has_bot = yrange.end > group_y0 + group_ysize;
+
+        let copy_x0 = x0.saturating_sub(rp.input_border_pixels[c].0);
         let copy_x1 =
-            (x0 + xsize + self.input_border_pixels[c].0).min(self.shared.input_size.0.shrc(dx));
+            (x0 + xsize + rp.input_border_pixels[c].0).min(rp.shared.input_size.0.shrc(dx));
 
         debug_assert!(copy_x1 >= group_x0);
 
-        let mut copy_byte_offset = RowBuffer::x0_byte_offset() - (x0 - copy_x0) * ty.size();
+        let copy_byte_offset_initial = RowBuffer::x0_byte_offset() - (x0 - copy_x0) * ty.size();
 
-        let base_gid = igy * self.shared.group_count.0 + gx;
+        let gw = rp.shared.group_count.0;
 
-        // Previous group horizontally, if needed.
-        if copy_x0 < group_x0 {
-            let (input_buf, xs) = if is_topbottom {
-                (
-                    self.input_buffers[base_gid - 1].topbottom[c]
-                        .as_ref()
-                        .unwrap(),
-                    group_xsize,
-                )
-            } else {
-                (
-                    self.input_buffers[base_gid - 1].leftright[c]
-                        .as_ref()
-                        .unwrap(),
-                    4 * (bx >> dx),
-                )
-            };
-            let input_row = input_buf.row(input_y);
+        let mut images: [Option<&'a OwnedRawImage>; 9] = [None; 9];
 
-            let to_copy = (group_x0 - copy_x0) * ty.size();
-            let src_byte_offset = xs * ty.size() - to_copy;
+        let has_left = copy_x0 < group_x0;
+        let has_right = copy_x1 > group_x1;
 
-            output_row[copy_byte_offset..copy_byte_offset + to_copy]
-                .copy_from_slice(&input_row[src_byte_offset..src_byte_offset + to_copy]);
-            copy_byte_offset += to_copy;
-        }
-        let input_buf = if is_topbottom {
-            self.input_buffers[base_gid].topbottom[c].as_ref().unwrap()
+        let to_copy_left = if has_left {
+            (group_x0 - copy_x0) * ty.size()
         } else {
-            self.input_buffers[base_gid].data[c].as_ref().unwrap()
+            0
         };
-        let input_row = input_buf.row(input_y);
+
+        let src_byte_offset_left_topbottom = group_xsize * ty.size() - to_copy_left;
+        let src_byte_offset_left_center = 4 * (bx >> dx) * ty.size() - to_copy_left;
+
+        if has_top {
+            let base_gid = (gy - 1) * gw + gx;
+            if has_left {
+                images[0] = rp.input_buffers[base_gid - 1].topbottom[c].as_ref();
+            }
+            images[1] = rp.input_buffers[base_gid].topbottom[c].as_ref();
+            if has_right {
+                images[2] = rp.input_buffers[base_gid + 1].topbottom[c].as_ref();
+            }
+        }
+
+        if has_center {
+            let base_gid = gy * gw + gx;
+            if has_left {
+                images[3] = rp.input_buffers[base_gid - 1].leftright[c].as_ref();
+            }
+            images[4] = rp.input_buffers[base_gid].data[c].as_ref();
+            if has_right {
+                images[5] = rp.input_buffers[base_gid + 1].leftright[c].as_ref();
+            }
+        }
+
+        if has_bot {
+            let base_gid = (gy + 1) * gw + gx;
+            if has_left {
+                images[6] = rp.input_buffers[base_gid - 1].topbottom[c].as_ref();
+            }
+            images[7] = rp.input_buffers[base_gid].topbottom[c].as_ref();
+            if has_right {
+                images[8] = rp.input_buffers[base_gid + 1].topbottom[c].as_ref();
+            }
+        }
+
         let copy_start = copy_x0.saturating_sub(group_x0) * ty.size();
         let copy_end = (copy_x1.min(group_x1) - group_x0) * ty.size();
-        let to_copy = copy_end - copy_start;
-        output_row[copy_byte_offset..copy_byte_offset + to_copy]
-            .copy_from_slice(&input_row[copy_start..copy_end]);
-        copy_byte_offset += to_copy;
-        // Next group horizontally, if any.
-        if copy_x1 > group_x1 {
-            let input_buf = if is_topbottom {
-                self.input_buffers[base_gid + 1].topbottom[c]
-                    .as_ref()
-                    .unwrap()
-            } else {
-                self.input_buffers[base_gid + 1].leftright[c]
-                    .as_ref()
-                    .unwrap()
-            };
-            let input_row = input_buf.row(input_y);
-            let dx = self.shared.channel_info[0][c].downsample.0;
-            let gid = gy * self.shared.group_count.0 + gx;
-            let next_group_xsize = self.shared.group_size(gid + 1).0.shrc(dx);
+        let to_copy_main = copy_end - copy_start;
+
+        let (to_copy_right, padding_range) = if has_right {
+            let gid = gy * gw + gx;
+            let next_group_xsize = rp.shared.group_size(gid + 1).0.shrc(dx);
             let border_x = (copy_x1 - group_x1).min(next_group_xsize);
-            output_row[copy_byte_offset..copy_byte_offset + border_x * ty.size()]
-                .copy_from_slice(&input_row[..border_x * ty.size()]);
-            if border_x + group_x1 < copy_x1 {
+            let to_copy_right = border_x * ty.size();
+            let pad = if border_x + group_x1 < copy_x1 {
                 let pad_from = (xsize + border_x) as isize;
                 let pad_to = (xsize + copy_x1 - group_x1) as isize;
-                apply_x_padding(ty, output_row, pad_from..pad_to, 0..pad_from);
+                Some((pad_from, pad_to))
+            } else {
+                None
+            };
+            (to_copy_right, pad)
+        } else {
+            (0, None)
+        };
+
+        Some(Self {
+            c,
+            ty,
+            group_y0,
+            group_ysize,
+            top_y_offset,
+            bot_y_offset,
+            images,
+            copy_byte_offset_initial,
+            src_byte_offset_left_topbottom,
+            src_byte_offset_left_center,
+            to_copy_left,
+            copy_start,
+            copy_end,
+            to_copy_main,
+            to_copy_right,
+            padding_range,
+        })
+    }
+
+    fn fill(&self, data: &mut LowMemoryRenderPipelinePerThread, y: usize) {
+        let (row_idx, input_y) = if y < self.group_y0 {
+            (0, y + self.top_y_offset - self.group_y0)
+        } else if y >= self.group_y0 + self.group_ysize {
+            (2, y - self.bot_y_offset)
+        } else {
+            (1, y - self.group_y0)
+        };
+
+        let base = row_idx * 3;
+        let output_row = data.row_buffers[0][self.c].get_row_mut::<u8>(y);
+        let mut copy_byte_offset = self.copy_byte_offset_initial;
+
+        if let Some(left_buf) = self.images[base] {
+            let input_row = left_buf.row(input_y);
+            let src_byte_offset = if row_idx != 1 {
+                self.src_byte_offset_left_topbottom
+            } else {
+                self.src_byte_offset_left_center
+            };
+            output_row[copy_byte_offset..copy_byte_offset + self.to_copy_left]
+                .copy_from_slice(&input_row[src_byte_offset..src_byte_offset + self.to_copy_left]);
+            copy_byte_offset += self.to_copy_left;
+        }
+
+        let center_buf = self.images[base + 1].unwrap();
+        let input_row = center_buf.row(input_y);
+        output_row[copy_byte_offset..copy_byte_offset + self.to_copy_main]
+            .copy_from_slice(&input_row[self.copy_start..self.copy_end]);
+        copy_byte_offset += self.to_copy_main;
+
+        if let Some(right_buf) = self.images[base + 2] {
+            let input_row = right_buf.row(input_y);
+            output_row[copy_byte_offset..copy_byte_offset + self.to_copy_right]
+                .copy_from_slice(&input_row[..self.to_copy_right]);
+            if let Some((pad_from, pad_to)) = self.padding_range {
+                apply_x_padding(self.ty, output_row, pad_from..pad_to, 0..pad_from);
             }
         }
     }
+}
 
+impl LowMemoryRenderPipeline {
     // Renders *parts* of group's worth of data.
     // In particular, renders the sub-rectangle given in `image_area`, where (1, 1) refers to
     // the center of the group, and 0 and 2 include data from the neighbouring group (if any).
@@ -206,14 +310,21 @@ impl LowMemoryRenderPipeline {
         let vy0 = y0.saturating_sub(num_extra_rows);
         let vy1 = image_area.end().1 + num_extra_rows;
 
+        let fillers: ChannelVec<_> = (0..num_channels)
+            .map(|c| BufferFiller::new(self, c, (x0, xsize), (gx, gy), y0..image_area.end().1))
+            .collect();
+
         for vy in vy0..vy1 {
             let mut current_origin = (0, 0);
             let mut current_size = self.shared.input_size;
 
             // Step 1: read input channels.
             for c in 0..num_channels {
+                let Some(filler) = &fillers[c] else {
+                    continue;
+                };
                 // Same logic as below, but adapted to the input stage.
-                let (dx, dy) = self.shared.channel_info[0][c].downsample;
+                let (_, dy) = self.shared.channel_info[0][c].downsample;
                 let scaled_y_border = self.input_border_pixels[c].1 << dy;
                 let stage_vy = vy as isize - num_extra_rows as isize + scaled_y_border as isize;
                 if stage_vy % (1 << dy) != 0 {
@@ -228,7 +339,7 @@ impl LowMemoryRenderPipeline {
                     continue;
                 }
                 let y = y as usize;
-                self.fill_initial_buffers(data, c, y, (x0 >> dx, xsize >> dx), (gx, gy));
+                filler.fill(data, y);
             }
             // Step 2: go through stages one by one.
             for (i, stage) in self.shared.stages.iter().enumerate() {


### PR DESCRIPTION
The two commits in this PR:
1) separate part of the fill_input_buffer logic out to a precomputation phase
2) switch input buffers to AtomicRefCell
3) add an assertion that the buffer is not ready when setting a channel in it, and fix a lack of mark_group_to_rerender that caused the assert to trigger.