### PR TITLE
Parse Mul clamp without extra channels

### DIFF
--- a/jxl/src/headers/frame_header.rs
+++ b/jxl/src/headers/frame_header.rs
@@ -126,8 +126,9 @@ pub struct BlendingInfo {
     pub alpha_channel: u32,
 
     #[default(false)]
-    #[condition(nonserialized.num_extra_channels > 0 &&
-        (mode == BlendingMode::Blend || mode == BlendingMode::AlphaWeightedAdd || mode == BlendingMode::Mul))]
+    #[condition((nonserialized.num_extra_channels > 0 &&
+        (mode == BlendingMode::Blend || mode == BlendingMode::AlphaWeightedAdd)) ||
+        mode == BlendingMode::Mul)]
     pub clamp: bool,
 
     #[coder(u2S(0, 1, 2, 3))]


### PR DESCRIPTION
`Mul` blending serializes the `clamp` bit even when there are no extra channels. Skipping it shifted subsequent frame headers and made valid animations fail with `Section is too short`.

Always parse the bit for `Mul`. Conformance coverage: https://github.com/libjxl/conformance/pull/48
