### PR TITLE
Allow subsampled LF smoothing

### DIFF
--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -116,8 +116,6 @@ pub enum Error {
     PassesLastPassTooLarge,
     #[error("Non-patch reference frame with a crop")]
     NonPatchReferenceWithCrop,
-    #[error("Non-444 chroma subsampling is not allowed when adaptive DC smoothing is enabled")]
-    Non444ChromaSubsampling,
     #[error("Non-444 chroma subsampling is not allowed for bigger than 8x8 transforms")]
     InvalidBlockSizeForChromaSubsampling,
     #[error("Out of memory: {0}")]

--- a/jxl/src/headers/frame_header.rs
+++ b/jxl/src/headers/frame_header.rs
@@ -771,12 +771,6 @@ impl FrameHeader {
         if !self.save_before_ct && !self.full_frame && self.frame_type == FrameType::ReferenceOnly {
             return Err(Error::NonPatchReferenceWithCrop);
         }
-        if !self.is444()
-            && ((self.flags & Flags::SKIP_ADAPTIVE_LF_SMOOTHING) == 0)
-            && self.encoding == Encoding::VarDCT
-        {
-            return Err(Error::Non444ChromaSubsampling);
-        }
         Ok(())
     }
 }


### PR DESCRIPTION
Removes the error when doing non-444 LF smoothing, allowing for much less banding in low quality JPEG transcodes.

Only has an effect on files using https://github.com/libjxl/libjxl/pull/4932.