### PR TITLE
Make the render pipeline interface MT-friendly

### DIFF
--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -557,7 +557,7 @@ impl Frame {
         &mut self,
         group: usize,
         complete: bool,
-        buffer_splitter: &mut BufferSplitter,
+        buffer_splitter: &BufferSplitter,
     ) -> Result<()> {
         // TODO(sboukortt): consider making this a dedicated stage
         // TODO(veluca): SIMD.
@@ -670,7 +670,7 @@ impl Frame {
         &mut self,
         group: usize,
         passes: &mut [(usize, BitReader)],
-        buffer_splitter: &mut BufferSplitter,
+        buffer_splitter: &BufferSplitter,
         force_render: bool,
     ) -> Result<()> {
         // Group was fully rendered already, nothing to do.
@@ -777,7 +777,7 @@ impl Frame {
         &mut self,
         group: usize,
         passes: &mut [(usize, BitReader)],
-        buffer_splitter: &mut BufferSplitter,
+        buffer_splitter: &BufferSplitter,
         force_render: bool,
     ) -> Result<()> {
         if passes.is_empty() {
@@ -786,11 +786,11 @@ impl Frame {
 
         self.decode_and_render_varct_and_noise(group, passes, buffer_splitter, force_render)?;
 
-        let mut pass_to_pipeline = |chan, group, complete, image: Image<i32>| {
+        let pass_to_pipeline = |chan, group, complete, image: Image<i32>| {
             pipeline!(
                 self,
                 p,
-                p.set_buffer_for_group(chan, group, complete, image, &mut *buffer_splitter)?
+                p.set_buffer_for_group(chan, group, complete, image, &*buffer_splitter)?
             );
             Ok(())
         };
@@ -802,7 +802,7 @@ impl Frame {
                 &self.header,
                 &lf_global.tree,
                 br,
-                Some(&mut pass_to_pipeline),
+                Some(&pass_to_pipeline),
             )?;
         }
 

--- a/jxl/src/frame/lf_preview.rs
+++ b/jxl/src/frame/lf_preview.rs
@@ -11,7 +11,7 @@ use crate::{
     image::{DataTypeTag, Rect},
     render::{
         Channels, ChannelsMut, RenderPipelineInOutStage, RenderPipelineInPlaceStage,
-        buffer_splitter::{BufferSplitter, SaveStageBufferInfo},
+        buffer_splitter::{BufferSplitter, OutputChannelRef, SaveStageBufferInfo},
         low_memory_pipeline::row_buffers::RowBuffer,
         save::SaveStage,
         stages::{
@@ -31,7 +31,7 @@ impl Frame {
         rect: Rect,
         upsampled_rect: Rect,
         orientation: Orientation,
-        output_buffers: &mut [Option<JxlOutputBuffer<'_>>],
+        output_buffers: &mut [Option<OutputChannelRef>],
         full_size: (usize, usize),
         output_color_info: &OutputColorInfo,
         output_tf: &TransferFunction,
@@ -357,7 +357,7 @@ impl Frame {
         };
         let info = [Some(info)];
         let mut bufs = [Some(JxlOutputBuffer::reborrow(&mut output_buffers[0]))];
-        let mut bufs = BufferSplitter::new(&mut bufs);
+        let bufs = BufferSplitter::new(&mut bufs);
         for r in regions {
             let upsampled_rect = Rect {
                 size: (r.size.0 * 8, r.size.1 * 8),

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -567,7 +567,7 @@ impl FullModularImage {
         frame_header: &FrameHeader,
         global_tree: &Option<Tree>,
         br: &mut BitReader,
-        pass_to_pipeline: Option<&mut dyn FnMut(usize, usize, bool, Image<i32>) -> Result<()>>,
+        pass_to_pipeline: Option<&dyn Fn(usize, usize, bool, Image<i32>) -> Result<()>>,
     ) -> Result<()> {
         if self.buffer_info.is_empty() {
             info!("No modular channels to decode");
@@ -752,7 +752,7 @@ impl FullModularImage {
         &mut self,
         frame_header: &FrameHeader,
         tfm: usize,
-        pass_to_pipeline: &mut dyn FnMut(usize, usize, bool, Image<i32>) -> Result<()>,
+        pass_to_pipeline: &dyn Fn(usize, usize, bool, Image<i32>) -> Result<()>,
     ) -> Result<()> {
         self.transform_steps[tfm].do_run(
             frame_header,
@@ -778,7 +778,7 @@ impl FullModularImage {
     pub fn run_all_transforms(
         &mut self,
         frame_header: &FrameHeader,
-        pass_to_pipeline: &mut dyn FnMut(usize, usize, bool, Image<i32>) -> Result<()>,
+        pass_to_pipeline: &dyn Fn(usize, usize, bool, Image<i32>) -> Result<()>,
     ) -> Result<()> {
         while let Some(t) = self.ready_transform_steps.pop() {
             self.run_transform(frame_header, t, pass_to_pipeline)?;

--- a/jxl/src/frame/modular/transforms/step.rs
+++ b/jxl/src/frame/modular/transforms/step.rs
@@ -265,7 +265,7 @@ impl TransformStepChunk {
         frame_header: &FrameHeader,
         buffers: &[ModularBufferInfo],
         tranform_scratch_space: &mut TransformScratchSpace,
-        pass_to_pipeline: &mut dyn FnMut(usize, usize, bool, Image<i32>) -> Result<()>,
+        pass_to_pipeline: &dyn Fn(usize, usize, bool, Image<i32>) -> Result<()>,
     ) -> Result<()> {
         let is_final = self.missing_final_deps == 0;
         let buf_out = self.buf_out();

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 #[cfg(test)]
-macro_rules! pipeline {
+macro_rules! pipeline_mut {
     ($frame: expr, $pipeline: ident, $op: expr) => {
         if $frame.use_simple_pipeline {
             let $pipeline = $frame
@@ -59,9 +59,41 @@ macro_rules! pipeline {
 }
 
 #[cfg(not(test))]
-macro_rules! pipeline {
+macro_rules! pipeline_mut {
     ($frame: expr, $pipeline: ident, $op: expr) => {{
         let $pipeline = $frame.render_pipeline.as_mut().unwrap();
+        $op
+    }};
+}
+
+#[cfg(test)]
+macro_rules! pipeline {
+    ($frame: expr, $pipeline: ident, $op: expr) => {
+        if $frame.use_simple_pipeline {
+            let $pipeline = $frame
+                .render_pipeline
+                .as_ref()
+                .unwrap()
+                .downcast_ref::<SimpleRenderPipeline>()
+                .unwrap();
+            $op
+        } else {
+            use crate::render::LowMemoryRenderPipeline;
+            let $pipeline = $frame
+                .render_pipeline
+                .as_ref()
+                .unwrap()
+                .downcast_ref::<LowMemoryRenderPipeline>()
+                .unwrap();
+            $op
+        }
+    };
+}
+
+#[cfg(not(test))]
+macro_rules! pipeline {
+    ($frame: expr, $pipeline: ident, $op: expr) => {{
+        let $pipeline = $frame.render_pipeline.as_ref().unwrap();
         $op
     }};
 }
@@ -184,17 +216,17 @@ impl Frame {
             }));
         };
 
-        pipeline!(self, p, p.check_buffer_sizes(&mut buffers[..])?);
+        pipeline_mut!(self, p, p.check_buffer_sizes(&mut buffers[..])?);
 
-        let mut buffer_splitter = BufferSplitter::new(&mut buffers[..]);
+        let buffer_splitter = BufferSplitter::new(&mut buffers[..]);
 
-        pipeline!(self, p, p.render_outside_frame(&mut buffer_splitter)?);
+        pipeline_mut!(self, p, p.render_outside_frame(&buffer_splitter)?);
 
         let should_render_non_final = self.allow_rendering_before_last_pass() && do_flush;
 
         let modular_global = &mut self.lf_global.as_mut().unwrap().modular_global;
 
-        modular_global.set_pipeline_used_channels(pipeline!(self, p, p.used_channel_mask()));
+        modular_global.set_pipeline_used_channels(pipeline_mut!(self, p, p.used_channel_mask()));
 
         // STEP 1: figure out what modular buffers will be finalized during this decode, and mark them
         // as such.
@@ -265,7 +297,7 @@ impl Frame {
         if should_render_non_final {
             if self.header.encoding == Encoding::VarDCT {
                 for group in self.group_status.need_vardct_flush.iter() {
-                    pipeline!(self, p, p.mark_group_to_rerender(*group));
+                    pipeline_mut!(self, p, p.mark_group_to_rerender(*group));
                     modular_global.request_rerender(&self.header, *group);
                 }
             }
@@ -296,7 +328,7 @@ impl Frame {
         if self.header.encoding == Encoding::VarDCT {
             for (group, _) in groups.iter() {
                 if self.group_status.channel_status[*group][0] == DataStatus::Final {
-                    pipeline!(self, p, p.mark_group_to_rerender(*group));
+                    pipeline_mut!(self, p, p.mark_group_to_rerender(*group));
                 }
             }
         }
@@ -319,24 +351,24 @@ impl Frame {
             );
             self.group_status.need_vardct_flush.insert(g);
             if should_render_non_final || is_final {
-                pipeline!(self, p, p.mark_group_to_rerender(g));
+                pipeline_mut!(self, p, p.mark_group_to_rerender(g));
             }
         });
 
-        let mut pass_to_pipeline = |chan, group, complete, image: Image<i32>| {
+        let pass_to_pipeline = |chan, group, complete, image: Image<i32>| {
             pipeline!(
                 self,
                 p,
-                p.set_buffer_for_group(chan, group, complete, image, &mut buffer_splitter)?
+                p.set_buffer_for_group(chan, group, complete, image, &buffer_splitter)?
             );
             Ok(())
         };
 
-        modular_global.run_all_transforms(&self.header, &mut pass_to_pipeline)?;
+        modular_global.run_all_transforms(&self.header, &pass_to_pipeline)?;
 
         // STEP 4: decode the groups, eagerly decoding all the data.
         for (group, mut passes) in groups {
-            self.decode_hf_group(group, &mut passes, &mut buffer_splitter, do_flush)?;
+            self.decode_hf_group(group, &mut passes, &buffer_splitter, do_flush)?;
         }
 
         self.lf_global
@@ -349,7 +381,7 @@ impl Frame {
         // not rendered.
         if should_render_non_final || self.group_status.incomplete_groups == 0 {
             for g in std::mem::take(&mut self.group_status.need_vardct_flush) {
-                self.decode_hf_group(g, &mut [], &mut buffer_splitter, true)?;
+                self.decode_hf_group(g, &mut [], &buffer_splitter, true)?;
             }
         }
 

--- a/jxl/src/image/output_buffer.rs
+++ b/jxl/src/image/output_buffer.rs
@@ -97,9 +97,14 @@ impl<'a> JxlOutputBuffer<'a> {
         self.inner.byte_size()
     }
 
-    pub fn rect(&mut self, rect: Rect) -> JxlOutputBuffer<'_> {
+    /// # Safety
+    /// The caller must guarantee that there are no outstanding lends
+    /// of the provided `rect`.
+    pub(crate) unsafe fn rect(&self, rect: Rect) -> JxlOutputBuffer<'_> {
         // Safety note: the return value borrows from `self`, so we are lending our memory to the
-        // returned JxlOutputBuffer.
+        // returned JxlOutputBuffer. The caller guarantees that the region identified by
+        // `rect` does not overlap with other regions with outstanding borrows, so we have
+        // exclusive access to that region.
         Self {
             inner: self.inner.rect(rect),
             _ph: PhantomData,

--- a/jxl/src/image/rect.rs
+++ b/jxl/src/image/rect.rs
@@ -5,7 +5,7 @@
 
 use super::DataTypeTag;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Rect {
     pub origin: (usize, usize),
     // width, height
@@ -55,5 +55,12 @@ impl Rect {
                 end.1.min(size.1).saturating_sub(self.origin.1),
             ),
         }
+    }
+
+    pub fn intersects(&self, other: &Rect) -> bool {
+        self.end().0 > other.origin.0
+            && other.end().0 > self.origin.0
+            && self.end().1 > other.origin.1
+            && other.end().1 > self.origin.1
     }
 }

--- a/jxl/src/image/test.rs
+++ b/jxl/src/image/test.rs
@@ -68,6 +68,32 @@ fn rect_basic() -> Result<()> {
 }
 
 #[test]
+fn rect_intersects() {
+    let r1 = Rect {
+        origin: (0, 0),
+        size: (10, 10),
+    };
+    let r2 = Rect {
+        origin: (5, 5),
+        size: (10, 10),
+    };
+    let r3 = Rect {
+        origin: (10, 0),
+        size: (10, 10),
+    };
+    let r4 = Rect {
+        origin: (20, 20),
+        size: (10, 10),
+    };
+
+    assert!(r1.intersects(&r2));
+    assert!(r2.intersects(&r1));
+    assert!(!r1.intersects(&r3)); // touch at boundary
+    assert!(!r3.intersects(&r1));
+    assert!(!r1.intersects(&r4));
+}
+
+#[test]
 #[should_panic(expected = "image byte offset must be aligned to element size")]
 fn image_from_raw_rejects_misaligned_offset() {
     use super::OwnedRawImage;

--- a/jxl/src/render/buffer_splitter.rs
+++ b/jxl/src/render/buffer_splitter.rs
@@ -3,7 +3,97 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use crate::{api::JxlOutputBuffer, headers::Orientation, image::Rect, util::ShiftRightCeil};
+use std::{
+    collections::BTreeSet,
+    ops::{Deref, DerefMut},
+};
+
+use crate::{
+    api::JxlOutputBuffer,
+    headers::Orientation,
+    image::Rect,
+    util::{AtomicRefCell, ChannelVec, ShiftRightCeil},
+};
+
+pub struct OutputChannelSplitter<'a> {
+    // Safety invariant: all the currently-borrowed rects of are stored in
+    // `borrowed_rects`.
+    buffer: JxlOutputBuffer<'a>,
+    borrowed_rects: AtomicRefCell<BTreeSet<Rect>>,
+}
+
+impl<'a> Drop for OutputChannelSplitter<'a> {
+    fn drop(&mut self) {
+        assert!(self.borrowed_rects.borrow().is_empty())
+    }
+}
+
+impl<'a> OutputChannelSplitter<'a> {
+    pub fn new(buffer: JxlOutputBuffer<'a>) -> Self {
+        Self {
+            buffer,
+            borrowed_rects: AtomicRefCell::new(BTreeSet::new()),
+        }
+    }
+
+    #[allow(unsafe_code)]
+    pub fn borrow_rect(&self, rect: Rect) -> OutputChannelRef<'a, '_> {
+        let mut rects = loop {
+            if let Some(b) = self.borrowed_rects.try_borrow_mut() {
+                break b;
+            }
+        };
+        for r in rects.iter() {
+            assert!(!r.intersects(&rect));
+        }
+        rects.insert(rect);
+
+        OutputChannelRef {
+            s: self,
+            r: rect,
+            // SAFETY: we just checked that `self.borrowed_rects` does not contain
+            // any rects that intersect with the new rect. Since by safety invariant
+            // all the currently-borrowed rects are in `self.borrowed_rects`, the
+            // new rect does not intersect the old ones.
+            buf: Some(unsafe { self.buffer.rect(rect) }),
+        }
+    }
+}
+
+pub struct OutputChannelRef<'a, 'b> {
+    s: &'a OutputChannelSplitter<'b>,
+    buf: Option<JxlOutputBuffer<'b>>,
+    // Safety invariant: `r` is the rect that was used to obtain `buf` from `s`.
+    r: Rect,
+}
+
+impl<'a, 'b> Deref for OutputChannelRef<'a, 'b> {
+    type Target = JxlOutputBuffer<'b>;
+    fn deref(&self) -> &Self::Target {
+        self.buf.as_ref().unwrap()
+    }
+}
+
+impl<'a, 'b> DerefMut for OutputChannelRef<'a, 'b> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.buf.as_mut().unwrap()
+    }
+}
+
+impl<'a, 'b> Drop for OutputChannelRef<'a, 'b> {
+    fn drop(&mut self) {
+        self.buf = None;
+        loop {
+            if let Some(mut b) = self.s.borrowed_rects.try_borrow_mut() {
+                // Safety note: we just dropped the local buffer, and the
+                // safety invariant of `self` says that this is the correct rect
+                // to remove.
+                assert!(b.remove(&self.r));
+                break;
+            }
+        }
+    }
+}
 
 // Information for splitting the output buffers.
 #[derive(Debug)]
@@ -15,100 +105,300 @@ pub struct SaveStageBufferInfo {
 }
 
 /// Data structure responsible for handing out access to portions of the output buffers.
-pub struct BufferSplitter<'a, 'b> {
-    buffers: &'a mut [Option<JxlOutputBuffer<'b>>],
-    requested_rects: Vec<Rect>,
+pub struct BufferSplitter<'a> {
+    buffers: ChannelVec<Option<OutputChannelSplitter<'a>>>,
+    requested_rects: AtomicRefCell<Vec<Rect>>,
 }
 
-impl<'a, 'b> BufferSplitter<'a, 'b> {
-    pub fn new(bufs: &'a mut [Option<JxlOutputBuffer<'b>>]) -> Self {
+impl<'a> BufferSplitter<'a> {
+    pub fn new(bufs: &'a mut [Option<JxlOutputBuffer<'_>>]) -> Self {
         Self {
-            buffers: bufs,
-            requested_rects: vec![],
+            requested_rects: AtomicRefCell::new(vec![]),
+            buffers: bufs
+                .iter_mut()
+                .map(|x| {
+                    x.as_mut()
+                        .map(|x| OutputChannelSplitter::new(JxlOutputBuffer::reborrow(x)))
+                })
+                .collect(),
         }
     }
 
     pub(crate) fn get_local_buffers(
-        &mut self,
+        &self,
         save_buffer_info: &[Option<SaveStageBufferInfo>],
         rect: Rect,
         outside_current_frame: bool,
         frame_size: (usize, usize),
         full_image_size: (usize, usize),
         frame_origin: (isize, isize),
-    ) -> Vec<Option<JxlOutputBuffer<'_>>> {
-        self.requested_rects.push(rect);
-        let mut local_buffers = vec![];
-        let buffers = &mut *self.buffers;
-        local_buffers.reserve(buffers.len());
-        for _ in 0..buffers.len() {
-            local_buffers.push(None::<JxlOutputBuffer>);
+    ) -> ChannelVec<Option<OutputChannelRef<'a, '_>>> {
+        loop {
+            if let Some(mut req) = self.requested_rects.try_borrow_mut() {
+                req.push(rect);
+                break;
+            }
         }
         let rect = if !outside_current_frame {
             rect.clip(frame_size)
         } else {
             rect
         };
-        for (i, (info, buf)) in save_buffer_info.iter().zip(buffers.iter_mut()).enumerate() {
-            let Some(bi) = info else {
-                // We never write to this buffer.
-                continue;
-            };
-            let Some(buf) = buf.as_mut() else {
-                // The buffer to write into was not provided.
-                continue;
-            };
-            if outside_current_frame && !bi.after_extend {
-                // Before-extend stages do not write to rects outside the current frame.
-                continue;
-            }
-            let mut channel_rect = rect.downsample(bi.downsample);
-            if !outside_current_frame {
-                let frame_size = (
-                    frame_size.0.shrc(bi.downsample.0),
-                    frame_size.1.shrc(bi.downsample.1),
-                );
-                channel_rect = channel_rect.clip(frame_size);
-                if bi.after_extend {
-                    // clip this rect to its visible area in the full image (in full image coordinates).
-                    let origin = (
-                        rect.origin.0 as isize + frame_origin.0,
-                        rect.origin.1 as isize + frame_origin.1,
-                    );
-                    let end = (
-                        origin.0 + rect.size.0 as isize,
-                        origin.1 + rect.size.1 as isize,
-                    );
-                    let origin = (origin.0.max(0) as usize, origin.1.max(0) as usize);
-                    let end = (
-                        end.0.min(full_image_size.0 as isize).max(0) as usize,
-                        end.1.min(full_image_size.1 as isize).max(0) as usize,
-                    );
-                    channel_rect = Rect {
-                        origin,
-                        size: (
-                            end.0.saturating_sub(origin.0),
-                            end.1.saturating_sub(origin.1),
-                        ),
-                    };
+
+        save_buffer_info
+            .iter()
+            .zip(self.buffers.iter())
+            .map(|(info, buf)| {
+                let Some(bi) = info else {
+                    // We never write to this buffer.
+                    return None;
+                };
+                let buf = buf.as_ref()?;
+                if outside_current_frame && !bi.after_extend {
+                    // Before-extend stages do not write to rects outside the current frame.
+                    return None;
                 }
-            }
-            if channel_rect.size.0 == 0 || channel_rect.size.1 == 0 {
-                // Buffer would be empty anyway.
-                continue;
-            }
-            let channel_rect = bi.orientation.display_rect(channel_rect, full_image_size);
-            let channel_rect = channel_rect.to_byte_rect_sz(bi.byte_size);
-            local_buffers[i] = Some(buf.rect(channel_rect));
-        }
-        local_buffers
+                let mut channel_rect = rect.downsample(bi.downsample);
+                if !outside_current_frame {
+                    let frame_size = (
+                        frame_size.0.shrc(bi.downsample.0),
+                        frame_size.1.shrc(bi.downsample.1),
+                    );
+                    channel_rect = channel_rect.clip(frame_size);
+                    if bi.after_extend {
+                        // clip this rect to its visible area in the full image (in full image coordinates).
+                        let origin = (
+                            rect.origin.0 as isize + frame_origin.0,
+                            rect.origin.1 as isize + frame_origin.1,
+                        );
+                        let end = (
+                            origin.0 + rect.size.0 as isize,
+                            origin.1 + rect.size.1 as isize,
+                        );
+                        let origin = (origin.0.max(0) as usize, origin.1.max(0) as usize);
+                        let end = (
+                            end.0.min(full_image_size.0 as isize).max(0) as usize,
+                            end.1.min(full_image_size.1 as isize).max(0) as usize,
+                        );
+                        channel_rect = Rect {
+                            origin,
+                            size: (
+                                end.0.saturating_sub(origin.0),
+                                end.1.saturating_sub(origin.1),
+                            ),
+                        };
+                    }
+                }
+                if channel_rect.size.0 == 0 || channel_rect.size.1 == 0 {
+                    // Buffer would be empty anyway.
+                    return None;
+                }
+                let channel_rect = bi.orientation.display_rect(channel_rect, full_image_size);
+                let channel_rect = channel_rect.to_byte_rect_sz(bi.byte_size);
+                Some(buf.borrow_rect(channel_rect))
+            })
+            .collect()
     }
 
     pub fn into_changed_regions(self) -> Vec<Rect> {
-        self.requested_rects
+        std::mem::take(&mut *self.requested_rects.borrow_mut())
     }
 
-    pub fn get_full_buffers(&mut self) -> &mut [Option<JxlOutputBuffer<'b>>] {
-        &mut *self.buffers
+    #[cfg(test)]
+    pub fn get_full_buffers(&self) -> ChannelVec<Option<OutputChannelRef<'a, '_>>> {
+        self.buffers
+            .iter()
+            .map(|x| {
+                x.as_ref().map(|x| {
+                    x.borrow_rect(Rect {
+                        origin: (0, 0),
+                        size: x.buffer.byte_size(),
+                    })
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{api::JxlOutputBuffer, headers::Orientation, image::Rect};
+
+    #[test]
+    fn test_buffer_splitter_basic() {
+        let mut empty_bufs: [Option<JxlOutputBuffer>; 0] = [];
+        let splitter = BufferSplitter::new(&mut empty_bufs);
+        assert!(splitter.get_full_buffers().is_empty());
+
+        let mut raw0 = vec![0u8; 100];
+        let mut raw1 = vec![0u8; 200];
+        {
+            let buf0 = JxlOutputBuffer::new(&mut raw0, 10, 10);
+            let buf1 = JxlOutputBuffer::new(&mut raw1, 10, 20);
+            let mut bufs = [Some(buf0), Some(buf1), None];
+            let splitter = BufferSplitter::new(&mut bufs);
+
+            {
+                let mut full = splitter.get_full_buffers();
+                assert_eq!(full.len(), 3);
+                assert!(full[2].is_none());
+
+                full[0].as_mut().unwrap().row_mut(0)[0] = 42;
+                full[1].as_mut().unwrap().row_mut(1)[2] = 99;
+            }
+        }
+
+        assert_eq!(raw0[0], 42);
+        assert_eq!(raw1[20 + 2], 99);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_buffer_splitter_overlapping_borrows_panic() {
+        let mut raw0 = vec![0u8; 400];
+        let buf0 = JxlOutputBuffer::new(&mut raw0, 20, 20);
+        let mut bufs = [Some(buf0)];
+        let splitter = BufferSplitter::new(&mut bufs);
+
+        let info = vec![Some(SaveStageBufferInfo {
+            downsample: (0, 0),
+            orientation: Orientation::Identity,
+            byte_size: 1,
+            after_extend: false,
+        })];
+
+        let _local1 = splitter.get_local_buffers(
+            &info,
+            Rect {
+                origin: (0, 0),
+                size: (10, 10),
+            },
+            false,
+            (20, 20),
+            (20, 20),
+            (0, 0),
+        );
+
+        let _local2 = splitter.get_local_buffers(
+            &info,
+            Rect {
+                origin: (5, 5),
+                size: (10, 10),
+            },
+            false,
+            (20, 20),
+            (20, 20),
+            (0, 0),
+        );
+    }
+
+    #[cfg(not(any(target_family = "wasm", target_arch = "wasm32")))]
+    #[test]
+    fn test_buffer_splitter_multithreaded_arbtest() {
+        arbtest::arbtest(|u| {
+            let width = u.int_in_range(16..=128)?;
+            let height = u.int_in_range(16..=128)?;
+            let num_threads = u.int_in_range(2..=8)?;
+            let num_channels = u.int_in_range(1..=4)?;
+
+            let downsample_x: u8 = u.int_in_range(0..=2)?;
+            let downsample_y: u8 = u.int_in_range(0..=2)?;
+            let byte_size: usize = *u.choose(&[1, 2, 4])?;
+            let orientation = Orientation::Identity;
+
+            let info: Vec<Option<SaveStageBufferInfo>> = (0..num_channels)
+                .map(|ch| {
+                    if ch % 2 == 0 {
+                        Some(SaveStageBufferInfo {
+                            downsample: (downsample_x, downsample_y),
+                            orientation,
+                            byte_size,
+                            after_extend: false,
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let mut raws: Vec<Vec<u8>> = (0..num_channels)
+                .map(|_| vec![0u8; width * height * byte_size])
+                .collect();
+            let mut tiles = Vec::new();
+
+            {
+                let mut bufs: Vec<Option<JxlOutputBuffer>> = raws
+                    .iter_mut()
+                    .enumerate()
+                    .map(|(i, raw)| {
+                        if i == num_channels - 1 && num_channels > 1 {
+                            None
+                        } else {
+                            Some(JxlOutputBuffer::new(raw, height, width * byte_size))
+                        }
+                    })
+                    .collect();
+
+                let splitter = BufferSplitter::new(&mut bufs);
+
+                let align_x = 1usize << downsample_x;
+                let align_y = 1usize << downsample_y;
+                let tile_w = u.int_in_range(1..=4)? * align_x;
+                let tile_h = u.int_in_range(1..=4)? * align_y;
+
+                let mut tile_id = 1u8;
+
+                for y in (0..height).step_by(tile_h) {
+                    for x in (0..width).step_by(tile_w) {
+                        let w = tile_w.min(width - x);
+                        let h = tile_h.min(height - y);
+                        let rect = Rect {
+                            origin: (x, y),
+                            size: (w, h),
+                        };
+                        tiles.push((rect, tile_id));
+                        tile_id = tile_id.wrapping_add(1);
+                    }
+                }
+
+                let chunk_size = tiles.len().div_ceil(num_threads);
+                let tile_chunks: Vec<_> = tiles
+                    .chunks(chunk_size.max(1))
+                    .map(|c| c.to_vec())
+                    .collect();
+
+                std::thread::scope(|s| {
+                    for chunk in tile_chunks {
+                        let splitter_ref = &splitter;
+                        let info_ref = &info;
+                        s.spawn(move || {
+                            for (rect, id) in chunk {
+                                let mut local = splitter_ref.get_local_buffers(
+                                    info_ref,
+                                    rect,
+                                    false,
+                                    (width, height),
+                                    (width, height),
+                                    (0, 0),
+                                );
+
+                                for buf in local.iter_mut().flatten() {
+                                    let (_, bh) = buf.byte_size();
+                                    for ry in 0..bh {
+                                        let row = buf.row_mut(ry);
+                                        row.fill(id);
+                                    }
+                                }
+                            }
+                        });
+                    }
+                });
+
+                assert_eq!(splitter.into_changed_regions().len(), tiles.len());
+            }
+
+            Ok(())
+        });
     }
 }

--- a/jxl/src/render/buffer_splitter.rs
+++ b/jxl/src/render/buffer_splitter.rs
@@ -38,11 +38,7 @@ impl<'a> OutputChannelSplitter<'a> {
 
     #[allow(unsafe_code)]
     pub fn borrow_rect(&self, rect: Rect) -> OutputChannelRef<'a, '_> {
-        let mut rects = loop {
-            if let Some(b) = self.borrowed_rects.try_borrow_mut() {
-                break b;
-            }
-        };
+        let mut rects = self.borrowed_rects.spin_borrow_mut();
         for r in rects.iter() {
             assert!(!r.intersects(&rect));
         }
@@ -83,15 +79,11 @@ impl<'a, 'b> DerefMut for OutputChannelRef<'a, 'b> {
 impl<'a, 'b> Drop for OutputChannelRef<'a, 'b> {
     fn drop(&mut self) {
         self.buf = None;
-        loop {
-            if let Some(mut b) = self.s.borrowed_rects.try_borrow_mut() {
-                // Safety note: we just dropped the local buffer, and the
-                // safety invariant of `self` says that this is the correct rect
-                // to remove.
-                assert!(b.remove(&self.r));
-                break;
-            }
-        }
+        let mut b = self.s.borrowed_rects.spin_borrow_mut();
+        // Safety note: we just dropped the local buffer, and the
+        // safety invariant of `self` says that this is the correct rect
+        // to remove.
+        assert!(b.remove(&self.r));
     }
 }
 
@@ -133,11 +125,9 @@ impl<'a> BufferSplitter<'a> {
         full_image_size: (usize, usize),
         frame_origin: (isize, isize),
     ) -> ChannelVec<Option<OutputChannelRef<'a, '_>>> {
-        loop {
-            if let Some(mut req) = self.requested_rects.try_borrow_mut() {
-                req.push(rect);
-                break;
-            }
+        {
+            let mut req = self.requested_rects.spin_borrow_mut();
+            req.push(rect);
         }
         let rect = if !outside_current_frame {
             rect.clip(frame_size)

--- a/jxl/src/render/builder.rs
+++ b/jxl/src/render/builder.rs
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use crate::api::{JxlColorType, JxlDataFormat};
 use crate::error::{Error, Result};
 use crate::headers::Orientation;
@@ -49,10 +51,10 @@ impl<Pipeline: RenderPipeline> RenderPipelineBuilder<Pipeline> {
                 log_group_size,
                 group_count: (size.0.shrc(log_group_size), size.1.shrc(log_group_size)),
                 stages: vec![],
-                group_chan_complete: vec![
-                    vec![false; num_channels];
-                    size.0.shrc(log_group_size) * size.1.shrc(log_group_size)
-                ],
+                group_chan_complete: (0..(size.0.shrc(log_group_size)
+                    * size.1.shrc(log_group_size)))
+                    .map(|_| (0..num_channels).map(|_| AtomicBool::new(false)).collect())
+                    .collect(),
                 chunk_size,
                 extend_stage_index: None,
                 channel_is_used: vec![false; num_channels],
@@ -302,7 +304,7 @@ impl<Pipeline: RenderPipeline> RenderPipelineBuilder<Pipeline> {
             if chinfo.ty.is_none() {
                 assert!(!self.shared.channel_is_used[c]);
                 for g in self.shared.group_chan_complete.iter_mut() {
-                    g[c] = true;
+                    g[c].store(true, Ordering::Relaxed);
                 }
             }
         }

--- a/jxl/src/render/internal.rs
+++ b/jxl/src/render/internal.rs
@@ -5,6 +5,7 @@
 
 use std::any::Any;
 use std::fmt::Display;
+use std::sync::atomic::AtomicBool;
 
 use crate::error::Result;
 use crate::image::{DataTypeTag, ImageDataType};
@@ -106,7 +107,7 @@ pub struct RenderPipelineShared<Buffer> {
     pub input_size: (usize, usize),
     pub log_group_size: usize,
     pub group_count: (usize, usize),
-    pub group_chan_complete: Vec<Vec<bool>>,
+    pub group_chan_complete: Vec<Vec<AtomicBool>>,
     pub chunk_size: usize,
     pub stages: Vec<Stage<Buffer>>,
     pub extend_stage_index: Option<usize>,

--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -98,7 +98,7 @@ impl LowMemoryRenderPipeline {
     }
 
     pub(super) fn render_with_new_group(
-        &mut self,
+        &self,
         g: usize,
         buffer_splitter: &mut BufferSplitter,
     ) -> Result<()> {

--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -100,7 +100,7 @@ impl LowMemoryRenderPipeline {
     pub(super) fn render_with_new_group(
         &self,
         g: usize,
-        buffer_splitter: &mut BufferSplitter,
+        buffer_splitter: &BufferSplitter,
     ) -> Result<()> {
         let buf = self.input_buffers.get(g);
         assert!(buf.ready_channels.load(Ordering::Relaxed) <= self.shared.num_used_channels());

--- a/jxl/src/render/low_memory_pipeline/input_buffers.rs
+++ b/jxl/src/render/low_memory_pipeline/input_buffers.rs
@@ -124,7 +124,7 @@ impl InputBuffers {
 
         let all_finalized = (0..shared.num_channels())
             .filter(|&c| shared.channel_is_used[c])
-            .all(|c| shared.group_chan_complete[group][c]);
+            .all(|c| shared.group_chan_complete[group][c].load(Ordering::Relaxed));
 
         {
             let data = &self.buffers[group].data;
@@ -133,7 +133,7 @@ impl InputBuffers {
                 if !shared.channel_is_used[c] {
                     continue;
                 }
-                let is_finalized = shared.group_chan_complete[group][c];
+                let is_finalized = shared.group_chan_complete[group][c].load(Ordering::Relaxed);
                 let preserve = is_finalized && !all_finalized;
                 if !preserve {
                     if let Some(b) = std::mem::take(&mut *data[c].borrow_mut()) {
@@ -151,7 +151,10 @@ impl InputBuffers {
         // Clear border buffers that will not be used again.
         // This is certainly the case if *all* the groups in the 3x3 group area around
         // the current group are complete.
-        if shared.group_chan_complete[group].iter().all(|x| *x) {
+        if shared.group_chan_complete[group]
+            .iter()
+            .all(|x| x.load(Ordering::Relaxed))
+        {
             for g in [
                 gym1 * gw + gxm1,
                 gym1 * gw + gx,

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -327,7 +327,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
         group_id: usize,
         complete: bool,
         buf: Image<T>,
-        buffer_splitter: &mut BufferSplitter,
+        buffer_splitter: &BufferSplitter,
     ) -> Result<()> {
         if self.shared.channel_is_used[channel] {
             debug!(
@@ -365,7 +365,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
         Ok(())
     }
 
-    fn render_outside_frame(&mut self, buffer_splitter: &mut BufferSplitter) -> Result<()> {
+    fn render_outside_frame(&mut self, buffer_splitter: &BufferSplitter) -> Result<()> {
         if self.shared.extend_stage_index.is_none() || self.padding_was_rendered {
             return Ok(());
         }

--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use std::fmt::Debug;
+use std::sync::atomic::Ordering;
 
 use row_buffers::RowBuffer;
 
@@ -312,7 +313,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
     }
 
     #[instrument(skip_all, err)]
-    fn get_buffer<T: ImageDataType>(&mut self, channel: usize) -> Result<Image<T>> {
+    fn get_buffer<T: ImageDataType>(&self, channel: usize) -> Result<Image<T>> {
         if let Some(b) = self.maybe_get_scratch_buffer(channel, 0) {
             return Ok(Image::from_raw(b));
         }
@@ -321,7 +322,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
     }
 
     fn set_buffer_for_group<T: ImageDataType>(
-        &mut self,
+        &self,
         channel: usize,
         group_id: usize,
         complete: bool,
@@ -338,7 +339,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
             self.input_buffers
                 .get(group_id)
                 .set_buffer(channel, buf.into_raw());
-            self.shared.group_chan_complete[group_id][channel] = complete;
+            self.shared.group_chan_complete[group_id][channel].store(complete, Ordering::Relaxed);
 
             self.render_with_new_group(group_id, buffer_splitter)?;
         }
@@ -452,7 +453,7 @@ impl RenderPipeline for LowMemoryRenderPipeline {
     fn mark_group_to_rerender(&mut self, g: usize) {
         let all_finalized = (0..self.shared.num_channels())
             .filter(|&c| self.shared.channel_is_used[c])
-            .all(|c| self.shared.group_chan_complete[g][c]);
+            .all(|c| self.shared.group_chan_complete[g][c].load(Ordering::Relaxed));
         // The caller will feed back in all the non-ready channels.
         if !all_finalized {
             self.input_buffers.mark_not_ready(g);

--- a/jxl/src/render/low_memory_pipeline/render_group.rs
+++ b/jxl/src/render/low_memory_pipeline/render_group.rs
@@ -6,10 +6,10 @@
 use std::ops::Range;
 
 use crate::{
-    api::JxlOutputBuffer,
     error::Result,
     image::{DataTypeTag, OwnedRawImage, Rect},
     render::{
+        buffer_splitter::OutputChannelRef,
         internal::{ChannelInfo, Stage},
         low_memory_pipeline::{
             LowMemoryRenderPipelinePerThread, helpers::get_distinct_indices, run_stage::ExtraInfo,
@@ -293,7 +293,7 @@ impl LowMemoryRenderPipeline {
         data: &mut LowMemoryRenderPipelinePerThread,
         (gx, gy): (usize, usize),
         image_area: Rect,
-        buffers: &mut [Option<JxlOutputBuffer>],
+        buffers: &mut [Option<OutputChannelRef>],
     ) -> Result<()> {
         let start_of_row = image_area.origin.0 == 0;
         let end_of_row = image_area.end().0 == self.shared.input_size.0;
@@ -488,7 +488,7 @@ impl LowMemoryRenderPipeline {
         data: &mut LowMemoryRenderPipelinePerThread,
         xrange: Range<usize>,
         yrange: Range<usize>,
-        buffers: &mut [Option<JxlOutputBuffer>],
+        buffers: &mut [Option<OutputChannelRef>],
     ) -> Result<()> {
         let num_channels = self.shared.num_channels();
         let x0 = xrange.start;

--- a/jxl/src/render/low_memory_pipeline/save/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/save/mod.rs
@@ -4,10 +4,10 @@
 // license that can be found in the LICENSE file.
 
 use crate::{
-    api::{Endianness, JxlDataFormat, JxlOutputBuffer},
+    api::{Endianness, JxlDataFormat},
     error::Result,
     headers::Orientation,
-    render::save::SaveStage,
+    render::{buffer_splitter::OutputChannelRef, save::SaveStage},
 };
 
 use super::row_buffers::RowBuffer;
@@ -21,7 +21,7 @@ impl SaveStage {
     pub(crate) fn save_lowmem(
         &self,
         data: &[&RowBuffer],
-        buffers: &mut [Option<JxlOutputBuffer>],
+        buffers: &mut [Option<OutputChannelRef>],
         group_size: (usize, usize),
         frame_y: usize,
         group_origin: (usize, usize),

--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -122,12 +122,12 @@ pub(crate) trait RenderPipeline: Sized {
     /// Obtains a buffer suitable for storing the input in channel `channel`.
     /// This *might* be a buffer that was used to store that channel for that group in a previous
     /// pass, a new buffer, or a re-used buffer from i.e. previously decoded frames.
-    fn get_buffer<T: ImageDataType>(&mut self, channel: usize) -> Result<Image<T>>;
+    fn get_buffer<T: ImageDataType>(&self, channel: usize) -> Result<Image<T>>;
 
     /// Gives back the buffer for a channel and group to the render pipeline, marking whether
     /// this will be the last time that this function is called for this group.
     fn set_buffer_for_group<T: ImageDataType>(
-        &mut self,
+        &self,
         channel: usize,
         group_id: usize,
         complete: bool,

--- a/jxl/src/render/mod.rs
+++ b/jxl/src/render/mod.rs
@@ -132,7 +132,7 @@ pub(crate) trait RenderPipeline: Sized {
         group_id: usize,
         complete: bool,
         buf: Image<T>,
-        buffer_splitter: &mut BufferSplitter,
+        buffer_splitter: &BufferSplitter,
     ) -> Result<()>;
 
     /// Checks whether the provided buffer sizes are correct.
@@ -141,7 +141,7 @@ pub(crate) trait RenderPipeline: Sized {
     /// Renders any data outside the frame that would not be rendered by calls to
     /// set_buffer_for_group. Can be called multiple times - it is up to the pipeline
     /// implementation to ensure rendering only happens once.
-    fn render_outside_frame(&mut self, buffer_splitter: &mut BufferSplitter) -> Result<()>;
+    fn render_outside_frame(&mut self, buffer_splitter: &BufferSplitter) -> Result<()>;
 
     // Marks a group for being re-rendered later.
     fn mark_group_to_rerender(&mut self, g: usize);

--- a/jxl/src/render/simple_pipeline/mod.rs
+++ b/jxl/src/render/simple_pipeline/mod.rs
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+use std::sync::{Mutex, atomic::Ordering};
+
 use crate::{
     api::JxlOutputBuffer,
     error::Result,
@@ -25,25 +27,28 @@ mod save;
 /// Eventually meant to be used only for verification purposes.
 pub struct SimpleRenderPipeline {
     shared: RenderPipelineShared<Image<f64>>,
-    input_buffers: Vec<Image<f64>>,
+    input_buffers: Mutex<Vec<Image<f64>>>,
 }
 
 impl SimpleRenderPipeline {
     #[instrument(skip_all, err)]
-    fn do_render(&mut self, buffer_splitter: &mut BufferSplitter) -> Result<()> {
+    fn do_render(&self, buffer_splitter: &mut BufferSplitter) -> Result<()> {
         let ready = self
             .shared
             .group_chan_complete
             .iter()
             .flat_map(|x| x.iter())
-            .all(|x| *x);
+            .all(|x| x.load(Ordering::Relaxed));
         if !ready {
             debug!("not yet ready");
             return Ok(());
         }
         debug!("ready to render");
 
-        let mut current_buffers = clone_images(&self.input_buffers)?;
+        // We explicitly lock the mutex until the end of the function call to
+        // avoid concurrent calls to BufferSplitter.
+        let buffers = self.input_buffers.lock().unwrap();
+        let mut current_buffers = clone_images(&*buffers)?;
 
         let mut current_size = self.shared.input_size;
 
@@ -143,18 +148,18 @@ impl RenderPipeline for SimpleRenderPipeline {
 
         Ok(Self {
             shared,
-            input_buffers,
+            input_buffers: Mutex::new(input_buffers),
         })
     }
 
     #[instrument(skip_all, err)]
-    fn get_buffer<T: ImageDataType>(&mut self, channel: usize) -> Result<Image<T>> {
+    fn get_buffer<T: ImageDataType>(&self, channel: usize) -> Result<Image<T>> {
         let sz = self.shared.group_size_for_channel(channel, T::DATA_TYPE_ID);
         Image::<T>::new(sz)
     }
 
     fn set_buffer_for_group<T: ImageDataType>(
-        &mut self,
+        &self,
         channel: usize,
         group_id: usize,
         complete: bool,
@@ -172,18 +177,18 @@ impl RenderPipeline for SimpleRenderPipeline {
             let goffset = self.shared.group_offset(group_id);
             let ChannelInfo { ty, downsample } = self.shared.channel_info[0][channel];
             let off = (goffset.0 >> downsample.0, goffset.1 >> downsample.1);
-            debug!(?sz, input_buffers_sz=?self.input_buffers[channel].size(), offset=?off, ?downsample, ?goffset);
             let ty = ty.unwrap();
             assert_eq!(ty, T::DATA_TYPE_ID);
-            let total_sz = self.input_buffers[channel].size();
+            let mut buffers = self.input_buffers.lock().unwrap();
+            let total_sz = buffers[channel].size();
             for y in 0..sz.1.min(total_sz.1 - off.1) {
                 let row_in = buf.row(y);
-                let row_out = self.input_buffers[channel].row_mut(y + off.1);
+                let row_out = buffers[channel].row_mut(y + off.1);
                 for x in 0..sz.0.min(total_sz.0 - off.0) {
                     row_out[x + off.0] = row_in[x].to_f64();
                 }
             }
-            self.shared.group_chan_complete[group_id][channel] = complete;
+            self.shared.group_chan_complete[group_id][channel].store(complete, Ordering::Relaxed);
         }
 
         self.do_render(buffer_splitter)

--- a/jxl/src/render/simple_pipeline/mod.rs
+++ b/jxl/src/render/simple_pipeline/mod.rs
@@ -32,7 +32,7 @@ pub struct SimpleRenderPipeline {
 
 impl SimpleRenderPipeline {
     #[instrument(skip_all, err)]
-    fn do_render(&self, buffer_splitter: &mut BufferSplitter) -> Result<()> {
+    fn do_render(&self, buffer_splitter: &BufferSplitter) -> Result<()> {
         let ready = self
             .shared
             .group_chan_complete
@@ -48,7 +48,7 @@ impl SimpleRenderPipeline {
         // We explicitly lock the mutex until the end of the function call to
         // avoid concurrent calls to BufferSplitter.
         let buffers = self.input_buffers.lock().unwrap();
-        let mut current_buffers = clone_images(&*buffers)?;
+        let mut current_buffers = clone_images(&buffers)?;
 
         let mut current_size = self.shared.input_size;
 
@@ -119,7 +119,7 @@ impl SimpleRenderPipeline {
                     );
                 }
                 Stage::Save(stage) => {
-                    stage.save_simple(&output_buffers, buffer_splitter.get_full_buffers())?;
+                    stage.save_simple(&output_buffers, &mut buffer_splitter.get_full_buffers())?;
                 }
             }
             current_buffers = output_buffers;
@@ -164,7 +164,7 @@ impl RenderPipeline for SimpleRenderPipeline {
         group_id: usize,
         complete: bool,
         buf: Image<T>,
-        buffer_splitter: &mut BufferSplitter,
+        buffer_splitter: &BufferSplitter,
     ) -> Result<()> {
         debug!(
             "filling data for group {}, channel {}, using type {:?}",
@@ -199,7 +199,7 @@ impl RenderPipeline for SimpleRenderPipeline {
         Ok(())
     }
 
-    fn render_outside_frame(&mut self, _buffer_splitter: &mut BufferSplitter) -> Result<()> {
+    fn render_outside_frame(&mut self, _buffer_splitter: &BufferSplitter) -> Result<()> {
         // Nothing to do in the simple pipeline.
         Ok(())
     }

--- a/jxl/src/render/simple_pipeline/save.rs
+++ b/jxl/src/render/simple_pipeline/save.rs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+use crate::render::buffer_splitter::OutputChannelRef;
 use crate::util::f16;
 
 use crate::{
@@ -16,7 +17,7 @@ impl SaveStage {
     pub(super) fn save_simple(
         &self,
         data: &[Image<f64>],
-        buffers: &mut [Option<JxlOutputBuffer>],
+        buffers: &mut [Option<OutputChannelRef>],
     ) -> Result<()> {
         for i in self.channels.iter().skip(1) {
             assert_eq!(data[self.channels[0]].size(), data[*i].size());
@@ -94,7 +95,10 @@ impl SaveStage {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{api::JxlColorType, headers::Orientation, image::Rect, tests::assert_close};
+    use crate::{
+        api::JxlColorType, headers::Orientation, image::Rect,
+        render::buffer_splitter::OutputChannelSplitter, tests::assert_close,
+    };
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use test_log::test;
@@ -113,16 +117,16 @@ mod test {
         let src = [Image::<f64>::new_random((128, 128), &mut rng)?];
         let mut dst = Image::<u8>::new_random((128, 128), &mut rng)?;
 
-        save_stage.save_simple(
-            &src,
-            &mut [Some(JxlOutputBuffer::from_image_rect_mut(
-                dst.get_rect_mut(Rect {
-                    size: (128, 128),
-                    origin: (0, 0),
-                })
-                .into_raw(),
-            ))],
-        )?;
+        {
+            let r = Rect {
+                size: (128, 128),
+                origin: (0, 0),
+            };
+            let splitter = OutputChannelSplitter::new(JxlOutputBuffer::from_image_rect_mut(
+                dst.get_rect_mut(r).into_raw(),
+            ));
+            save_stage.save_simple(&src, &mut [Some(splitter.borrow_rect(r))])?;
+        }
 
         for y in 0..128 {
             for x in 0..128 {
@@ -161,16 +165,17 @@ mod test {
         let mut rng = XorShiftRng::seed_from_u64(0);
         let mut dst = Image::<f32>::new_random((ow, oh), &mut rng)?;
 
-        save_stage.save_simple(
-            &src,
-            &mut [Some(JxlOutputBuffer::from_image_rect_mut(
-                dst.get_rect_mut(Rect {
-                    origin: (0, 0),
-                    size: (ow, oh),
-                })
-                .into_raw(),
-            ))],
-        )?;
+        {
+            let r = Rect {
+                size: (ow, oh),
+                origin: (0, 0),
+            };
+            let splitter = OutputChannelSplitter::new(JxlOutputBuffer::from_image_rect_mut(
+                dst.get_rect_mut(r).into_raw(),
+            ));
+            let byte_rect = r.to_byte_rect_sz(std::mem::size_of::<f32>());
+            save_stage.save_simple(&src, &mut [Some(splitter.borrow_rect(byte_rect))])?;
+        }
 
         // Iterate over the DESTINATION image pixels.
         for y_dest in 0..oh {

--- a/jxl/src/render/test.rs
+++ b/jxl/src/render/test.rs
@@ -153,7 +153,7 @@ fn make_and_run_simple_pipeline_impl<InputT: ImageDataType, OutputT: ImageDataTy
         })
         .collect();
 
-    let mut buffer_splitter = BufferSplitter::new(&mut buf_ptrs);
+    let buffer_splitter = BufferSplitter::new(&mut buf_ptrs);
 
     for g in 0..num_groups {
         for &c in all_channels.iter() {
@@ -170,10 +170,12 @@ fn make_and_run_simple_pipeline_impl<InputT: ImageDataType, OutputT: ImageDataTy
                 g,
                 true,
                 extract_group_rect(&input_images[c], g, log_group_size)?,
-                &mut buffer_splitter,
+                &buffer_splitter,
             )?;
         }
     }
+
+    drop(buffer_splitter);
 
     Ok(outputs)
 }

--- a/jxl/src/render/test.rs
+++ b/jxl/src/render/test.rs
@@ -131,7 +131,7 @@ fn make_and_run_simple_pipeline_impl<InputT: ImageDataType, OutputT: ImageDataTy
             false,
         );
     }
-    let mut pipeline = pipeline.build()?;
+    let pipeline = pipeline.build()?;
 
     let num_groups = image_size.0.shrc(LOG_GROUP_SIZE) * image_size.1.shrc(LOG_GROUP_SIZE);
 

--- a/jxl/src/util/atomic_refcell/mod.rs
+++ b/jxl/src/util/atomic_refcell/mod.rs
@@ -39,6 +39,16 @@ impl<T: ?Sized> AtomicRefCell<T> {
     }
 
     #[inline]
+    pub fn spin_borrow(&self) -> AtomicRef<'_, T> {
+        loop {
+            if let Some(s) = self.try_borrow() {
+                return s;
+            }
+            std::hint::spin_loop();
+        }
+    }
+
+    #[inline]
     pub fn borrow_mut(&self) -> AtomicRefMut<'_, T> {
         AtomicRefMut::new(self).unwrap()
     }
@@ -46,6 +56,16 @@ impl<T: ?Sized> AtomicRefCell<T> {
     #[inline]
     pub fn try_borrow_mut(&self) -> Option<AtomicRefMut<'_, T>> {
         AtomicRefMut::new(self)
+    }
+
+    #[inline]
+    pub fn spin_borrow_mut(&self) -> AtomicRefMut<'_, T> {
+        loop {
+            if let Some(s) = self.try_borrow_mut() {
+                return s;
+            }
+            std::hint::spin_loop();
+        }
     }
 }
 

--- a/jxl/src/util/per_thread_storage.rs
+++ b/jxl/src/util/per_thread_storage.rs
@@ -28,16 +28,14 @@ impl<T> PerThreadStorage<T> {
     }
 
     pub fn get(&self) -> PerThreadStorageRef<'_, T> {
-        let t = loop {
-            if let Some(mut a) = self.storage.try_borrow_mut() {
-                if let Some(x) = a.pop() {
-                    break x;
-                }
-                // go to the call to `init()` if storage is empty
+        let t = {
+            let mut a = self.storage.spin_borrow_mut();
+            if let Some(x) = a.pop() {
+                x
             } else {
-                continue;
+                drop(a);
+                (self.init)()
             }
-            break (self.init)();
         };
         PerThreadStorageRef {
             r: self,
@@ -49,12 +47,8 @@ impl<T> PerThreadStorage<T> {
 impl<'a, T> Drop for PerThreadStorageRef<'a, T> {
     fn drop(&mut self) {
         let v = self.val.take().unwrap();
-        loop {
-            if let Some(mut a) = self.r.storage.try_borrow_mut() {
-                a.push(v);
-                break;
-            }
-        }
+        let mut a = self.r.storage.spin_borrow_mut();
+        a.push(v);
     }
 }
 


### PR DESCRIPTION
Includes #850.

This PR adds logic to BufferSplitter to allow simultaneously mutably-borrowing non-overlapping rects from a &BufferSplitter, and changes the render pipeline interface to not use &mut for methods that are meant to be MT-compatible.