### PR TITLE
Extend the Zero-predictor fast path to scaled leaves

### DIFF
--- a/jxl/src/frame/modular/decode/specialized_trees.rs
+++ b/jxl/src/frame/modular/decode/specialized_trees.rs
@@ -370,6 +370,8 @@ impl<R: Reader> ModularChannelDecoder for SingleGradientOnly<R> {
 struct NoTreeZero {
     clustered_ctx: usize,
     single_value: Option<i32>,
+    multiplier: u32,
+    offset: i64,
 }
 
 impl ModularChannelDecoder for NoTreeZero {
@@ -398,10 +400,16 @@ impl ModularChannelDecoder for NoTreeZero {
         let row = buffers[chan].data.row_mut(y);
         debug_assert_eq!(row.len(), xsize);
         if let Some(sym) = self.single_value {
-            row.fill(sym);
-        } else {
+            row.fill(make_pixel(sym, self.multiplier, self.offset));
+        } else if self.multiplier == 1 && self.offset == 0 {
             for r in row.iter_mut() {
                 *r = reader.read_signed_clustered_inline(histograms, br, self.clustered_ctx);
+            }
+        } else {
+            for r in row.iter_mut() {
+                let residual =
+                    reader.read_signed_clustered_inline(histograms, br, self.clustered_ctx);
+                *r = make_pixel(residual, self.multiplier, self.offset);
             }
         }
     }
@@ -508,8 +516,8 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
     if let [
         TreeNode::Leaf {
             predictor: Predictor::Zero,
-            multiplier: 1,
-            offset: 0,
+            multiplier,
+            offset,
             id,
         },
     ] = &*pruned_tree
@@ -517,6 +525,8 @@ pub fn run_on_specialized_tree<F: FnOnce(&mut dyn ModularChannelDecoder) -> Resu
         return run(&mut NoTreeZero {
             clustered_ctx: *id as usize,
             single_value: single_symbol.map(unpack_signed),
+            multiplier: *multiplier,
+            offset: *offset as i64,
         });
     }
 


### PR DESCRIPTION
Single-leaf Zero trees with a non-trivial multiplier or offset (common for palette-delta index channels) previously fell through to the generic flat-tree decoder, recomputing all tree properties per pixel. This routes them through the existing `NoTreeZero` fast path, applying the multiplier/offset when producing the pixel. The tight loop for `multiplier == 1, offset == 0` is unchanged.

Measured with a single-binary A/B toggle (so code layout is constant), median of 8 alternating `taskset`-pinned runs, `--release`, `--num-threads 1`:

| file | before MP/s | after MP/s | delta |
|---|---|---|---|
| palette-heavy photo (e7, palette+delta) | 12.97 | 15.51 | +19.5% |
| effort-3 lossless | 9.19 | 9.71 | +5.6% |
| 55_Cancri_e (cjxl v0.12 `-d 0`) | 6.21 | 6.30 | +1.4% |

Decoded output is bit-identical to main on all test files.
