### PR TITLE
Reduce Modular decoder peak memory

### DIFF
--- a/jxl/src/frame/modular/buffers.rs
+++ b/jxl/src/frame/modular/buffers.rs
@@ -77,6 +77,10 @@ impl NeededBorders {
         topbottom: false,
         leftright: true,
     };
+    pub const BOTH: Self = Self {
+        topbottom: true,
+        leftright: true,
+    };
 
     pub fn is_empty(&self) -> bool {
         !self.topbottom && !self.leftright
@@ -94,6 +98,9 @@ pub(super) struct ModularBuffer {
     // the transform chunk that produced this buffer.
     pub(super) auxiliary_data: RwLock<Option<Image<i32>>>,
     pub(super) needed_borders: NeededBorders,
+    // Number of final-render transforms that still need each border buffer.
+    remaining_topbottom_uses: AtomicUsize,
+    remaining_leftright_uses: AtomicUsize,
     // Number of times this buffer will be used, *including* when it is used for output.
     pub(super) remaining_uses: AtomicUsize,
     // Number of full-buffer uses for final renders.
@@ -120,6 +127,8 @@ impl ModularBuffer {
             leftright: RwLock::new(None),
             auxiliary_data: RwLock::new(None),
             needed_borders: NeededBorders::NONE,
+            remaining_topbottom_uses: AtomicUsize::new(0),
+            remaining_leftright_uses: AtomicUsize::new(0),
             remaining_uses: AtomicUsize::new(0),
             full_uses_count_final: 0,
             used_by_transforms_final: vec![],
@@ -136,6 +145,55 @@ impl ModularBuffer {
 
     pub fn has_borders(&self) -> bool {
         self.topbottom.try_read().unwrap().is_some() || self.leftright.try_read().unwrap().is_some()
+    }
+
+    pub fn add_final_border_use(&self, borders: NeededBorders) {
+        if borders.topbottom {
+            self.remaining_topbottom_uses
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if borders.leftright {
+            self.remaining_leftright_uses
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    // Every cell with needed borders holds one extra "extract credit" per orientation,
+    // released by its producer after its last `extract_needed_borders` call. This guarantees
+    // that the border use counts can only reach zero -- and thus the border storage can only be
+    // freed -- after the producer has finished (re-)extracting the borders, so the freeing
+    // write can never race with the extraction write.
+    pub fn add_border_extract_credit(&self) {
+        self.add_final_border_use(self.needed_borders);
+    }
+
+    pub fn release_border_extract_credit(&self) {
+        self.mark_final_borders_used(self.needed_borders);
+    }
+
+    pub fn mark_final_borders_used(&self, borders: NeededBorders) {
+        if borders.topbottom {
+            let previous = self
+                .remaining_topbottom_uses
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |uses| {
+                    Some(uses.checked_sub(1).unwrap())
+                })
+                .unwrap();
+            if previous == 1 {
+                *self.topbottom.try_write().unwrap() = None;
+            }
+        }
+        if borders.leftright {
+            let previous = self
+                .remaining_leftright_uses
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |uses| {
+                    Some(uses.checked_sub(1).unwrap())
+                })
+                .unwrap();
+            if previous == 1 {
+                *self.leftright.try_write().unwrap() = None;
+            }
+        }
     }
 
     pub fn extract_needed_borders(&self) -> Result<()> {

--- a/jxl/src/frame/modular/buffers.rs
+++ b/jxl/src/frame/modular/buffers.rs
@@ -254,6 +254,14 @@ impl ModularBuffer {
         Ok(())
     }
 
+    // Whether a use of this buffer is allowed to consume it: either this is a final use, or the
+    // buffer holds partially-rendered data that a later progressive render pass will regenerate
+    // from its (retained) producer inputs.
+    #[inline]
+    pub fn can_consume(&self, is_final: bool) -> bool {
+        (self.produced_by_step.is_some() && self.data_status == DataStatus::Partial) || is_final
+    }
+
     // Gives out a copy of the buffer + auxiliary buffer, marking the buffer as used.
     // If this was the last usage of the buffer, does not actually copy the buffer.
     pub fn get_buffer(&self, can_consume: bool) -> Result<ModularChannel> {

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -763,6 +763,14 @@ impl FullModularImage {
         frame_header: &FrameHeader,
         mut group_callback: impl FnMut(usize, usize, bool),
     ) {
+        // Reset the use counts of partially-rendered buffers that will be re-rendered during
+        // this pass; the uses of this pass are counted below.
+        for &(b, g) in &self.rerendered_buffers {
+            let buf = &self.buffer_info[b].buffer_grid[g];
+            if buf.can_consume(false) {
+                buf.remaining_uses.store(0, Ordering::Relaxed);
+            }
+        }
         for t in self.pending_transforms.iter().cloned() {
             let is_final = self.transform_steps[t].ready_for_final_render();
             if is_final {
@@ -792,8 +800,11 @@ impl FullModularImage {
                 }
                 if self.rerendered_buffers.contains(&(*buffer, *grid)) {
                     let buf = &mut self.buffer_info[*buffer].buffer_grid[*grid];
-                    // TODO(veluca): account for *non-final* uses here, when we actually
-                    // deallocate temporary buffers.
+                    // Account for non-final uses of partially-rendered buffers, so that their
+                    // last use in this pass can consume them.
+                    if !*order_only && buf.can_consume(false) {
+                        buf.remaining_uses.fetch_add(1, Ordering::Relaxed);
+                    }
                     buf.used_by_transforms_current.try_lock().unwrap().push(t);
                     self.transform_steps[t].add_current_dep();
                     has_current_deps = true;

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -12,7 +12,7 @@ use jxl_transforms::transform_map::*;
 use crate::bit_reader::BitReader;
 use crate::error::{Error, Result};
 use crate::frame::block_context_map::BlockContextMap;
-use crate::frame::modular::buffers::{ModularBuffer, ModularChannel};
+use crate::frame::modular::buffers::{ModularBuffer, ModularChannel, NeededBorders};
 use crate::frame::modular::transforms::step::{TransformDependency, TransformStepChunk};
 use crate::frame::quantizer::{self, LfQuantFactors, QuantizerParams};
 use crate::frame::{ColorCorrelationParams, DataStatus, HfMetaViews};
@@ -259,6 +259,11 @@ pub struct FullModularImage {
     pipeline_used_channels: Vec<bool>,
     // Stack of transforms that are ready to process
     ready_transform_steps: Mutex<Vec<usize>>,
+    // Border buffers pinned for the duration of the current render pass. Partial renders (e.g.
+    // squeeze upsampling) pick their inputs dynamically, so their border reads cannot be
+    // accounted for statically; instead the borders they may read are pinned while preparing the
+    // pass (with exclusive access) and released once the pass has completed.
+    transient_border_pins: Vec<(usize, usize)>,
 }
 
 impl FullModularImage {
@@ -339,6 +344,7 @@ impl FullModularImage {
                 pending_transforms: BTreeSet::new(),
                 rerendered_buffers: HashSet::new(),
                 delayed_ready_sections: Mutex::new(BTreeSet::new()),
+                transient_border_pins: vec![],
             });
         }
 
@@ -508,6 +514,7 @@ impl FullModularImage {
             pending_transforms: BTreeSet::new(),
             rerendered_buffers: HashSet::new(),
             delayed_ready_sections: Mutex::new(BTreeSet::new()),
+            transient_border_pins: vec![],
         })
     }
 
@@ -627,6 +634,8 @@ impl FullModularImage {
 
         for b in self.section_buffer_indices[section_id].iter().copied() {
             self.buffer_info[b].buffer_grid[grid].extract_needed_borders()?;
+            // Section cells are decoded (and hence extracted) exactly once.
+            self.buffer_info[b].buffer_grid[grid].release_border_extract_credit();
         }
 
         self.has_decoded_data.fetch_or(
@@ -755,19 +764,32 @@ impl FullModularImage {
         mut group_callback: impl FnMut(usize, usize, bool),
     ) {
         for t in self.pending_transforms.iter().cloned() {
-            if self.transform_steps[t].ready_for_final_render() {
+            let is_final = self.transform_steps[t].ready_for_final_render();
+            if is_final {
                 self.transform_steps[t].set_squeeze_upsample(None);
             }
             // If this will produce output, tell the caller.
             if let Some((g, c)) = self.transform_steps[t].output_info() {
-                group_callback(g, c, self.transform_steps[t].ready_for_final_render());
+                group_callback(g, c, is_final);
             }
             let mut has_current_deps = false;
             // Add dependency edges from *all* the buffers that will be modified and that are used.
-            for TransformDependency { buffer, grid, .. } in self.transform_steps[t]
+            for TransformDependency {
+                buffer,
+                grid,
+                order_only,
+            } in self.transform_steps[t]
                 .dependencies(&self.buffer_info, frame_header)
                 .iter()
             {
+                if !is_final && *order_only {
+                    // Partial renders choose their inputs dynamically (e.g. squeeze
+                    // upsampling), so their border reads are not part of the static border
+                    // use counts. Pin those borders for the duration of this render pass.
+                    self.buffer_info[*buffer].buffer_grid[*grid]
+                        .add_final_border_use(NeededBorders::BOTH);
+                    self.transient_border_pins.push((*buffer, *grid));
+                }
                 if self.rerendered_buffers.contains(&(*buffer, *grid)) {
                     let buf = &mut self.buffer_info[*buffer].buffer_grid[*grid];
                     // TODO(veluca): account for *non-final* uses here, when we actually
@@ -787,6 +809,14 @@ impl FullModularImage {
         self.rerendered_buffers.clear();
         for (s, g) in std::mem::take(&mut *self.delayed_ready_sections.try_lock().unwrap()) {
             self.mark_section_ready(s, g);
+        }
+    }
+
+    // Releases the border pins taken by `prepare_render`. Must only be called once the render
+    // pass has completed, i.e. no transforms are running concurrently.
+    pub fn release_transient_border_pins(&mut self) {
+        for (buffer, grid) in std::mem::take(&mut self.transient_border_pins) {
+            self.buffer_info[buffer].buffer_grid[grid].mark_final_borders_used(NeededBorders::BOTH);
         }
     }
 

--- a/jxl/src/frame/modular/transforms/meta_apply.rs
+++ b/jxl/src/frame/modular/transforms/meta_apply.rs
@@ -390,6 +390,7 @@ pub fn make_grids(
                 grid_pos: (grid_pos.0 as usize, grid_pos.1 as usize),
                 missing_final_deps: 0,
                 missing_deps: AtomicUsize::new(0),
+                border_uses: vec![],
             });
             ts
         };
@@ -419,6 +420,13 @@ pub fn make_grids(
         grid.needed_borders.leftright |= needed_borders.leftright;
         if needed_borders.is_empty() {
             grid.full_uses_count_final += 1;
+        } else {
+            grid.add_final_border_use(needed_borders);
+            grid_transform_steps[ts].border_uses.push((
+                input_buffer_idx,
+                input_grid_pos,
+                needed_borders,
+            ));
         }
         if !grid.used_by_transforms_final.contains(&ts) {
             grid_transform_steps[ts].missing_final_deps += 1;
@@ -641,6 +649,13 @@ pub fn make_grids(
         }
     }
 
+    // Reserve the border extract credits; see `add_border_extract_credit`.
+    for bi in buffer_info.iter() {
+        for grid in bi.buffer_grid.iter() {
+            grid.add_border_extract_credit();
+        }
+    }
+
     // Write on transform outputs which step produces them.
     for (ts, step) in grid_transform_steps.iter().enumerate() {
         for &(buf, grid) in step.outputs(buffer_info).iter() {
@@ -703,6 +718,7 @@ pub fn make_grids(
                             grid_pos: (gx, gy),
                             missing_final_deps: 1,
                             missing_deps: AtomicUsize::new(0),
+                            border_uses: vec![],
                         });
                     }
                 }

--- a/jxl/src/frame/modular/transforms/step.rs
+++ b/jxl/src/frame/modular/transforms/step.rs
@@ -285,12 +285,15 @@ impl SqueezeInfo {
     fn decrement_refs(self, buffers: &[ModularBufferInfo], is_final: bool) {
         match self {
             Self::Regular { in_avg, in_res, .. } => {
-                buffers[in_avg.0].buffer_grid[in_avg.1].mark_used(is_final);
-                buffers[in_res.0].buffer_grid[in_res.1].mark_used(is_final);
+                let buf_avg = &buffers[in_avg.0].buffer_grid[in_avg.1];
+                let buf_res = &buffers[in_res.0].buffer_grid[in_res.1];
+                buf_avg.mark_used(buf_avg.can_consume(is_final));
+                buf_res.mark_used(buf_res.can_consume(is_final));
             }
             Self::Upsample { upsample: u, .. } => {
                 assert!(!is_final);
-                buffers[u.source_buf].buffer_grid[u.source_grid].mark_used(false);
+                let buf = &buffers[u.source_buf].buffer_grid[u.source_grid];
+                buf.mark_used(buf.can_consume(false));
             }
         }
     }
@@ -682,7 +685,8 @@ impl TransformStepChunk {
                     if b_in.data_status == DataStatus::Zero && !b_in.has_buffer() {
                         b_out.ensure_buffer(&buffers[buf_out[i]].info)?;
                     } else {
-                        *b_out.data.try_write().unwrap() = Some(b_in.get_buffer(is_final)?);
+                        *b_out.data.try_write().unwrap() =
+                            Some(b_in.get_buffer(b_in.can_consume(is_final))?);
                     }
                 }
                 with_buffers(buffers, buf_out, out_grid, |mut bufs| {
@@ -697,8 +701,10 @@ impl TransformStepChunk {
                 ..
             } if buffers[*buf_in].info.size.0 == 0 => {
                 // Nothing to do, just bookkeeping.
-                buffers[*buf_in].buffer_grid[out_grid].mark_used(is_final);
-                buffers[*buf_pal].buffer_grid[0].mark_used(is_final);
+                let buf_in_grid = &buffers[*buf_in].buffer_grid[out_grid];
+                let buf_pal_grid = &buffers[*buf_pal].buffer_grid[0];
+                buf_in_grid.mark_used(buf_in_grid.can_consume(is_final));
+                buf_pal_grid.mark_used(buf_pal_grid.can_consume(is_final));
                 with_buffers(buffers, buf_out, out_grid, |_| Ok(()))?;
             }
             TransformStep::Palette {
@@ -783,8 +789,10 @@ impl TransformStepChunk {
                         );
                     }
                 }
-                buffers[*buf_in].buffer_grid[out_grid].mark_used(is_final);
-                buffers[*buf_pal].buffer_grid[0].mark_used(is_final);
+                let buf_in_grid = &buffers[*buf_in].buffer_grid[out_grid];
+                let buf_pal_grid = &buffers[*buf_pal].buffer_grid[0];
+                buf_in_grid.mark_used(buf_in_grid.can_consume(is_final));
+                buf_pal_grid.mark_used(buf_pal_grid.can_consume(is_final));
             }
             TransformStep::Palette {
                 buf_in,
@@ -877,9 +885,11 @@ impl TransformStepChunk {
                         &mut transform_scratch_space.palette_row_scratch,
                     )?;
                 }
-                buffers[*buf_pal].buffer_grid[0].mark_used(is_final);
+                let buf_pal_grid = &buffers[*buf_pal].buffer_grid[0];
+                buf_pal_grid.mark_used(buf_pal_grid.can_consume(is_final));
                 for grid_x in 0..grid_shape.0 {
-                    buffers[*buf_in].buffer_grid[out_grid + grid_x].mark_used(is_final);
+                    let buf_in_grid = &buffers[*buf_in].buffer_grid[out_grid + grid_x];
+                    buf_in_grid.mark_used(buf_in_grid.can_consume(is_final));
                 }
             }
             TransformStep::HSqueeze {
@@ -972,7 +982,7 @@ impl TransformStepChunk {
                     let zero = Image::new(rect.map(|x| x.size).unwrap_or(buf.size))?;
                     pass_to_pipeline(*channel, *group, is_final, zero)?;
                 } else {
-                    let modular_buf = buf.get_buffer(is_final)?;
+                    let modular_buf = buf.get_buffer(buf.can_consume(is_final))?;
                     if let Some(rect) = rect {
                         let mut cropped = Image::new(rect.size)?;
                         let src_view = modular_buf.data.get_rect(*rect);

--- a/jxl/src/frame/modular/transforms/step.rs
+++ b/jxl/src/frame/modular/transforms/step.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 
 use super::{RctOp, RctPermutation};
 use crate::error::Result;
-use crate::frame::modular::buffers::{ModularChannel, with_buffers};
+use crate::frame::modular::buffers::{ModularChannel, NeededBorders, with_buffers};
 use crate::frame::modular::transforms::smooth_squeeze::smooth_upsample;
 use crate::frame::modular::{
     DataStatus, FullModularImage, ModularBufferInfo, ModularGridKind, Predictor,
@@ -80,6 +80,10 @@ pub struct TransformStepChunk {
     // Number of dependencies that are still missing *during this progressive
     // preview phase*.
     pub(super) missing_deps: AtomicUsize,
+
+    // Border buffers this transform uses, as registered at graph construction time; they are
+    // released once every registered user has completed its final render.
+    pub(super) border_uses: Vec<(usize, usize, NeededBorders)>,
 }
 
 impl TransformStepChunk {
@@ -985,6 +989,16 @@ impl TransformStepChunk {
 
         for &(buf, grid) in self.outputs(buffers).iter() {
             buffers[buf].buffer_grid[grid].extract_needed_borders()?;
+            if is_final {
+                // The final render is the last time this cell's borders are extracted.
+                buffers[buf].buffer_grid[grid].release_border_extract_credit();
+            }
+        }
+
+        if is_final {
+            for &(buffer, grid, needed_borders) in self.border_uses.iter() {
+                buffers[buffer].buffer_grid[grid].mark_final_borders_used(needed_borders);
+            }
         }
 
         Ok(())

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -476,6 +476,12 @@ impl Frame {
         }
 
         self.lf_global
+            .as_mut()
+            .unwrap()
+            .modular_global
+            .release_transient_border_pins();
+
+        self.lf_global
             .as_ref()
             .unwrap()
             .modular_global


### PR DESCRIPTION
**Now rebased on top of #919** (its commit shows in this PR until it lands); the earlier ad-hoc render-step batching in this PR has been dropped in favor of `run_ordered`.

## Summary

- release Modular border buffers once no transform can read them anymore:
  - border uses are registered at graph construction time in `make_grids`, alongside the scheduling dependencies, and released as each registered user completes its final render
  - partial renders choose their inputs dynamically (squeeze upsampling), so `prepare_render` pins the borders they may read for the duration of the render pass
  - each cell holds an extract credit released by its producer after its last `extract_needed_borders` call, so border storage can only be freed after the final extraction and the freeing write is ordered after every extracting write
- consume partially-rendered full buffers during progressive renders (ported from #899): non-final uses of re-rendered partial buffers are counted while preparing a render pass, so the last consumer within the pass deallocates or moves them instead of copying; later passes regenerate them from their retained producers

On the 8192x8192 lossless Modular reproducer from #782, median peak RSS over five release runs, measured against #919 as the baseline:

| mode | #919 | #919 + this PR |
|---|---:|---:|
| one-shot, 1 thread | 498.6 MiB | 365.0 MiB |
| one-shot, automatic threads | 865.3 MiB | 845.3 MiB |
| progressive (`--render-interval 1024`), automatic threads | 885.3 MiB | 889.2 MiB |
| progressive (`--render-interval 128`), automatic threads | 6424.9 MiB | 4900.9 MiB |

(For reference, current `main` is at 500.2 / 2016.1 / 2015.7 / 6365.3 MiB for the same configurations.) The flush-heavy `--render-interval 128` case also speeds up from 8.1 MP/s to 40.2 MP/s; the other configurations are unchanged within this VM's noise. The remaining `--render-interval 128` peak appears to be dominated outside the Modular buffers and is left for follow-up work.

## Tests

- `cargo test --workspace`
- `cargo test --release --features shuttle shuttle` (188 tests, five consecutive runs)
- `cargo clippy -p jxl --all-targets -- -D warnings`

Fixes #782.
