### PR TITLE
Bump up SIMD/scalar comparison limits.

### DIFF
--- a/jxl/src/render/stages/xyb.rs
+++ b/jxl/src/render/stages/xyb.rs
@@ -353,7 +353,7 @@ mod test {
                     let max = simd.abs().max(scalar.abs());
                     let rel = abs / max;
                     assert!(
-                        abs < 1e-3 || rel < 1e-3,
+                        abs < 2e-3 || rel < 2e-3,
                         "simd {simd}, scalar {scalar}, abs {abs:?} rel {rel:?}",
                     );
                 }

--- a/jxl_simd/src/lib.rs
+++ b/jxl_simd/src/lib.rs
@@ -604,7 +604,7 @@ mod test {
                     let simd_res = compute(d, &a, &b, &c);
                     for (scalar, simd) in scalar_res.iter().zip(simd_res.iter()) {
                         // Less strict requirements because of fma.
-                        compare_scalar_simd(*scalar, *simd, 2e-5, 2e-5);
+                        compare_scalar_simd(*scalar, *simd, 3e-5, 3e-5);
                     }
                     Ok(())
                 })


### PR DESCRIPTION
They occasionally fail post-merge checks.