### PR TITLE
Add CMYK interleaved pixel format

### DIFF
--- a/jxl/src/api/data_types.rs
+++ b/jxl/src/api/data_types.rs
@@ -14,6 +14,10 @@ pub enum JxlColorType {
     Rgba,
     Bgr,
     Bgra,
+    /// Four interleaved channels: C, M, Y and K, where K is taken from the
+    /// image's Black extra channel. Only valid for color images with a Black
+    /// extra channel.
+    Cmyk,
 }
 
 impl JxlColorType {
@@ -23,6 +27,7 @@ impl JxlColorType {
             Self::GrayscaleAlpha => true,
             Self::Rgb | Self::Bgr => false,
             Self::Rgba | Self::Bgra => true,
+            Self::Cmyk => false,
         }
     }
     pub fn samples_per_pixel(&self) -> usize {
@@ -30,7 +35,7 @@ impl JxlColorType {
             Self::Grayscale => 1,
             Self::GrayscaleAlpha => 2,
             Self::Rgb | Self::Bgr => 3,
-            Self::Rgba | Self::Bgra => 4,
+            Self::Rgba | Self::Bgra | Self::Cmyk => 4,
         }
     }
     pub fn is_grayscale(&self) -> bool {
@@ -39,13 +44,38 @@ impl JxlColorType {
             Self::GrayscaleAlpha => true,
             Self::Rgb | Self::Bgr => false,
             Self::Rgba | Self::Bgra => false,
+            Self::Cmyk => false,
         }
     }
-    pub fn add_alpha(&self) -> Self {
+    pub fn add_alpha(&self) -> Option<Self> {
         match self {
-            Self::Grayscale | Self::GrayscaleAlpha => Self::GrayscaleAlpha,
-            Self::Rgb | Self::Rgba => Self::Rgba,
-            Self::Bgr | Self::Bgra => Self::Bgra,
+            Self::Grayscale | Self::GrayscaleAlpha => Some(Self::GrayscaleAlpha),
+            Self::Rgb | Self::Rgba => Some(Self::Rgba),
+            Self::Bgr | Self::Bgra => Some(Self::Bgra),
+            Self::Cmyk => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::JxlColorType;
+
+    #[test]
+    fn add_alpha() {
+        for (color_type, expected) in [
+            (JxlColorType::Grayscale, Some(JxlColorType::GrayscaleAlpha)),
+            (
+                JxlColorType::GrayscaleAlpha,
+                Some(JxlColorType::GrayscaleAlpha),
+            ),
+            (JxlColorType::Rgb, Some(JxlColorType::Rgba)),
+            (JxlColorType::Rgba, Some(JxlColorType::Rgba)),
+            (JxlColorType::Bgr, Some(JxlColorType::Bgra)),
+            (JxlColorType::Bgra, Some(JxlColorType::Bgra)),
+            (JxlColorType::Cmyk, None),
+        ] {
+            assert_eq!(color_type.add_alpha(), expected);
         }
     }
 }
@@ -241,6 +271,15 @@ impl JxlPixelFormat {
             color_data_format: Some(JxlDataFormat::F32 {
                 endianness: Endianness::native(),
             }),
+            extra_channel_format: vec![None; num_extra_channels],
+        }
+    }
+
+    /// Creates a CMYK 8-bit pixel format.
+    pub fn cmyk8(num_extra_channels: usize) -> Self {
+        Self {
+            color_type: JxlColorType::Cmyk,
+            color_data_format: Some(JxlDataFormat::U8 { bit_depth: 8 }),
             extra_channel_format: vec![None; num_extra_channels],
         }
     }

--- a/jxl/src/api/data_types.rs
+++ b/jxl/src/api/data_types.rs
@@ -14,6 +14,15 @@ pub enum JxlColorType {
     Rgba,
     Bgr,
     Bgra,
+    /// Four interleaved channels: C, M, Y and K, where K is taken from the
+    /// image's Black extra channel. Sample values keep the color channel
+    /// convention (maximum value = no ink), matching the "Inverted CMYK"
+    /// convention produced by CMYK JPEG decoders and expected by CMS
+    /// libraries. Only valid for CMYK images, i.e. color images with a Black
+    /// extra channel and a CMYK ICC color profile. There is no CMYKA: if the
+    /// image carries an alpha extra channel, request it as a separate extra
+    /// channel plane.
+    Cmyk,
 }
 
 impl JxlColorType {
@@ -23,6 +32,7 @@ impl JxlColorType {
             Self::GrayscaleAlpha => true,
             Self::Rgb | Self::Bgr => false,
             Self::Rgba | Self::Bgra => true,
+            Self::Cmyk => false,
         }
     }
     pub fn samples_per_pixel(&self) -> usize {
@@ -30,7 +40,7 @@ impl JxlColorType {
             Self::Grayscale => 1,
             Self::GrayscaleAlpha => 2,
             Self::Rgb | Self::Bgr => 3,
-            Self::Rgba | Self::Bgra => 4,
+            Self::Rgba | Self::Bgra | Self::Cmyk => 4,
         }
     }
     pub fn is_grayscale(&self) -> bool {
@@ -39,6 +49,7 @@ impl JxlColorType {
             Self::GrayscaleAlpha => true,
             Self::Rgb | Self::Bgr => false,
             Self::Rgba | Self::Bgra => false,
+            Self::Cmyk => false,
         }
     }
     pub fn add_alpha(&self) -> Self {
@@ -46,6 +57,9 @@ impl JxlColorType {
             Self::Grayscale | Self::GrayscaleAlpha => Self::GrayscaleAlpha,
             Self::Rgb | Self::Rgba => Self::Rgba,
             Self::Bgr | Self::Bgra => Self::Bgra,
+            // There is no CMYKA; alpha is only available as a separate
+            // extra channel plane.
+            Self::Cmyk => Self::Cmyk,
         }
     }
 }
