### PR TITLE
Shared queue for transforms, and add JxlParallelRunner::run_ordered.

### DIFF
--- a/jxl/fuzz/fuzz_targets/decode_parallel.rs
+++ b/jxl/fuzz/fuzz_targets/decode_parallel.rs
@@ -72,6 +72,10 @@ impl JxlParallelRunner for SimpleParallelRunner {
             Ok(())
         }
     }
+
+    fn num_threads(&self) -> usize {
+        self.max_threads
+    }
 }
 
 fn reborrow<'a>(

--- a/jxl/src/api/inner/codestream_parser/frame_info.rs
+++ b/jxl/src/api/inner/codestream_parser/frame_info.rs
@@ -505,22 +505,26 @@ impl FrameInfo {
             let decoder_state = &frame.decoder_state;
             let lf_global = frame.lf_global.as_ref().unwrap();
 
-            parallel_runner.run(self.lf_sections.len(), &|i: usize| -> Result<()> {
-                let lf_section = &self.lf_sections[i];
-                let Section::Lf { group } = &lf_section.section else {
-                    unreachable!()
-                };
-                Frame::decode_lf_group(
-                    header,
-                    decoder_state,
-                    lf_global,
-                    *group,
-                    &mut BitReader::new(&lf_section.data),
-                    lf_splitter.as_ref(),
-                    hf_meta_splitter.as_ref(),
-                )?;
-                Ok(())
-            })?;
+            parallel_runner.run_ordered(
+                self.lf_sections.len(),
+                None,
+                &|i: usize| -> Result<()> {
+                    let lf_section = &self.lf_sections[i];
+                    let Section::Lf { group } = &lf_section.section else {
+                        unreachable!()
+                    };
+                    Frame::decode_lf_group(
+                        header,
+                        decoder_state,
+                        lf_global,
+                        *group,
+                        &mut BitReader::new(&lf_section.data),
+                        lf_splitter.as_ref(),
+                        hf_meta_splitter.as_ref(),
+                    )?;
+                    Ok(())
+                },
+            )?;
         }
 
         for lf_section in self.lf_sections.drain(..) {

--- a/jxl/src/api/inner/process.rs
+++ b/jxl/src/api/inner/process.rs
@@ -133,11 +133,12 @@ impl Deref for SmallBuffer {
 pub(crate) struct SequentialRunner;
 
 impl JxlParallelRunner for SequentialRunner {
-    fn run(&mut self, num: usize, fun: &JxlParallelRunnerFun) -> Result<()> {
-        for i in 0..num {
-            fun(i)?
-        }
-        Ok(())
+    fn run(&mut self, _num: usize, _fun: &JxlParallelRunnerFun) -> Result<()> {
+        unreachable!("jxl-rs should only use run_ordered!")
+    }
+
+    fn num_threads(&self) -> usize {
+        1
     }
 }
 

--- a/jxl/src/api/mod.rs
+++ b/jxl/src/api/mod.rs
@@ -14,6 +14,8 @@ mod options;
 mod signature;
 mod xyb_constants;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 pub use color::*;
 pub use data_types::*;
 pub use decoder::*;
@@ -84,4 +86,46 @@ pub trait JxlParallelRunner {
     /// This implies that different invocations of `fun(i)` are not allowed
     /// to wait on each other.
     fn run(&mut self, num: usize, fun: &JxlParallelRunnerFun<'_>) -> Result<()>;
+
+    /// Returns an estimate of the number of parallel threads that this parallel
+    /// runner will use.
+    ///
+    /// Note that this is just an optimization hint.
+    fn num_threads(&self) -> usize;
+
+    /// Runs `fun(i)` for each `i` in `0..num`, possibly in parallel.
+    ///
+    /// Equivalent to `run`, but attempts to start tasks in roughly sequential
+    /// order and receives a hint on the number of threads to use.
+    /// This is not a hard guarantee, but doing otherwise might have negative
+    /// performance implications.
+    /// The default implementation uses `run` to start
+    /// `min(num_threads, num, max_threads)` tasks, and uses an atomic counter
+    /// to ensure each task is executed exactly once and approximately in
+    /// order.
+    fn run_ordered(
+        &mut self,
+        num: usize,
+        max_threads: Option<usize>,
+        fun: &JxlParallelRunnerFun<'_>,
+    ) -> Result<()> {
+        let max_threads = max_threads
+            .unwrap_or(usize::MAX)
+            .min(self.num_threads())
+            .min(num);
+        if max_threads <= 1 {
+            for i in 0..num {
+                fun(i)?;
+            }
+            return Ok(());
+        }
+        let next_index = AtomicUsize::new(0);
+        self.run(max_threads, &|_| loop {
+            let t = next_index.fetch_add(1, Ordering::Relaxed);
+            if t >= num {
+                return Ok(());
+            }
+            fun(t)?;
+        })
+    }
 }

--- a/jxl/src/frame/adaptive_lf_smoothing.rs
+++ b/jxl/src/frame/adaptive_lf_smoothing.rs
@@ -61,7 +61,7 @@ pub fn adaptive_lf_smoothing(
 
     let num_lf_groups = frame_header.num_lf_groups();
 
-    parallel_runner.run(num_lf_groups, &|g| {
+    parallel_runner.run_ordered(num_lf_groups, None, &|g| {
         let r = frame_header.lf_group_rect(g);
         let mut out_ref_0 = splitter0.borrow_typed_rect::<f32>(r);
         let mut out_ref_1 = splitter1.borrow_typed_rect::<f32>(r);

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -257,7 +257,7 @@ pub struct FullModularImage {
     delayed_ready_sections: Mutex<BTreeSet<(usize, usize)>>,
     // Whether each channel is used or not by the render pipeline.
     pipeline_used_channels: Vec<bool>,
-    // Stack of transform steps that are ready to process.
+    // Stack of transforms that are ready to process
     ready_transform_steps: Mutex<Vec<usize>>,
 }
 
@@ -634,28 +634,23 @@ impl FullModularImage {
             Ordering::Relaxed,
         );
 
-        let mut ready_steps = vec![];
         if section_id == 1 {
             self.delayed_ready_sections
                 .lock()
                 .unwrap()
                 .insert((1, grid));
         } else {
-            self.mark_section_ready(section_id, grid, &mut ready_steps);
+            self.mark_section_ready(section_id, grid);
         }
 
         if let Some(pass_to_pipeline) = pass_to_pipeline {
-            self.run_transforms(frame_header, pass_to_pipeline, &mut ready_steps)
+            self.run_transforms(frame_header, pass_to_pipeline)
         } else {
-            self.ready_transform_steps
-                .lock()
-                .unwrap()
-                .extend_from_slice(&ready_steps);
             Ok(())
         }
     }
 
-    fn update_deps(&self, buf: usize, grid: usize, ready_steps: &mut Vec<usize>) {
+    fn update_deps(&self, buf: usize, grid: usize) {
         for t in self.buffer_info[buf].buffer_grid[grid]
             .used_by_transforms_current
             .try_lock()
@@ -663,14 +658,14 @@ impl FullModularImage {
             .drain(..)
         {
             if self.transform_steps[t].current_dep_ready() {
-                ready_steps.push(t);
+                self.ready_transform_steps.lock().unwrap().push(t);
             }
         }
     }
 
-    fn mark_section_ready(&self, section_id: usize, grid: usize, ready_steps: &mut Vec<usize>) {
+    fn mark_section_ready(&self, section_id: usize, grid: usize) {
         for buf in self.section_buffer_indices[section_id].iter().copied() {
-            self.update_deps(buf, grid, ready_steps);
+            self.update_deps(buf, grid);
         }
     }
 
@@ -791,7 +786,7 @@ impl FullModularImage {
         self.pending_transforms.clear();
         self.rerendered_buffers.clear();
         for (s, g) in std::mem::take(&mut *self.delayed_ready_sections.try_lock().unwrap()) {
-            self.mark_section_ready(s, g, &mut self.ready_transform_steps.try_lock().unwrap());
+            self.mark_section_ready(s, g);
         }
     }
 
@@ -801,7 +796,6 @@ impl FullModularImage {
         tfm: usize,
         scratch_space: &mut TransformScratchSpace,
         pass_to_pipeline: &dyn Fn(usize, usize, bool, Image<i32>) -> Result<()>,
-        ready_steps: &mut Vec<usize>,
     ) -> Result<()> {
         self.transform_steps[tfm].do_run(
             frame_header,
@@ -811,7 +805,7 @@ impl FullModularImage {
         )?;
 
         for &(buf, grid) in self.transform_steps[tfm].outputs(&self.buffer_info).iter() {
-            self.update_deps(buf, grid, ready_steps);
+            self.update_deps(buf, grid);
         }
         Ok(())
     }
@@ -820,23 +814,18 @@ impl FullModularImage {
         &self,
         frame_header: &FrameHeader,
         pass_to_pipeline: &dyn Fn(usize, usize, bool, Image<i32>) -> Result<()>,
-        ready_steps: &mut Vec<usize>,
     ) -> Result<()> {
         let mut scratch_space = self.transform_scratch_space.get();
-        while let Some(t) = ready_steps.pop() {
-            self.run_transform(
-                frame_header,
-                t,
-                &mut scratch_space,
-                pass_to_pipeline,
-                ready_steps,
-            )?;
+        loop {
+            let Some(t) = self.ready_transform_steps.lock().unwrap().pop() else {
+                return Ok(());
+            };
+            self.run_transform(frame_header, t, &mut scratch_space, pass_to_pipeline)?;
         }
-        Ok(())
     }
 
-    pub fn take_ready_steps(&mut self) -> Vec<usize> {
-        std::mem::take(self.ready_transform_steps.get_mut().unwrap())
+    pub fn num_ready_steps(&mut self) -> usize {
+        self.ready_transform_steps.get_mut().unwrap().len()
     }
 
     pub fn validate_state_after_transforms(&self) {

--- a/jxl/src/frame/render.rs
+++ b/jxl/src/frame/render.rs
@@ -29,7 +29,6 @@ use crate::render::buffer_splitter::BufferSplitter;
 use crate::render::stages::*;
 use crate::render::{LowMemoryRenderPipeline, RenderPipeline, RenderPipelineBuilder};
 use crate::util::SmallVec;
-use crate::util::sync::atomic::{AtomicUsize, Ordering};
 use crate::util::sync::{Arc, RwLock};
 
 #[cfg(test)]
@@ -380,8 +379,6 @@ impl Frame {
                 BTreeSet::new()
             };
 
-        let ready_steps = modular_global.take_ready_steps();
-
         for g in extra_groups_to_vardct_render.iter() {
             let sz = self.header.group_rect(*g).size;
             let area = sz.0 * sz.1;
@@ -392,6 +389,7 @@ impl Frame {
 
         const TRANSFORM_STEPS_PER_TASK: usize = 3;
 
+        #[derive(Debug)]
         enum RenderStep<'a> {
             Decode {
                 group: usize,
@@ -400,26 +398,33 @@ impl Frame {
             FlushVarDCT {
                 group: usize,
             },
-            RunTransformSteps {
-                steps: SmallVec<usize, TRANSFORM_STEPS_PER_TASK>,
-            },
+            RunTransformSteps,
         }
 
-        let render_steps: Vec<_> = ready_steps
-            .chunks(TRANSFORM_STEPS_PER_TASK)
-            .map(|x| RenderStep::RunTransformSteps {
-                steps: x.iter().copied().collect(),
+        let num_transform_tasks = modular_global
+            .num_ready_steps()
+            .div_ceil(TRANSFORM_STEPS_PER_TASK);
+        let mut render_steps: Vec<_> = groups
+            .into_iter()
+            .map(|(g, p)| RenderStep::Decode {
+                group: g,
+                passes: p,
             })
             .chain(
                 extra_groups_to_vardct_render
                     .iter()
                     .map(|x| RenderStep::FlushVarDCT { group: *x }),
             )
-            .chain(groups.into_iter().map(|(g, p)| RenderStep::Decode {
-                group: g,
-                passes: p,
-            }))
+            .chain((0..num_transform_tasks).map(|_| RenderStep::RunTransformSteps))
             .collect();
+
+        // Note that sorting by group has noticeable positive effects on memory usage,
+        // and also on performance by virtue of increased locality.
+        render_steps.sort_unstable_by_key(|s| match s {
+            RenderStep::Decode { group, .. } => *group,
+            RenderStep::FlushVarDCT { group } => *group,
+            RenderStep::RunTransformSteps => usize::MAX,
+        });
 
         // STEP 4: actually run the steps.
 
@@ -432,7 +437,10 @@ impl Frame {
             Ok(())
         };
 
-        let run_step = |i| {
+        // Avoid significantly more than one thread per largest-group worth of work.
+        let max_threads = groups_of_work.div_ceil(THREAD_COUNT_DENOMINATOR).max(1);
+
+        parallel_runner.run_ordered(render_steps.len(), Some(max_threads), &|i| {
             match &render_steps[i] {
                 RenderStep::Decode { group, passes } => {
                     let mut new_passes: SmallVec<_, 11> = passes.iter().cloned().collect();
@@ -446,37 +454,16 @@ impl Frame {
                 RenderStep::FlushVarDCT { group } => {
                     self.decode_hf_group(*group, &mut [], &buffer_splitter, true)?;
                 }
-                RenderStep::RunTransformSteps { steps } => {
-                    let mut steps = steps.iter().copied().collect();
+                RenderStep::RunTransformSteps => {
                     self.lf_global
                         .as_ref()
                         .unwrap()
                         .modular_global
-                        .run_transforms(&self.header, &pass_to_pipeline, &mut steps)?;
+                        .run_transforms(&self.header, &pass_to_pipeline)?;
                 }
             }
             Ok(())
-        };
-
-        // Avoid significantly more than one thread per largest-group worth of work.
-        let max_threads = groups_of_work.div_ceil(THREAD_COUNT_DENOMINATOR).max(1);
-
-        let hw_threads = std::thread::available_parallelism()
-            .map(|x| x.get())
-            .unwrap_or(max_threads);
-
-        if render_steps.len() > max_threads && max_threads < hw_threads {
-            let next_index = AtomicUsize::new(0);
-            parallel_runner.run(max_threads, &|_| loop {
-                let t = next_index.fetch_add(1, Ordering::Relaxed);
-                if t >= render_steps.len() {
-                    return Ok(());
-                }
-                run_step(t)?;
-            })?;
-        } else {
-            parallel_runner.run(render_steps.len(), &run_step)?;
-        }
+        })?;
 
         for g in render_steps.iter().filter_map(|x| match x {
             RenderStep::Decode { group, .. } => Some(*group),

--- a/jxl/src/tests/compare_parallel.rs
+++ b/jxl/src/tests/compare_parallel.rs
@@ -24,7 +24,7 @@ use crate::image::Image;
 use crate::tests::decode::{compare_frames, decode_internal};
 
 pub struct TestParallelRunner {
-    pub max_threads: usize,
+    max_threads: usize,
 }
 
 impl JxlParallelRunner for TestParallelRunner {
@@ -73,6 +73,10 @@ impl JxlParallelRunner for TestParallelRunner {
         } else {
             Ok(())
         }
+    }
+
+    fn num_threads(&self) -> usize {
+        self.max_threads
     }
 }
 

--- a/jxl_cli/src/dec/mod.rs
+++ b/jxl_cli/src/dec/mod.rs
@@ -39,13 +39,11 @@ struct RayonParallelRunner;
 
 impl JxlParallelRunner for RayonParallelRunner {
     fn run(&mut self, num: usize, fun: &JxlParallelRunnerFun) -> jxl::error::Result<()> {
-        if num == 1 || rayon::current_num_threads() == 1 {
-            for i in 0..num {
-                fun(i)?;
-            }
-            return Ok(());
-        }
         (0..num).into_par_iter().try_for_each(fun)
+    }
+
+    fn num_threads(&self) -> usize {
+        rayon::current_num_threads()
     }
 }
 


### PR DESCRIPTION
Having ordered execution allows significantly reducing the amount of memory used by modular decoding.

Fixes #782.