### PR TITLE
Premultiply expanded grayscale RGBA channels

### DIFF
--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -880,9 +880,14 @@ impl Frame {
             if let Some(df) = &pixel_format.color_data_format {
                 // Add premultiply stage if needed (before conversion to output format)
                 if should_premultiply && let Some(alpha_channel) = alpha_in_color {
+                    let num_output_color_channels = if pixel_format.color_type.is_grayscale() {
+                        1
+                    } else {
+                        3
+                    };
                     pipeline = pipeline.add_inplace_stage(PremultiplyAlphaStage::new(
                         0,
-                        num_color_channels,
+                        num_output_color_channels,
                         alpha_channel,
                     ));
                 }

--- a/jxl/src/tests/api.rs
+++ b/jxl/src/tests/api.rs
@@ -305,6 +305,23 @@ fn test_premultiply_output_straight_alpha() {
     }
 }
 
+/// Test that premultiplied RGBA output from a grayscale image remains gray.
+#[test]
+fn test_premultiply_output_grayscale_as_rgba() {
+    let file = std::fs::read("resources/test/gray_alpha_lossless.jxl").unwrap();
+    let (buffers, width, height) =
+        decode_with_format::<f32>(&file, &JxlPixelFormat::rgba_f32(1), false, true).unwrap();
+    let rgba = &buffers[0];
+
+    for y in 0..height {
+        let row = rgba.row(y);
+        for x in 0..width {
+            assert_eq!(row[x * 4], row[x * 4 + 1]);
+            assert_eq!(row[x * 4 + 1], row[x * 4 + 2]);
+        }
+    }
+}
+
 /// Test that premultiply_output=true doesn't double-premultiply
 /// when the source already has premultiplied alpha (alpha_associated=true).
 #[test]


### PR DESCRIPTION
When grayscale images are requested as RGBA, alpha premultiplication only updates the source grayscale channel, leaving the expanded G/B channels unpremultiplied.

Premultiply all output color channels and add a regression checking that premultiplied RGBA output remains grayscale.