### PR TITLE
Fix short reads when buffering container boxes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Google LLC <*@google.com>
 # Individuals:
 Caio <c410.f3r@gmail.com>
 Galaxy4594 <164440799+Galaxy4594@users.noreply.github.com>
+Greg B <64932474+gregbenz@users.noreply.github.com>
 Ewout ter Hoeven <E.M.terHoeven@student.tudelft.nl>
 Helmut Januschka <helmut@januschka.com>
 Inflation <2375962+inflation@users.noreply.github.com>

--- a/jxl/src/api/inner/box_parser.rs
+++ b/jxl/src/api/inner/box_parser.rs
@@ -460,6 +460,7 @@ impl BoxParser {
                         buf.data.resize(cur + space, 0);
                         let n =
                             self.read_inner(input, &mut [IoSliceMut::new(&mut buf.data[cur..])])?;
+                        buf.data.truncate(cur + n);
                         if n == 0 {
                             break;
                         }
@@ -552,6 +553,7 @@ impl BoxParser {
             let cur = buf.data.len();
             buf.data.resize(cur + space, 0);
             let n = self.read_inner(input, &mut [IoSliceMut::new(&mut buf.data[cur..])])?;
+            buf.data.truncate(cur + n);
             if n == 0 {
                 break;
             }


### PR DESCRIPTION
## Summary

- truncate out-of-order `jxlp` buffers to the number of bytes actually read
- apply the same fix to selected auxiliary-box buffers

## Background

`JxlBitstreamInput::available_bytes()` is documented as an estimate. The two buffering paths used that estimate to resize their vectors before calling `read`, but did not remove the unwritten tail when `read` returned fewer bytes. As a result, ordinary short reads could insert zero-filled gaps into captured auxiliary data or a buffered out-of-order codestream.

This is most likely with fragmented or streaming inputs, where the availability estimate can exceed the next read. The resulting zero-filled gaps can corrupt captured auxiliary-box data or a reconstructed out-of-order codestream, potentially causing metadata corruption or decode failure.

The auxiliary-box buffering path was added in #926, and the out-of-order `jxlp` path was added in #752.

The fix preserves the existing allocation and parser-state behavior. It only commits the bytes reported by `read`.

## Testing

- `cargo test --offline -p jxl api::inner::box_parser::tests`
- `cargo test --offline -p jxl`
- `cargo fmt --all -- --check`