### PR TITLE
Take read locks on palette prediction context grids

### DIFF
--- a/jxl/src/frame/modular/transforms/palette.rs
+++ b/jxl/src/frame/modular/transforms/palette.rs
@@ -255,10 +255,10 @@ pub fn do_palette_step_general(
 
 #[allow(clippy::too_many_arguments)]
 fn get_prediction_data(
-    buf: &mut [&mut ModularChannel],
+    cur_row: &[&mut ModularChannel],
+    prev_row: Option<&[&ModularChannel]>,
     idx: usize,
     grid_x: usize,
-    grid_y: usize,
     grid_xsize: usize,
     x: usize,
     y: usize,
@@ -266,29 +266,25 @@ fn get_prediction_data(
     ysize: usize,
 ) -> PredictionData {
     PredictionData::get_with_neighbors(
-        &buf[idx].data,
+        &cur_row[idx].data,
         if grid_x > 0 {
-            Some(&buf[idx - 1].data)
+            Some(&cur_row[idx - 1].data)
         } else {
             None
         },
-        if grid_y > 0 {
-            Some(&buf[idx - grid_xsize].data)
-        } else {
-            None
-        },
-        if grid_x > 0 && grid_y > 0 {
-            Some(&buf[idx - grid_xsize - 1].data)
+        prev_row.map(|p| &p[idx].data),
+        if grid_x > 0 {
+            prev_row.map(|p| &p[idx - 1].data)
         } else {
             None
         },
         if grid_x + 1 < grid_xsize {
-            Some(&buf[idx + 1].data)
+            Some(&cur_row[idx + 1].data)
         } else {
             None
         },
-        if grid_x + 1 < grid_xsize && grid_y > 0 {
-            Some(&buf[idx - grid_xsize + 1].data)
+        if grid_x + 1 < grid_xsize {
+            prev_row.map(|p| &p[idx + 1].data)
         } else {
             None
         },
@@ -304,10 +300,9 @@ pub fn do_palette_step_one_group(
     buf_in: &ModularChannel,
     buf_pal: &ModularChannel,
     buf_out: &mut [&mut ModularChannel],
-    grid_x: usize,
-    grid_y: usize,
-    grid_xsize: usize,
-    grid_ysize: usize,
+    buf_left: Option<&[&ModularChannel]>,
+    buf_top: Option<&[&ModularChannel]>,
+    buf_topleft: Option<&[&ModularChannel]>,
     num_colors: usize,
     num_deltas: usize,
     predictor: Predictor,
@@ -315,13 +310,18 @@ pub fn do_palette_step_one_group(
     let h = buf_in.data.size().1;
     let palette = &buf_pal.data;
     let bit_depth = buf_in.bit_depth.bits_per_sample().min(24) as usize;
-    let num_c = buf_out.len() / (grid_xsize * grid_ysize);
-    let (xsize, ysize) = buf_out[0].data.size();
+    let num_c = buf_out.len();
+    // The size of a full (non-edge) grid, used to index the context grids;
+    // the center grid may be smaller than its top/left neighbours.
+    let (xsize, ysize) = buf_topleft
+        .or(buf_top)
+        .or(buf_left)
+        .map(|b| b[0].data.size())
+        .unwrap_or(buf_out[0].data.size());
 
     for c in 0..num_c {
         for y in 0..h {
             let index_img = buf_in.data.row(y);
-            let out_idx = c * grid_ysize * grid_xsize + grid_y * grid_xsize + grid_x;
             for (x, &index) in index_img.iter().enumerate() {
                 let palette_entry = get_palette_value(
                     palette,
@@ -332,8 +332,17 @@ pub fn do_palette_step_one_group(
                 );
                 let val = if index < num_deltas as i32 {
                     let pred = predictor.predict_one(
-                        get_prediction_data(
-                            buf_out, out_idx, grid_x, grid_y, grid_xsize, x, y, xsize, ysize,
+                        PredictionData::get_with_neighbors(
+                            &buf_out[c].data,
+                            buf_left.map(|b| &b[c].data),
+                            buf_top.map(|b| &b[c].data),
+                            buf_topleft.map(|b| &b[c].data),
+                            None,
+                            None,
+                            x,
+                            y,
+                            xsize,
+                            ysize,
                         ),
                         /*wp_pred=*/ 0,
                     );
@@ -341,7 +350,7 @@ pub fn do_palette_step_one_group(
                 } else {
                     palette_entry
                 };
-                buf_out[out_idx].data.row_mut(y)[x] = val;
+                buf_out[c].data.row_mut(y)[x] = val;
             }
         }
     }
@@ -351,19 +360,15 @@ pub fn do_palette_step_one_group(
 pub fn zero_palette_step_one_group(
     buf_pal: &ModularChannel,
     buf_out: &mut [&mut ModularChannel],
-    grid_x: usize,
-    grid_y: usize,
-    grid_xsize: usize,
-    grid_ysize: usize,
     num_colors: usize,
     num_deltas: usize,
 ) {
     let palette = &buf_pal.data;
     let bit_depth = buf_out[0].bit_depth.bits_per_sample().min(24) as usize;
-    let num_c = buf_out.len() / (grid_xsize * grid_ysize);
+    let num_c = buf_out.len();
     let (xsize, ysize) = buf_out[0].data.size();
 
-    for c in 0..num_c {
+    for (c, buf) in buf_out.iter_mut().enumerate().take(num_c) {
         let palette_entry = get_palette_value(
             palette,
             0,
@@ -372,8 +377,7 @@ pub fn zero_palette_step_one_group(
             /*bit_depth=*/ bit_depth,
         );
         for y in 0..ysize {
-            let out_idx = c * grid_ysize * grid_xsize + grid_y * grid_xsize + grid_x;
-            buf_out[out_idx].data.row_mut(y)[..xsize].fill(palette_entry);
+            buf.data.row_mut(y)[..xsize].fill(palette_entry);
         }
     }
 }
@@ -383,7 +387,7 @@ pub fn do_palette_step_group_row(
     buf_in: &[&ModularChannel],
     buf_pal: &ModularChannel,
     buf_out: &mut [&mut ModularChannel],
-    grid_y: usize,
+    buf_prev: Option<&[&ModularChannel]>,
     grid_xsize: usize,
     num_colors: usize,
     num_deltas: usize,
@@ -393,21 +397,23 @@ pub fn do_palette_step_group_row(
     let palette = &buf_pal.data;
     let h = buf_in[0].data.size().1;
     let bit_depth = buf_in[0].bit_depth.bits_per_sample().min(24) as usize;
-    let grid_ysize = grid_y + 1;
-    let num_c = buf_out.len() / (grid_xsize * grid_ysize);
+    let num_c = buf_out.len() / grid_xsize;
     let total_w = buf_out[0..grid_xsize]
         .iter()
         .map(|buf| buf.data.size().0)
         .sum();
-    let (xsize, ysize) = buf_out[0].data.size();
+    // The size of a full (non-edge) grid, used to index the context grids;
+    // the current (last) row of grids may be smaller than the previous row.
+    let (xsize, ysize) = buf_prev
+        .map(|p| p[0].data.size())
+        .unwrap_or(buf_out[0].data.size());
 
     if predictor == Predictor::Weighted {
         for c in 0..num_c {
             let mut wp_state = WeightedPredictorState::new(wp_header, total_w);
-            let out_row_idx = c * grid_ysize * grid_xsize + grid_y * grid_xsize;
-            if grid_y > 0 {
-                let prev_row_idx = out_row_idx - grid_y * grid_xsize;
-                wp_state.restore_state(buf_out[prev_row_idx].auxiliary_data.as_ref().unwrap());
+            let out_row_idx = c * grid_xsize;
+            if let Some(prev) = buf_prev {
+                wp_state.restore_state(prev[out_row_idx].auxiliary_data.as_ref().unwrap());
             }
             for y in 0..h {
                 for (grid_x, index_buf) in buf_in.iter().enumerate().take(grid_xsize) {
@@ -422,7 +428,7 @@ pub fn do_palette_step_group_row(
                             /*bit_depth=*/ bit_depth,
                         );
                         let prediction_data = get_prediction_data(
-                            buf_out, out_idx, grid_x, grid_y, grid_xsize, x, y, xsize, ysize,
+                            buf_out, buf_prev, out_idx, grid_x, grid_xsize, x, y, xsize, ysize,
                         );
                         let (pred, _) = wp_state
                             .predict_and_property((grid_x * xsize + x, y & 1), &prediction_data);
@@ -445,7 +451,7 @@ pub fn do_palette_step_group_row(
             for y in 0..h {
                 for (grid_x, index_buf) in buf_in.iter().enumerate().take(grid_xsize) {
                     let index_img = index_buf.data.row(y);
-                    let out_idx = c * grid_ysize * grid_xsize + grid_y * grid_xsize + grid_x;
+                    let out_idx = c * grid_xsize + grid_x;
                     for (x, &index) in index_img.iter().enumerate() {
                         let palette_entry = get_palette_value(
                             palette,
@@ -457,7 +463,7 @@ pub fn do_palette_step_group_row(
                         let val = if index < num_deltas as i32 {
                             let pred = predictor.predict_one(
                                 get_prediction_data(
-                                    buf_out, out_idx, grid_x, grid_y, grid_xsize, x, y, xsize,
+                                    buf_out, buf_prev, out_idx, grid_x, grid_xsize, x, y, xsize,
                                     ysize,
                                 ),
                                 /*wp_pred=*/ 0,

--- a/jxl/src/frame/modular/transforms/step.rs
+++ b/jxl/src/frame/modular/transforms/step.rs
@@ -353,20 +353,36 @@ impl TransformStepChunk {
                     let grid_x = out_grid % grid_shape.0;
                     let grid_y = out_grid / grid_shape.0;
                     let border = if *predictor == Predictor::Zero { 0 } else { 1 };
-                    let grid_x0 = grid_x.saturating_sub(border);
-                    let grid_y0 = grid_y.saturating_sub(border);
-                    let grid_x1 = grid_x + 1;
-                    let grid_y1 = grid_y + 1;
+                    let has_left = border > 0 && grid_x > 0;
+                    let has_top = border > 0 && grid_y > 0;
+                    // Neighbouring grid positions are only read as prediction context,
+                    // so take read locks on them: other transforms (e.g. Output) may
+                    // read them concurrently.
+                    let ctx_guards = |dx: usize, dy: usize| {
+                        buf_out
+                            .iter()
+                            .map(|i| {
+                                let grid = (grid_y - dy) * grid_shape.0 + (grid_x - dx);
+                                borrow_channel(buffers, (*i, grid))
+                            })
+                            .collect::<Vec<_>>()
+                    };
+                    let left_guards = has_left.then(|| ctx_guards(1, 0));
+                    let top_guards = has_top.then(|| ctx_guards(0, 1));
+                    let topleft_guards = (has_left && has_top).then(|| ctx_guards(1, 1));
+                    let left_refs: Option<Vec<&ModularChannel>> = left_guards
+                        .as_ref()
+                        .map(|g| g.iter().map(|x| x.as_ref().unwrap()).collect());
+                    let top_refs: Option<Vec<&ModularChannel>> = top_guards
+                        .as_ref()
+                        .map(|g| g.iter().map(|x| x.as_ref().unwrap()).collect());
+                    let topleft_refs: Option<Vec<&ModularChannel>> = topleft_guards
+                        .as_ref()
+                        .map(|g| g.iter().map(|x| x.as_ref().unwrap()).collect());
                     let mut guards = vec![];
                     for i in buf_out {
-                        for gy in grid_y0..grid_y1 {
-                            for gx in grid_x0..grid_x1 {
-                                let grid = gy * grid_shape.0 + gx;
-                                let buf = &buffers[*i];
-                                let b = &buf.buffer_grid[grid];
-                                guards.push(b.data.try_write().unwrap());
-                            }
-                        }
+                        let b = &buffers[*i].buffer_grid[out_grid];
+                        guards.push(b.data.try_write().unwrap());
                     }
                     let mut out_buf_refs: Vec<&mut ModularChannel> =
                         guards.iter_mut().map(|g| g.as_mut().unwrap()).collect();
@@ -376,10 +392,6 @@ impl TransformStepChunk {
                         super::palette::zero_palette_step_one_group(
                             img_pal.as_ref().unwrap(),
                             &mut out_buf_refs,
-                            grid_x - grid_x0,
-                            grid_y - grid_y0,
-                            grid_x1 - grid_x0,
-                            grid_y1 - grid_y0,
                             *num_colors,
                             *num_deltas,
                         );
@@ -389,10 +401,9 @@ impl TransformStepChunk {
                             img_in.as_ref().unwrap(),
                             img_pal.as_ref().unwrap(),
                             &mut out_buf_refs,
-                            grid_x - grid_x0,
-                            grid_y - grid_y0,
-                            grid_x1 - grid_x0,
-                            grid_y1 - grid_y0,
+                            left_refs.as_deref(),
+                            top_refs.as_deref(),
+                            topleft_refs.as_deref(),
                             *num_colors,
                             *num_deltas,
                             *predictor,
@@ -417,8 +428,6 @@ impl TransformStepChunk {
                 {
                     assert_eq!(out_grid % grid_shape.0, 0);
                     let grid_y = out_grid / grid_shape.0;
-                    let grid_y0 = grid_y.saturating_sub(1);
-                    let grid_y1 = grid_y + 1;
                     let mut in_bufs = vec![];
                     for grid_x in 0..grid_shape.0 {
                         let grid = grid_y * grid_shape.0 + grid_x;
@@ -430,15 +439,26 @@ impl TransformStepChunk {
                     let in_buf_refs: Vec<&ModularChannel> =
                         in_bufs.iter().map(|x| x.as_ref().unwrap()).collect();
                     let img_pal = borrow_channel(buffers, (*buf_pal, 0));
+                    // The previous row of output grids is only read as prediction
+                    // context, so take read locks on it: other transforms (e.g.
+                    // Output) may read it concurrently.
+                    let mut prev_guards = vec![];
+                    if grid_y > 0 {
+                        for i in buf_out {
+                            for grid_x in 0..grid_shape.0 {
+                                let grid = (grid_y - 1) * grid_shape.0 + grid_x;
+                                prev_guards.push(borrow_channel(buffers, (*i, grid)));
+                            }
+                        }
+                    }
+                    let prev_refs: Vec<&ModularChannel> =
+                        prev_guards.iter().map(|g| g.as_ref().unwrap()).collect();
                     let mut guards = vec![];
                     for i in buf_out {
-                        for grid_y in grid_y0..grid_y1 {
-                            for grid_x in 0..grid_shape.0 {
-                                let grid = grid_y * grid_shape.0 + grid_x;
-                                let buf = &buffers[*i];
-                                let b = &buf.buffer_grid[grid];
-                                guards.push(b.data.try_write().unwrap());
-                            }
+                        for grid_x in 0..grid_shape.0 {
+                            let grid = grid_y * grid_shape.0 + grid_x;
+                            let b = &buffers[*i].buffer_grid[grid];
+                            guards.push(b.data.try_write().unwrap());
                         }
                     }
                     let mut out_buf_refs: Vec<&mut ModularChannel> =
@@ -447,7 +467,7 @@ impl TransformStepChunk {
                         &in_buf_refs,
                         img_pal.as_ref().unwrap(),
                         &mut out_buf_refs,
-                        grid_y - grid_y0,
+                        (grid_y > 0).then_some(&prev_refs[..]),
                         grid_shape.0,
                         *num_colors,
                         *num_deltas,


### PR DESCRIPTION
More shuttle fuzzing on top of #862, this time with the PCT scheduler: the palette transform write-locks all grids it touches, including neighbouring grids (previous row for full-row predictors, left/top/top-left otherwise) it only reads as prediction context. An `Output` step reading a previous-row grid concurrently makes the `try_write`/`try_read` calls panic with `WouldBlock` (`test_compare_parallel_progressive_shuttle_issue648_palette0`).

Split the palette helpers' buffer slices into written grids and read-only context grids, and take read locks for the latter; ordering with the producers of the context grids is already guaranteed by the dependency graph. With this (plus #867 and #868) the shuttle suite is clean under both the random and PCT schedulers.
