### PR TITLE
Reject invalid blending reference frames

### DIFF
--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -147,6 +147,8 @@ pub enum Error {
     InvalidProperty(u32),
     #[error("Invalid alpha channel for blending: {0}, limit is {1}")]
     InvalidBlendingAlphaChannel(usize, usize),
+    #[error("Blending cannot use reference frame {0} saved before color transforms")]
+    BlendingPreColorTransform(usize),
     #[error("Invalid alpha channel for blending: {0}, limit is {1}")]
     PatchesInvalidAlphaChannel(usize, usize),
     #[error("Invalid patch blend mode: {0}, limit is {1}")]

--- a/jxl/src/render/stages/blending.rs
+++ b/jxl/src/render/stages/blending.rs
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::features::blending::perform_blending;
 use crate::features::patches::{PatchBlendMode, PatchBlending};
 use crate::frame::ReferenceFrame;
@@ -61,18 +61,34 @@ impl BlendingStage {
         file_header: &FileHeader,
         reference_frames: Arc<[Option<ReferenceFrame>; 4]>,
     ) -> Result<BlendingStage> {
-        let xsize = file_header.size.xsize();
+        let image_size = (
+            file_header.size.xsize() as usize,
+            file_header.size.ysize() as usize,
+        );
+        for info in
+            std::iter::once(&frame_header.blending_info).chain(frame_header.ec_blending_info.iter())
+        {
+            let source = info.source as usize;
+            let Some(frame) = reference_frames[source].as_ref() else {
+                continue;
+            };
+            if frame.saved_before_color_transform {
+                return Err(Error::BlendingPreColorTransform(source));
+            }
+            assert_eq!(frame.frame[0].size(), image_size);
+        }
+
         let ec_blending_info = frame_header.ec_blending_info.clone();
         let ec_patch_blending_info = ec_blending_info.iter().map(PatchBlending::from).collect();
         Ok(BlendingStage {
             frame_origin: (frame_header.x0 as isize, frame_header.y0 as isize),
-            image_size: (xsize as isize, file_header.size.ysize() as isize),
+            image_size: (image_size.0 as isize, image_size.1 as isize),
             blending_info: frame_header.blending_info.clone(),
             ec_blending_info,
             ec_patch_blending_info,
             extra_channels: file_header.image_metadata.extra_channel_info.clone(),
             reference_frames,
-            zeros: vec![0f32; xsize as usize],
+            zeros: vec![0f32; image_size.0],
         })
     }
 }
@@ -179,17 +195,67 @@ mod test {
     fn blending_consistency() -> Result<()> {
         let (file_header, frame_header, _) =
             read_headers_and_toc(include_bytes!("../../../resources/test/basic.jxl")).unwrap();
+        let image_size = (
+            file_header.size.xsize() as usize,
+            file_header.size.ysize() as usize,
+        );
         let mut rng = rand_xorshift::XorShiftRng::seed_from_u64(0);
+        let mut reference_frame =
+            || ReferenceFrame::random(&mut rng, image_size.0, image_size.1, 4, false);
         let reference_frames = Arc::new([
-            Some(ReferenceFrame::random(&mut rng, 500, 500, 4, false)?),
-            Some(ReferenceFrame::random(&mut rng, 500, 500, 4, false)?),
-            Some(ReferenceFrame::random(&mut rng, 500, 500, 4, false)?),
-            Some(ReferenceFrame::random(&mut rng, 500, 500, 4, false)?),
+            Some(reference_frame()?),
+            Some(reference_frame()?),
+            Some(reference_frame()?),
+            Some(reference_frame()?),
         ]);
         crate::render::test::test_stage_consistency(
             || BlendingStage::new(&frame_header, &file_header, reference_frames.clone()).unwrap(),
             (500, 500),
             4,
         )
+    }
+
+    #[test]
+    fn reject_blending_with_pre_color_transform_reference() -> Result<()> {
+        let (file_header, mut frame_header, _) =
+            read_headers_and_toc(include_bytes!("../../../resources/test/basic.jxl")).unwrap();
+        frame_header.blending_info.source = 3;
+        let image_size = (
+            file_header.size.xsize() as usize,
+            file_header.size.ysize() as usize,
+        );
+        let reference_frames = Arc::new([
+            None,
+            None,
+            None,
+            Some(ReferenceFrame::blank(image_size.0, image_size.1, 4, true)?),
+        ]);
+
+        let result = BlendingStage::new(&frame_header, &file_header, reference_frames);
+        assert!(matches!(result, Err(Error::BlendingPreColorTransform(3))));
+        Ok(())
+    }
+
+    #[test]
+    fn reject_extra_channel_blending_with_pre_color_transform_reference() -> Result<()> {
+        let (file_header, mut frame_header, _) =
+            read_headers_and_toc(include_bytes!("../../../resources/test/basic.jxl")).unwrap();
+        let mut ec_blending_info = frame_header.blending_info.clone();
+        ec_blending_info.source = 2;
+        frame_header.ec_blending_info.push(ec_blending_info);
+        let image_size = (
+            file_header.size.xsize() as usize,
+            file_header.size.ysize() as usize,
+        );
+        let reference_frames = Arc::new([
+            None,
+            None,
+            Some(ReferenceFrame::blank(image_size.0, image_size.1, 4, true)?),
+            None,
+        ]);
+
+        let result = BlendingStage::new(&frame_header, &file_header, reference_frames);
+        assert!(matches!(result, Err(Error::BlendingPreColorTransform(2))));
+        Ok(())
     }
 }


### PR DESCRIPTION
Reject blending against pre-color-transform or undersized reference frames before constructing the render pipeline. This prevents out-of-bounds row access for malformed codestreams.

ClusterFuzz: https://clusterfuzz.com/testcase?key=5937058744926208
Chromium issue: https://issues.chromium.org/issues/550831596
