### PR TITLE
Clip low-memory ready rectangles to the input size

### DIFF
--- a/jxl/src/render/low_memory_pipeline/group_scheduler.rs
+++ b/jxl/src/render/low_memory_pipeline/group_scheduler.rs
@@ -70,6 +70,55 @@ fn foreach_ready_rect(
     Ok(())
 }
 
+fn ready_image_area(
+    group_rect: Rect,
+    group_position: (usize, usize),
+    group_count: (usize, usize),
+    input_size: (usize, usize),
+    border_size: (usize, usize),
+    xrange: Range<u8>,
+    yrange: Range<u8>,
+) -> Option<Rect> {
+    let (gx, gy) = group_position;
+    let y0 = match (gy == 0, yrange.start) {
+        (true, 0) => group_rect.origin.1,
+        (false, 0) => group_rect.origin.1 - border_size.1,
+        (_, 1) => group_rect.origin.1 + border_size.1,
+        // (_, 2)
+        _ => group_rect.end().1 - border_size.1,
+    };
+    let x0 = match (gx == 0, xrange.start) {
+        (true, 0) => group_rect.origin.0,
+        (false, 0) => group_rect.origin.0 - border_size.0,
+        (_, 1) => group_rect.origin.0 + border_size.0,
+        // (_, 2)
+        _ => group_rect.end().0 - border_size.0,
+    };
+
+    let y1 = match (gy + 1 == group_count.1, yrange.end) {
+        (true, 3) => group_rect.end().1,
+        (false, 3) => group_rect.end().1 + border_size.1,
+        (_, 2) => group_rect.end().1 - border_size.1,
+        // (_, 1)
+        _ => group_rect.origin.1 + border_size.1,
+    }
+    .min(input_size.1);
+
+    let x1 = match (gx + 1 == group_count.0, xrange.end) {
+        (true, 3) => group_rect.end().0,
+        (false, 3) => group_rect.end().0 + border_size.0,
+        (_, 2) => group_rect.end().0 - border_size.0,
+        // (_, 1)
+        _ => group_rect.origin.0 + border_size.0,
+    }
+    .min(input_size.0);
+
+    (x1 >= x0 && y1 >= y0).then_some(Rect {
+        origin: (x0, y0),
+        size: (x1 - x0, y1 - y0),
+    })
+}
+
 impl LowMemoryRenderPipeline {
     pub(super) fn maybe_get_scratch_buffer(
         &self,
@@ -185,48 +234,16 @@ impl LowMemoryRenderPipeline {
         data.ensure_populated(self)?;
 
         foreach_ready_rect(ready_mask, |xrange, yrange| {
-            let y0 = match (gy == 0, yrange.start) {
-                (true, 0) => group_rect.origin.1,
-                (false, 0) => group_rect.origin.1 - self.border_size.1,
-                (_, 1) => group_rect.origin.1 + self.border_size.1,
-                // (_, 2)
-                _ => group_rect.end().1 - self.border_size.1,
-            };
-            let x0 = match (gx == 0, xrange.start) {
-                (true, 0) => group_rect.origin.0,
-                (false, 0) => group_rect.origin.0 - self.border_size.0,
-                (_, 1) => group_rect.origin.0 + self.border_size.0,
-                // (_, 2)
-                _ => group_rect.end().0 - self.border_size.0,
-            };
-
-            let y1 = match (gy + 1 == self.shared.group_count.1, yrange.end) {
-                (true, 3) => group_rect.end().1,
-                (false, 3) => {
-                    (group_rect.end().1 + self.border_size.1).min(self.shared.input_size.1)
-                }
-                (_, 2) => group_rect.end().1 - self.border_size.1,
-                // (_, 1)
-                _ => group_rect.origin.1 + self.border_size.1,
-            };
-
-            let x1 = match (gx + 1 == self.shared.group_count.0, xrange.end) {
-                (true, 3) => group_rect.end().0,
-                (false, 3) => {
-                    (group_rect.end().0 + self.border_size.0).min(self.shared.input_size.0)
-                }
-                (_, 2) => group_rect.end().0 - self.border_size.0,
-                // (_, 1)
-                _ => group_rect.origin.0 + self.border_size.0,
-            };
-
-            if x1 < x0 || y1 < y0 {
+            let Some(image_area) = ready_image_area(
+                group_rect,
+                (gx, gy),
+                self.shared.group_count,
+                self.shared.input_size,
+                self.border_size,
+                xrange,
+                yrange,
+            ) else {
                 return Ok(());
-            }
-
-            let image_area = Rect {
-                origin: (x0, y0),
-                size: (x1 - x0, y1 - y0),
             };
 
             let mut local_buffers = buffer_splitter.get_local_buffers(
@@ -300,5 +317,28 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_ready_image_area_clips_tiny_edge_group() {
+        let area = ready_image_area(
+            Rect {
+                origin: (512, 512),
+                size: (8, 8),
+            },
+            (1, 1),
+            (2, 2),
+            (520, 520),
+            (18, 18),
+            0..1,
+            0..1,
+        );
+        assert_eq!(
+            area,
+            Some(Rect {
+                origin: (494, 494),
+                size: (26, 26),
+            })
+        );
     }
 }


### PR DESCRIPTION
#872's extra render thread exposed a pre-existing low-memory pipeline bug: a ready sector around a tiny edge group can extend beyond the image (for `stp2_520x260_d25_e6`, x=494..530 for a 520px image). Output buffers clip it, but pipeline stages still treat the extra pixels as valid, so right-edge padding starts too late and progressive output depends on group completion order.

Clip every computed ready rectangle to `input_size`; added a regression test for an 8x8 bottom-right group with an 18px border. Replays #872's failing shuttle seed cleanly; full regular/random/PCT suites pass.
