### PR TITLE
Use deterministic iteration order for decode scheduling sets

### DIFF
--- a/jxl/src/frame/decode.rs
+++ b/jxl/src/frame/decode.rs
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use super::render::pipeline;
@@ -266,7 +266,7 @@ impl Frame {
             lf_quant: Arc::new(RwLock::new(LfQuantFactors::default())),
             color_correlation_params: Arc::new(RwLock::new(ColorCorrelationParams::default())),
             epf_sigma: Arc::new(RwLock::new(SigmaSource::default())),
-            dirty_lf_groups: HashSet::new(),
+            dirty_lf_groups: BTreeSet::new(),
         })
     }
 

--- a/jxl/src/frame/mod.rs
+++ b/jxl/src/frame/mod.rs
@@ -3,7 +3,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
 
 use crate::{
     api::{JxlDecoderOptions, JxlParallelRunner},
@@ -240,8 +243,8 @@ pub enum DataStatus {
 #[derive(Debug)]
 struct GroupStatus {
     // Groups that should be rendered on the next call to flush().
-    need_vardct_flush: HashSet<usize>,
-    need_modular_flush: HashSet<usize>,
+    need_vardct_flush: BTreeSet<usize>,
+    need_modular_flush: BTreeSet<usize>,
     channel_status: Vec<Vec<DataStatus>>,
     final_vardct_render_done: HashSet<usize>,
     incomplete_groups: usize,
@@ -254,8 +257,8 @@ impl GroupStatus {
         // We don't track noise channels because we pretend they always
         // have the same status as VarDCT channels.
         GroupStatus {
-            need_vardct_flush: HashSet::new(),
-            need_modular_flush: HashSet::new(),
+            need_vardct_flush: BTreeSet::new(),
+            need_modular_flush: BTreeSet::new(),
             channel_status: vec![vec![DataStatus::Zero; 3 + ecs]; count],
             final_vardct_render_done: HashSet::new(),
             incomplete_groups: count,
@@ -307,7 +310,7 @@ pub struct Frame {
     epf_sigma: Arc<RwLock<SigmaSource>>,
     // LF groups that received data and thus should trigger a modular
     // re-render of the corresponding groups.
-    dirty_lf_groups: HashSet<usize>,
+    dirty_lf_groups: BTreeSet<usize>,
 }
 
 impl Frame {

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -5,7 +5,7 @@
 
 use std::{
     cmp::min,
-    collections::HashSet,
+    collections::{BTreeSet, HashSet},
     fmt::Debug,
     sync::{
         Mutex,
@@ -244,9 +244,9 @@ pub struct FullModularImage {
     has_decoded_data: AtomicBool,
     global_header: Option<GroupHeader>,
     output_transforms_for_group: Vec<Vec<usize>>,
-    pending_transforms: HashSet<usize>,
+    pending_transforms: BTreeSet<usize>,
     rerendered_buffers: HashSet<(usize, usize)>,
-    delayed_ready_sections: Mutex<HashSet<(usize, usize)>>,
+    delayed_ready_sections: Mutex<BTreeSet<(usize, usize)>>,
     // Whether each channel is used or not by the render pipeline.
     pipeline_used_channels: Vec<bool>,
     // Stack of transform steps that are ready to process.
@@ -326,9 +326,9 @@ impl FullModularImage {
                 pipeline_used_channels: vec![],
                 output_transforms_for_group: vec![vec![]; frame_header.num_groups()],
                 ready_transform_steps: Mutex::new(vec![]),
-                pending_transforms: HashSet::new(),
+                pending_transforms: BTreeSet::new(),
                 rerendered_buffers: HashSet::new(),
-                delayed_ready_sections: Mutex::new(HashSet::new()),
+                delayed_ready_sections: Mutex::new(BTreeSet::new()),
             });
         }
 
@@ -495,9 +495,9 @@ impl FullModularImage {
             output_transforms_for_group,
             pipeline_used_channels: vec![],
             ready_transform_steps: Mutex::new(vec![]),
-            pending_transforms: HashSet::new(),
+            pending_transforms: BTreeSet::new(),
             rerendered_buffers: HashSet::new(),
-            delayed_ready_sections: Mutex::new(HashSet::new()),
+            delayed_ready_sections: Mutex::new(BTreeSet::new()),
         })
     }
 
@@ -771,8 +771,7 @@ impl FullModularImage {
         }
         self.pending_transforms.clear();
         self.rerendered_buffers.clear();
-        for (s, g) in std::mem::take(&mut *self.delayed_ready_sections.try_lock().unwrap()).drain()
-        {
+        for (s, g) in std::mem::take(&mut *self.delayed_ready_sections.try_lock().unwrap()) {
             self.mark_section_ready(s, g, &mut self.ready_transform_steps.try_lock().unwrap());
         }
     }

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -23,7 +23,7 @@ use crate::headers::{Orientation, color_encoding::ColorSpace, extra_channels::Ex
 use crate::image::Image;
 use crate::image::Rect;
 use crate::util::SmallVec;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::AtomicUsize;
@@ -365,7 +365,7 @@ impl Frame {
                 }
                 gr
             } else {
-                HashSet::new()
+                BTreeSet::new()
             };
 
         let ready_steps = modular_global.take_ready_steps();


### PR DESCRIPTION
Shuttle's `UncontrolledNondeterminismCheckScheduler` flags 40 of the #862 concurrency tests: replaying the exact same schedule diverges, because the order in which transforms and groups get queued depends on `HashSet` iteration order (seeded per process). That breaks "failing schedule" replays -- the replayed execution can panic somewhere else or not at all -- and makes decode work ordering differ run to run.

Switch the scheduling sets that get iterated (`pending_transforms`, `delayed_ready_sections`, `need_vardct_flush`, `need_modular_flush`, `dirty_lf_groups`) to `BTreeSet`; membership-only sets stay `HashSet`. With this the whole shuttle suite passes under the nondeterminism check, and schedule replays reproduce failures exactly.
