### PR TITLE
Reject pixel format changes after the first frame header is decoded

### DIFF
--- a/jxl/src/api/decoder.rs
+++ b/jxl/src/api/decoder.rs
@@ -154,8 +154,12 @@ impl JxlDecoder<WithImageInfo> {
     ///
     /// Setting this may also change output color profile in some cases, if the profile was not set
     /// manually before.
-    pub fn set_pixel_format(&mut self, pixel_format: JxlPixelFormat) {
-        self.inner.set_pixel_format(pixel_format);
+    ///
+    /// The pixel format can only be changed before the first frame header is
+    /// decoded, i.e. right after basic info becomes available; afterwards
+    /// this returns an error (except when the format does not change).
+    pub fn set_pixel_format(&mut self, pixel_format: JxlPixelFormat) -> Result<()> {
+        self.inner.set_pixel_format(pixel_format)
     }
 
     pub fn process(

--- a/jxl/src/api/inner/mod.rs
+++ b/jxl/src/api/inner/mod.rs
@@ -10,6 +10,7 @@ use super::{JxlBasicInfo, JxlColorProfile, JxlDecoderOptions, JxlPixelFormat};
 #[cfg(test)]
 use crate::api::FrameCallback;
 use crate::api::{JxlFrameHeader, VisibleFrameInfo, VisibleFrameSeekTarget};
+use crate::error::{Error, Result};
 
 mod box_parser;
 mod codestream_parser;
@@ -66,11 +67,27 @@ impl JxlDecoderInner {
         self.codestream_parser.pixel_format.as_ref()
     }
 
-    pub fn set_pixel_format(&mut self, pixel_format: JxlPixelFormat) {
+    pub fn set_pixel_format(&mut self, pixel_format: JxlPixelFormat) -> Result<()> {
         // TODO(veluca): return an error if we are asking for both planar and
         // interleaved-in-color alpha.
+        // Frame render pipelines are built for the pixel format that is
+        // current when the frame's TOC is parsed, so the format can only be
+        // changed before the first frame header is decoded, i.e. right after
+        // basic info becomes available.
+        let frame_header_was_decoded = self
+            .codestream_parser
+            .frame_info
+            .current_frame_header()
+            .is_some()
+            || !self.codestream_parser.scanned_frames().is_empty();
+        if frame_header_was_decoded
+            && self.codestream_parser.pixel_format.as_ref() != Some(&pixel_format)
+        {
+            return Err(Error::PixelFormatChangedAfterFirstFrame);
+        }
         self.codestream_parser.pixel_format = Some(pixel_format);
         self.codestream_parser.update_default_output_options();
+        Ok(())
     }
 
     pub fn frame_header(&self) -> Option<JxlFrameHeader> {

--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -267,6 +267,8 @@ pub enum Error {
     NotGrayscale,
     #[error("Image is not CMYK, but CMYK output was requested")]
     NotCmyk,
+    #[error("The pixel format can only be changed before the first frame header is decoded")]
+    PixelFormatChangedAfterFirstFrame,
     #[error("Invalid output buffer byte size {0}x{1} for {2}x{3} image with type {4:?} {5:?}")]
     InvalidOutputBufferSize(usize, usize, usize, usize, JxlColorType, JxlDataFormat),
     #[error("Attempting to save channels with different downsample amounts: {0:?} and {1:?}")]

--- a/jxl/src/tests/api.rs
+++ b/jxl/src/tests/api.rs
@@ -93,7 +93,7 @@ fn test_set_pixel_format() {
         color_data_format: Some(JxlDataFormat::U8 { bit_depth: 8 }),
         extra_channel_format: vec![],
     };
-    decoder.set_pixel_format(new_format.clone());
+    decoder.set_pixel_format(new_format.clone()).unwrap();
     assert_eq!(decoder.current_pixel_format(), &new_format);
 }
 
@@ -115,19 +115,21 @@ fn test_default_output_tf_by_pixel_format() {
         JxlTransferFunction::Linear,
     );
 
-    decoder.set_pixel_format(JxlPixelFormat::rgba8(0));
+    decoder.set_pixel_format(JxlPixelFormat::rgba8(0)).unwrap();
     assert_eq!(
         *decoder.output_color_profile().transfer_function().unwrap(),
         JxlTransferFunction::SRGB,
     );
 
-    decoder.set_pixel_format(JxlPixelFormat::rgba_f16(0));
+    decoder
+        .set_pixel_format(JxlPixelFormat::rgba_f16(0))
+        .unwrap();
     assert_eq!(
         *decoder.output_color_profile().transfer_function().unwrap(),
         JxlTransferFunction::Linear,
     );
 
-    decoder.set_pixel_format(JxlPixelFormat::rgba16(0));
+    decoder.set_pixel_format(JxlPixelFormat::rgba16(0)).unwrap();
     assert_eq!(
         *decoder.output_color_profile().transfer_function().unwrap(),
         JxlTransferFunction::SRGB,
@@ -180,7 +182,7 @@ fn test_fill_opaque_alpha_both_pipelines() {
         let mut decoder = decoder;
         let mut decoder = advance_decoder!(decoder);
         decoder.set_use_simple_pipeline(use_simple);
-        decoder.set_pixel_format(rgba_format.clone());
+        decoder.set_pixel_format(rgba_format.clone()).unwrap();
 
         let basic_info = decoder.basic_info().clone();
         let (width, height) = basic_info.size;
@@ -391,7 +393,7 @@ fn test_animation_with_reference_frames() {
         color_data_format: Some(JxlDataFormat::f32()),
         extra_channel_format: vec![],
     };
-    decoder.set_pixel_format(rgb_format);
+    decoder.set_pixel_format(rgb_format).unwrap();
 
     let basic_info = decoder.basic_info().clone();
     let (width, height) = basic_info.size;
@@ -468,7 +470,7 @@ fn test_skip_frame_then_decode_next() {
         color_data_format: Some(JxlDataFormat::f32()),
         extra_channel_format: vec![],
     };
-    decoder.set_pixel_format(rgb_format);
+    decoder.set_pixel_format(rgb_format).unwrap();
 
     let basic_info = decoder.basic_info().clone();
     let (width, height) = basic_info.size;
@@ -782,7 +784,7 @@ fn decode_with_format<T: crate::image::ImageDataType>(
         }
     };
     decoder.set_use_simple_pipeline(use_simple);
-    decoder.set_pixel_format(pixel_format.clone());
+    decoder.set_pixel_format(pixel_format.clone()).unwrap();
 
     let (width, height) = decoder.basic_info().size;
     let num_samples = pixel_format.color_type.samples_per_pixel();
@@ -978,7 +980,7 @@ fn assert_start_new_frame_matches_sequential(data: &[u8]) {
                     .map(|_| Some(JxlDataFormat::f32()))
                     .collect(),
             };
-            decoder.set_pixel_format(requested_format.clone());
+            decoder.set_pixel_format(requested_format.clone()).unwrap();
 
             let channels = requested_format.color_type.samples_per_pixel();
             let num_ec = requested_format.extra_channel_format.len();

--- a/jxl/src/tests/decode.rs
+++ b/jxl/src/tests/decode.rs
@@ -123,7 +123,9 @@ pub fn decode_internal(
             .map(|_| Some(JxlDataFormat::f32()))
             .collect(),
     };
-    decoder_with_image_info.set_pixel_format(requested_format);
+    decoder_with_image_info
+        .set_pixel_format(requested_format)
+        .unwrap();
 
     // Get the configured pixel format
     let pixel_format = decoder_with_image_info.current_pixel_format().clone();

--- a/jxl_cli/src/dec/mod.rs
+++ b/jxl_cli/src/dec/mod.rs
@@ -219,7 +219,7 @@ pub fn decode_frames<In: JxlBitstreamInputExt>(
             })
             .collect(),
     };
-    decoder_with_image_info.set_pixel_format(new_format);
+    decoder_with_image_info.set_pixel_format(new_format)?;
 
     // If linear output is requested, initialize the CMS transformer
     let mut output_profile = decoder_with_image_info.output_color_profile().clone();


### PR DESCRIPTION
Reworked per review: the pixel format is now frozen as soon as the first frame header is decoded. `set_pixel_format` returns `Error::PixelFormatChangedAfterFirstFrame` after that point (setting an identical format stays allowed), so the format can be changed at most right after basic info becomes available. No render-time checks or pipeline-format snapshots are needed anymore.

One subtlety: this is reachable through the type-safe API as well. Invisible frames (e.g. reference frames) are decoded inside `process()` while the decoder stays in the `WithImageInfo` state, so the typestate `set_pixel_format` now returns `Result` and propagates the error rather than hiding it.

Chrome-side reproduction (fixed in https://chromium-review.googlesource.com/c/chromium/src/+/8278890, so this is defense in depth): the frame scanner (`scan_frames_only`) processed all buffered input in a loop and only configured its pixel format (no extra channel buffers) after the loop drained. When the first network chunk contained enough data, the decoder had already parsed ahead into `patches.jxl`'s reference frame and built its pipeline with the default pixel format (color + all extra channels), so any later render aborted the renderer (`index out of bounds: the len is 5 but the index is 5` in `check_buffer_sizes`). The Chromium fix configures the format right when `process()` first reports basic info.
