### PR TITLE
Count partial groups when limiting render parallelism

### DIFF
--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -329,8 +329,20 @@ impl Frame {
             }
         }
 
+        let largest_group_area = self.header.group_dim().min(self.header.size().0)
+            * self.header.group_dim().min(self.header.size().1);
+
+        const THREAD_COUNT_DENOMINATOR: usize = 16;
+
+        let mut groups_of_work = 0;
+
         if self.header.encoding == Encoding::VarDCT {
             for (group, _) in groups.iter() {
+                let sz = self.header.group_rect(*group).size;
+                let area = sz.0 * sz.1;
+                if area >= largest_group_area {
+                    groups_of_work += THREAD_COUNT_DENOMINATOR;
+                }
                 if self.group_status.channel_status[*group][0] == DataStatus::Final {
                     pipeline_mut!(self, p, p.mark_group_to_rerender(*group));
                 }
@@ -340,6 +352,13 @@ impl Frame {
         // STEP 3: Make sure modular_global is ready to run, and prepare the list of
         // all the decoding/rendering steps that we want to run.
         modular_global.prepare_render(&self.header, |g, c, is_final| {
+            let sz = self.header.group_rect(g).size;
+            let area = sz.0 * sz.1;
+            if area >= largest_group_area {
+                groups_of_work += THREAD_COUNT_DENOMINATOR / 2;
+            } else if area * 2 >= largest_group_area {
+                groups_of_work += THREAD_COUNT_DENOMINATOR / 4;
+            }
             self.group_status.update_status(
                 g,
                 c,
@@ -367,6 +386,14 @@ impl Frame {
             };
 
         let ready_steps = modular_global.take_ready_steps();
+
+        for g in extra_groups_to_vardct_render.iter() {
+            let sz = self.header.group_rect(*g).size;
+            let area = sz.0 * sz.1;
+            if area >= largest_group_area {
+                groups_of_work += THREAD_COUNT_DENOMINATOR / 2;
+            }
+        }
 
         const TRANSFORM_STEPS_PER_TASK: usize = 3;
 
@@ -436,13 +463,8 @@ impl Frame {
             Ok(())
         };
 
-        // Avoid significantly more than one thread per group's worth of work.
-        // Measured in whole groups of area rather than per dimension: truncating
-        // each dimension separately makes the product zero whenever a dimension
-        // is under one group, which pins max_threads to 1 and renders serially.
-        let group_dim = self.header.group_dim();
-        let max_threads =
-            (self.header.size().0 * self.header.size().1).div_ceil(group_dim * group_dim) + 1;
+        // Avoid significantly more than one thread per largest-group worth of work.
+        let max_threads = groups_of_work.div_ceil(THREAD_COUNT_DENOMINATOR).max(1);
 
         let hw_threads = std::thread::available_parallelism()
             .map(|x| x.get())

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -436,10 +436,13 @@ impl Frame {
             Ok(())
         };
 
-        // Avoid significantly more than one thread per full group
-        let max_threads = (self.header.size().0 / self.header.group_dim())
-            * (self.header.size().1 / self.header.group_dim())
-            + 1;
+        // Avoid significantly more than one thread per group's worth of work.
+        // Measured in whole groups of area rather than per dimension: truncating
+        // each dimension separately makes the product zero whenever a dimension
+        // is under one group, which pins max_threads to 1 and renders serially.
+        let group_dim = self.header.group_dim();
+        let max_threads =
+            (self.header.size().0 * self.header.size().1).div_ceil(group_dim * group_dim) + 1;
 
         let hw_threads = std::thread::available_parallelism()
             .map(|x| x.get())

--- a/jxl/src/headers/frame_header.rs
+++ b/jxl/src/headers/frame_header.rs
@@ -652,6 +652,19 @@ impl FrameHeader {
         Rect { origin, size }
     }
 
+    pub fn group_rect(&self, group: usize) -> Rect {
+        let lf_dims = self.size_groups();
+        let dims = self.size();
+        let gx = group % lf_dims.0;
+        let gy = group / lf_dims.0;
+        let origin = (gx * self.group_dim(), gy * self.group_dim());
+        let size = (
+            min(dims.0.checked_sub(origin.0).unwrap(), self.group_dim()),
+            min(dims.1.checked_sub(origin.1).unwrap(), self.group_dim()),
+        );
+        Rect { origin, size }
+    }
+
     pub fn postprocess(&mut self, nonserialized: &FrameHeaderNonserialized) {
         if self.upsampling > 1 {
             for i in 0..nonserialized.extra_channel_info.len() {


### PR DESCRIPTION
max_threads in decode_and_render_hf_groups is a product of two truncating
divisions, so any image with a side smaller than group_dim gets a zero factor,
a cap of 1, and a serial render. A 1476x156 image has six groups but only ever
gets one thread.

Use div_ceil so partial groups count. On 8 threads that is 1.5x to 4.4x faster
for images with a short side (1476x156 goes from 17.8ms to 4.0ms). Images with
both sides larger than group_dim are unchanged.