### PR TITLE
Use mimalloc as the allocator for jxl_cli.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "jxl_cms",
  "jxl_macros",
  "lcms2",
+ "mimalloc",
  "png",
  "tracing-subscriber",
  "vergen-gitcl",
@@ -757,6 +758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +786,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/jxl_cli/Cargo.toml
+++ b/jxl_cli/Cargo.toml
@@ -17,6 +17,7 @@ half = "2.4.1"
 png = "0.18.0"
 exr = { version = "1.73.0", optional = true }
 color-eyre = "0.6.5"
+mimalloc = "0.1.52"
 
 [dev-dependencies]
 jxl_macros = { path = "../jxl_macros", features = ["test"], version = "=0.5.1" }

--- a/jxl_cli/src/main.rs
+++ b/jxl_cli/src/main.rs
@@ -14,6 +14,11 @@ use std::io::{BufReader, Read, Seek};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 const VERSION_STRING: &str = concat!(
     env!("VERGEN_GIT_DESCRIBE"),
     " (rustc ",


### PR DESCRIPTION
Eventually, the core library will improve its own allocation patterns, but in the meantime mimalloc gives better consistency across changes, making the benchmark a bit more reliable.

It is also somewhat faster.