@@ -241,6 +255,15 @@ impl JxlPixelFormat {
             color_data_format: Some(JxlDataFormat::F32 {
                 endianness: Endianness::native(),
             }),
+            extra_channel_format: vec![None; num_extra_channels],
+        }
+    }
+
+    /// Creates a CMYK 8-bit pixel format.
+    pub fn cmyk8(num_extra_channels: usize) -> Self {
+        Self {
+            color_type: JxlColorType::Cmyk,
+            color_data_format: Some(JxlDataFormat::U8 { bit_depth: 8 }),
             extra_channel_format: vec![None; num_extra_channels],
         }
     }

--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -263,6 +263,8 @@ pub enum Error {
     WrongBufferCount(usize, usize),
     #[error("Image is not grayscale, but grayscale output was requested")]
     NotGrayscale,
+    #[error("Image is not CMYK, but CMYK output was requested")]
+    NotCmyk,
     #[error("Invalid output buffer byte size {0}x{1} for {2}x{3} image with type {4:?} {5:?}")]
     InvalidOutputBufferSize(usize, usize, usize, usize, JxlColorType, JxlDataFormat),
     #[error("Attempting to save channels with different downsample amounts: {0:?} and {1:?}")]

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -848,13 +848,35 @@ impl Frame {
                 && alpha_in_color.is_some()
                 && !source_alpha_associated;
 
-            let color_source_channels: &[usize] =
+            // For CMYK output, interleave the Black extra channel as the
+            // fourth channel. This requires a color image with a Black extra
+            // channel.
+            let black_in_color = if pixel_format.color_type == JxlColorType::Cmyk {
+                let black_channel = decoder_state
+                    .file_header
+                    .image_metadata
+                    .extra_channel_info
+                    .iter()
+                    .position(|info| info.ec_type == ExtraChannel::Black);
+                match (num_color_channels, black_channel) {
+                    (3, Some(index)) => Some(index + 3),
+                    _ => return Err(Error::NotCmyk),
+                }
+            } else {
+                None
+            };
+            let cmyk_channels;
+            let color_source_channels: &[usize] = if let Some(black) = black_in_color {
+                cmyk_channels = [0, 1, 2, black];
+                &cmyk_channels
+            } else {
                 match (pixel_format.color_type.is_grayscale(), alpha_in_color) {
                     (true, None) => &[0],
                     (true, Some(c)) => &[0, c],
                     (false, None) => &[0, 1, 2],
                     (false, Some(c)) => &[0, 1, 2, c],
-                };
+                }
+            };
             if let Some(df) = &pixel_format.color_data_format {
                 // Add premultiply stage if needed (before conversion to output format)
                 if should_premultiply && let Some(alpha_channel) = alpha_in_color {

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -848,13 +848,41 @@ impl Frame {
                 && alpha_in_color.is_some()
                 && !source_alpha_associated;
 
-            let color_source_channels: &[usize] =
+            // For CMYK output, interleave the Black extra channel as the
+            // fourth channel. This requires an actual CMYK image: a color
+            // image with a Black extra channel and a CMYK ICC profile.
+            let black_in_color = if pixel_format.color_type == JxlColorType::Cmyk {
+                let black_channel = decoder_state
+                    .file_header
+                    .image_metadata
+                    .extra_channel_info
+                    .iter()
+                    .position(|info| info.ec_type == ExtraChannel::Black);
+                // ICC.1:2022 section 7.2: bytes 16..20 of the profile header
+                // hold the data colour space signature.
+                let has_cmyk_profile = matches!(
+                    output_profile,
+                    JxlColorProfile::Icc(icc) if icc.get(16..20) == Some(b"CMYK".as_slice())
+                );
+                match (num_color_channels, black_channel, has_cmyk_profile) {
+                    (3, Some(index), true) => Some(index + 3),
+                    _ => return Err(Error::NotCmyk),
+                }
+            } else {
+                None
+            };
+            let cmyk_channels;
+            let color_source_channels: &[usize] = if let Some(black) = black_in_color {
+                cmyk_channels = [0, 1, 2, black];
+                &cmyk_channels
+            } else {
                 match (pixel_format.color_type.is_grayscale(), alpha_in_color) {
                     (true, None) => &[0],
                     (true, Some(c)) => &[0, c],
                     (false, None) => &[0, 1, 2],
                     (false, Some(c)) => &[0, 1, 2, c],
-                };
+                }
+            };
             if let Some(df) = &pixel_format.color_data_format {
                 // Add premultiply stage if needed (before conversion to output format)
                 if should_premultiply && let Some(alpha_channel) = alpha_in_color {

--- a/jxl/src/tests/api.rs
+++ b/jxl/src/tests/api.rs
@@ -227,9 +227,11 @@ fn test_premultiply_output_straight_alpha() {
 
     for use_simple in [true, false] {
         let (straight_buffer, width, height) =
-            decode_with_format::<f32>(&file, &rgba_format, use_simple, false);
+            decode_with_format::<f32>(&file, &rgba_format, use_simple, false).unwrap();
+        let straight_buffer = &straight_buffer[0];
         let (premul_buffer, _, _) =
-            decode_with_format::<f32>(&file, &rgba_format, use_simple, true);
+            decode_with_format::<f32>(&file, &rgba_format, use_simple, true).unwrap();
+        let premul_buffer = &premul_buffer[0];
 
         let mut found_semitransparent = false;
         for y in 0..height {
@@ -318,9 +320,11 @@ fn test_premultiply_output_already_premultiplied() {
 
     for use_simple in [true, false] {
         let (without_flag_buffer, width, height) =
-            decode_with_format::<f32>(&file, &rgba_format, use_simple, false);
+            decode_with_format::<f32>(&file, &rgba_format, use_simple, false).unwrap();
+        let without_flag_buffer = &without_flag_buffer[0];
         let (with_flag_buffer, _, _) =
-            decode_with_format::<f32>(&file, &rgba_format, use_simple, true);
+            decode_with_format::<f32>(&file, &rgba_format, use_simple, true).unwrap();
+        let with_flag_buffer = &with_flag_buffer[0];
 
         for y in 0..height {
             let without_row = without_flag_buffer.row(y);
@@ -528,8 +532,11 @@ fn test_output_format_u8_matches_f32() {
 
         for use_simple in [true, false] {
             let (f32_buffer, width, height) =
-                decode_with_format::<f32>(&file, &f32_format, use_simple, false);
-            let (u8_buffer, _, _) = decode_with_format::<u8>(&file, &u8_format, use_simple, false);
+                decode_with_format::<f32>(&file, &f32_format, use_simple, false).unwrap();
+            let f32_buffer = &f32_buffer[0];
+            let (u8_buffer, _, _) =
+                decode_with_format::<u8>(&file, &u8_format, use_simple, false).unwrap();
+            let u8_buffer = &u8_buffer[0];
 
             let tolerance = 0.004;
             let mut max_error: f32 = 0.0;
@@ -584,9 +591,11 @@ fn test_output_format_u16_matches_f32() {
 
         for use_simple in [true, false] {
             let (f32_buffer, width, height) =
-                decode_with_format::<f32>(&file, &f32_format, use_simple, false);
+                decode_with_format::<f32>(&file, &f32_format, use_simple, false).unwrap();
+            let f32_buffer = &f32_buffer[0];
             let (u16_buffer, _, _) =
-                decode_with_format::<u16>(&file, &u16_format, use_simple, false);
+                decode_with_format::<u16>(&file, &u16_format, use_simple, false).unwrap();
+            let u16_buffer = &u16_buffer[0];
 
             let tolerance = 0.0001;
 
@@ -639,9 +648,11 @@ fn test_output_format_f16_matches_f32() {
 
         for use_simple in [true, false] {
             let (f32_buffer, width, height) =
-                decode_with_format::<f32>(&file, &f32_format, use_simple, false);
+                decode_with_format::<f32>(&file, &f32_format, use_simple, false).unwrap();
+            let f32_buffer = &f32_buffer[0];
             let (f16_buffer, _, _) =
-                decode_with_format::<f16>(&file, &f16_format, use_simple, false);
+                decode_with_format::<f16>(&file, &f16_format, use_simple, false).unwrap();
+            let f16_buffer = &f16_buffer[0];
 
             let tolerance = 0.002;
 
@@ -669,13 +680,72 @@ fn test_output_format_f16_matches_f32() {
     }
 }
 
-/// Helper function to decode an image with a specific format.
+/// CMYK interleaved output matches the RGB color channels for C, M and Y, and
+/// the Black extra channel plane for K.
+#[test]
+fn test_cmyk_pixel_format() {
+    let file = std::fs::read("resources/test/conformance_test_images/cmyk_layers.jxl").unwrap();
+
+    // cmyk_layers.jxl has two extra channels: Black (index 0) and Alpha
+    // (index 1).
+    let cmyk_format = JxlPixelFormat::cmyk8(2);
+    let reference_format = JxlPixelFormat {
+        color_type: JxlColorType::Rgb,
+        color_data_format: Some(JxlDataFormat::U8 { bit_depth: 8 }),
+        extra_channel_format: vec![Some(JxlDataFormat::U8 { bit_depth: 8 }), None],
+    };
+
+    for use_simple in [true, false] {
+        let (cmyk_buffers, width, height) =
+            decode_with_format::<u8>(&file, &cmyk_format, use_simple, false).unwrap();
+        let (reference_buffers, _, _) =
+            decode_with_format::<u8>(&file, &reference_format, use_simple, false).unwrap();
+        let cmyk = &cmyk_buffers[0];
+        let rgb = &reference_buffers[0];
+        let black = &reference_buffers[1];
+
+        for y in 0..height {
+            let cmyk_row = cmyk.row(y);
+            let rgb_row = rgb.row(y);
+            let black_row = black.row(y);
+            for x in 0..width {
+                for c in 0..3 {
+                    assert_eq!(
+                        cmyk_row[x * 4 + c],
+                        rgb_row[x * 3 + c],
+                        "CMY mismatch at ({x},{y}) channel {c} (use_simple={use_simple})"
+                    );
+                }
+                assert_eq!(
+                    cmyk_row[x * 4 + 3],
+                    black_row[x],
+                    "K mismatch at ({x},{y}) (use_simple={use_simple})"
+                );
+            }
+        }
+    }
+}
+
+/// Requesting CMYK output for a non-CMYK image fails.
+#[test]
+fn test_cmyk_pixel_format_requires_cmyk_image() {
+    let file = std::fs::read("resources/test/basic.jxl").unwrap();
+    let result = decode_with_format::<u8>(&file, &JxlPixelFormat::cmyk8(0), false, false);
+    assert!(
+        matches!(result, Err(Error::NotCmyk)),
+        "expected NotCmyk, got {result:?}"
+    );
+}
+
+/// Helper function to decode an image with a specific format, with buffers
+/// for the color channels (if requested) plus every requested extra channel
+/// plane. Returns the decoded buffers in process() buffer order.
 fn decode_with_format<T: crate::image::ImageDataType>(
     file: &[u8],
     pixel_format: &JxlPixelFormat,
     use_simple: bool,
     premultiply: bool,
-) -> (Image<T>, usize, usize) {
+) -> Result<(Vec<Image<T>>, usize, usize), Error> {
     let options = JxlDecoderOptions {
         premultiply_output: premultiply,
         ..Default::default()
@@ -684,7 +754,7 @@ fn decode_with_format<T: crate::image::ImageDataType>(
     let mut input = file;
 
     let mut decoder = loop {
-        match decoder.process(&mut input, None).unwrap() {
+        match decoder.process(&mut input, None)? {
             ProcessingResult::Complete { result } => break result,
             ProcessingResult::NeedsMoreInput { fallback, .. } => {
                 if input.is_empty() {
@@ -697,13 +767,11 @@ fn decode_with_format<T: crate::image::ImageDataType>(
     decoder.set_use_simple_pipeline(use_simple);
     decoder.set_pixel_format(pixel_format.clone());
 
-    let basic_info = decoder.basic_info().clone();
-    let (width, height) = basic_info.size;
-
+    let (width, height) = decoder.basic_info().size;
     let num_samples = pixel_format.color_type.samples_per_pixel();
 
-    let decoder = loop {
-        match decoder.process(&mut input, None).unwrap() {
+    let mut decoder = loop {
+        match decoder.process(&mut input, None)? {
             ProcessingResult::Complete { result } => break result,
             ProcessingResult::NeedsMoreInput { fallback, .. } => {
                 if input.is_empty() {
@@ -714,19 +782,32 @@ fn decode_with_format<T: crate::image::ImageDataType>(
         }
     };
 
-    let mut buffer = Image::<T>::new((width * num_samples, height)).unwrap();
-    let mut buffers: Vec<_> = vec![JxlOutputBuffer::from_image_rect_mut(
-        buffer
-            .get_rect_mut(Rect {
-                origin: (0, 0),
-                size: (width * num_samples, height),
-            })
-            .into_raw(),
-    )];
+    let mut images = Vec::new();
+    if pixel_format.color_data_format.is_some() {
+        images.push(Image::<T>::new((width * num_samples, height))?);
+    }
+    for ec_format in &pixel_format.extra_channel_format {
+        if ec_format.is_some() {
+            images.push(Image::<T>::new((width, height))?);
+        }
+    }
+    let mut buffers: Vec<JxlOutputBuffer> = images
+        .iter_mut()
+        .map(|image| {
+            let size = image.size();
+            JxlOutputBuffer::from_image_rect_mut(
+                image
+                    .get_rect_mut(Rect {
+                        origin: (0, 0),
+                        size,
+                    })
+                    .into_raw(),
+            )
+        })
+        .collect();
 
-    let mut decoder = decoder;
     loop {
-        match decoder.process(&mut input, &mut buffers, None).unwrap() {
+        match decoder.process(&mut input, &mut buffers, None)? {
             ProcessingResult::Complete { .. } => break,
             ProcessingResult::NeedsMoreInput { fallback, .. } => {
                 if input.is_empty() {
@@ -736,8 +817,9 @@ fn decode_with_format<T: crate::image::ImageDataType>(
             }
         }
     }
+    drop(buffers);
 
-    (buffer, width, height)
+    Ok((images, width, height))
 }
 
 /// Regression test for ClusterFuzz issue 5342436251336704

--- a/jxl/src/tests/api.rs
+++ b/jxl/src/tests/api.rs
@@ -669,6 +669,144 @@ fn test_output_format_f16_matches_f32() {
     }
 }
 
+/// Helper to decode with u8 output and buffers for the color channels plus
+/// every requested extra channel plane. Returns the decoded buffers in
+/// process() buffer order.
+fn decode_with_ec_buffers(
+    file: &[u8],
+    pixel_format: &JxlPixelFormat,
+    use_simple: bool,
+) -> Result<(Vec<Image<u8>>, usize, usize), Error> {
+    let options = JxlDecoderOptions::default();
+    let mut decoder = JxlDecoder::<states::Initialized>::new(options);
+    let mut input = file;
+
+    let mut decoder = loop {
+        match decoder.process(&mut input, None)? {
+            ProcessingResult::Complete { result } => break result,
+            ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                if input.is_empty() {
+                    panic!("Unexpected end of input");
+                }
+                decoder = fallback;
+            }
+        }
+    };
+    decoder.set_use_simple_pipeline(use_simple);
+    decoder.set_pixel_format(pixel_format.clone());
+
+    let (width, height) = decoder.basic_info().size;
+    let num_samples = pixel_format.color_type.samples_per_pixel();
+
+    let mut decoder = loop {
+        match decoder.process(&mut input, None)? {
+            ProcessingResult::Complete { result } => break result,
+            ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                if input.is_empty() {
+                    panic!("Unexpected end of input");
+                }
+                decoder = fallback;
+            }
+        }
+    };
+
+    let mut images = Vec::new();
+    if pixel_format.color_data_format.is_some() {
+        images.push(Image::<u8>::new((width * num_samples, height)).unwrap());
+    }
+    for ec_format in &pixel_format.extra_channel_format {
+        if ec_format.is_some() {
+            images.push(Image::<u8>::new((width, height)).unwrap());
+        }
+    }
+    let mut buffers: Vec<JxlOutputBuffer> = images
+        .iter_mut()
+        .map(|image| {
+            let size = image.size();
+            JxlOutputBuffer::from_image_rect_mut(
+                image
+                    .get_rect_mut(Rect {
+                        origin: (0, 0),
+                        size,
+                    })
+                    .into_raw(),
+            )
+        })
+        .collect();
+
+    loop {
+        match decoder.process(&mut input, &mut buffers, None)? {
+            ProcessingResult::Complete { .. } => break,
+            ProcessingResult::NeedsMoreInput { fallback, .. } => {
+                if input.is_empty() {
+                    panic!("Unexpected end of input");
+                }
+                decoder = fallback;
+            }
+        }
+    }
+    drop(buffers);
+
+    Ok((images, width, height))
+}
+
+/// CMYK interleaved output matches the RGB color channels for C, M and Y, and
+/// the Black extra channel plane for K.
+#[test]
+fn test_cmyk_pixel_format() {
+    let file = std::fs::read("resources/test/conformance_test_images/cmyk_layers.jxl").unwrap();
+
+    // cmyk_layers.jxl has two extra channels: Black (index 0) and Alpha
+    // (index 1).
+    let cmyk_format = JxlPixelFormat::cmyk8(2);
+    let reference_format = JxlPixelFormat {
+        color_type: JxlColorType::Rgb,
+        color_data_format: Some(JxlDataFormat::U8 { bit_depth: 8 }),
+        extra_channel_format: vec![Some(JxlDataFormat::U8 { bit_depth: 8 }), None],
+    };
+
+    for use_simple in [true, false] {
+        let (cmyk_buffers, width, height) =
+            decode_with_ec_buffers(&file, &cmyk_format, use_simple).unwrap();
+        let (reference_buffers, _, _) =
+            decode_with_ec_buffers(&file, &reference_format, use_simple).unwrap();
+        let cmyk = &cmyk_buffers[0];
+        let rgb = &reference_buffers[0];
+        let black = &reference_buffers[1];
+
+        for y in 0..height {
+            let cmyk_row = cmyk.row(y);
+            let rgb_row = rgb.row(y);
+            let black_row = black.row(y);
+            for x in 0..width {
+                for c in 0..3 {
+                    assert_eq!(
+                        cmyk_row[x * 4 + c],
+                        rgb_row[x * 3 + c],
+                        "CMY mismatch at ({x},{y}) channel {c} (use_simple={use_simple})"
+                    );
+                }
+                assert_eq!(
+                    cmyk_row[x * 4 + 3],
+                    black_row[x],
+                    "K mismatch at ({x},{y}) (use_simple={use_simple})"
+                );
+            }
+        }
+    }
+}
+
+/// Requesting CMYK output for a non-CMYK image fails.
+#[test]
+fn test_cmyk_pixel_format_requires_cmyk_image() {
+    let file = std::fs::read("resources/test/basic.jxl").unwrap();
+    let result = decode_with_ec_buffers(&file, &JxlPixelFormat::cmyk8(0), false);
+    assert!(
+        matches!(result, Err(Error::NotCmyk)),
+        "expected NotCmyk, got {result:?}"
+    );
+}
+
 /// Helper function to decode an image with a specific format.
 fn decode_with_format<T: crate::image::ImageDataType>(
     file: &[u8],

--- a/jxl_cli/src/dec/mod.rs
+++ b/jxl_cli/src/dec/mod.rs
@@ -198,7 +198,10 @@ pub fn decode_frames<In: JxlBitstreamInputExt>(
     let current_format = decoder_with_image_info.current_pixel_format().clone();
     let new_format = JxlPixelFormat {
         color_type: if interleave_alpha {
-            current_format.color_type.add_alpha()
+            current_format
+                .color_type
+                .add_alpha()
+                .ok_or_else(|| eyre!("Output color type does not support interleaved alpha"))?
         } else {
             current_format.color_type
         },


### PR DESCRIPTION
Embedders currently receive K as a separate extra channel plane and have to re-interleave it into the fourth byte before handing pixels to their CMS (skcms consumes C,M,Y,K interleaved with K in the alpha slot, qcms takes interleaved CMYK too); both Firefox and Chromium grew per-pixel merge loops for this.

Add `JxlColorType::Cmyk`: four interleaved channels where K comes from the Black extra channel, keeping the color channel convention (max value = no ink). That matches the "inverted CMYK" convention CMYK JPEG decoders produce, so the buffer drops straight into existing CMYK consumer paths. Requesting it errors with `NotCmyk` unless the image is a color image with a Black extra channel. There is no CMYKA; if the image also carries an alpha extra channel it stays available as a separate extra channel plane, untouched by this format.

Tests: interleaved output matches the Rgb + Black-plane decode bit-exactly on `cmyk_layers.jxl` for both pipelines, plus the error case.