### PR TITLE
Disable implicit cube/deltas for partial rendering.

### DIFF
--- a/jxl/src/frame/modular/transforms/apply_local.rs
+++ b/jxl/src/frame/modular/transforms/apply_local.rs
@@ -311,6 +311,7 @@ impl TransformStep {
                         prev_aux: None,
                         aux_out: &mut [],
                         storage,
+                        is_partial: false,
                     }
                     .run(&mut scratch_space.palette_row_scratch)?;
                 }

--- a/jxl/src/frame/modular/transforms/palette.rs
+++ b/jxl/src/frame/modular/transforms/palette.rs
@@ -230,6 +230,7 @@ pub(super) struct PaletteStep<'a, 'b> {
     pub prev_aux: Option<&'a [Option<&'b Image<i32>>]>,
     pub aux_out: &'a mut [RwLockWriteGuard<'b, Option<Image<i32>>>],
     pub storage: ModularStorage,
+    pub is_partial: bool,
 }
 
 #[inline(always)]
@@ -257,6 +258,7 @@ impl<'a, 'b> PaletteStep<'a, 'b> {
             prev_aux,
             aux_out,
             storage,
+            is_partial,
         } = self;
         let (w0, h) = buf_in[0].size(storage);
         if w0 == 0 || h == 0 {
@@ -268,26 +270,51 @@ impl<'a, 'b> PaletteStep<'a, 'b> {
         if predictor == Predictor::Zero {
             assert_eq!(grid_xsize, 1);
             assert_eq!(buf_in.len(), 1);
+            let is_single_channel = buf_out.len() == 1;
             for (c, out_buf) in buf_out.iter_mut().enumerate() {
                 let palette = Palette::new(&out_buf.bit_depth, c, buf_pal, storage);
+                // Avoid partial render overshoots going into the implicit cube / deltas.
+                // If we are not doing delta palette, we have a single channel, we have an actual
+                // palette, and we have partial data, almost certainly any under/over shoot is just
+                // due to partial rendering noise, so clip the index in those cases.
+                let palette_size = (palette.explicit.len() / storage.sample_size()) as i32;
+                let clip =
+                    is_partial && palette_size != 0 && self.num_deltas == 0 && is_single_channel;
                 if storage == ModularStorage::I16 {
                     let in_rect = ImageRect::<i16>::from_raw(buf_in[0].data.as_rect());
                     let mut out_rect = ImageRectMut::<i16>::from_raw(out_buf.data.as_rect_mut());
                     for y in 0..h {
                         let index_row = in_rect.row(y);
                         let out_row = out_rect.row(y);
-                        for (out, &index) in out_row.iter_mut().zip(index_row.iter()) {
-                            *out = palette.get(index as isize) as i16;
+                        if clip {
+                            for (out, &index) in out_row.iter_mut().zip(index_row.iter()) {
+                                *out = palette.get(index.clamp(0, palette_size as i16 - 1) as isize)
+                                    as i16;
+                            }
+                        } else {
+                            for (out, &index) in out_row.iter_mut().zip(index_row.iter()) {
+                                *out = palette.get(index as isize) as i16;
+                            }
                         }
                     }
                 } else {
                     let in_rect = ImageRect::<i32>::from_raw(buf_in[0].data.as_rect());
                     let mut out_rect = ImageRectMut::<i32>::from_raw(out_buf.data.as_rect_mut());
-                    for y in 0..h {
-                        let index_row = in_rect.row(y);
-                        let out_row = out_rect.row(y);
-                        for (out, &index) in out_row.iter_mut().zip(index_row.iter()) {
-                            *out = palette.get(index as isize);
+                    if clip {
+                        for y in 0..h {
+                            let index_row = in_rect.row(y);
+                            let out_row = out_rect.row(y);
+                            for (out, &index) in out_row.iter_mut().zip(index_row.iter()) {
+                                *out = palette.get(index.clamp(0, palette_size - 1) as isize);
+                            }
+                        }
+                    } else {
+                        for y in 0..h {
+                            let index_row = in_rect.row(y);
+                            let out_row = out_rect.row(y);
+                            for (out, &index) in out_row.iter_mut().zip(index_row.iter()) {
+                                *out = palette.get(index as isize);
+                            }
                         }
                     }
                 }

--- a/jxl/src/frame/modular/transforms/step.rs
+++ b/jxl/src/frame/modular/transforms/step.rs
@@ -859,6 +859,9 @@ impl TransformStepChunk {
                                 .then_some(&prev_aux_refs[..]),
                             aux_out: &mut aux_out,
                             storage: buffers[*buf_in].storage,
+                            is_partial: matches!(predictor, Predictor::Zero)
+                                && buffers[*buf_in].buffer_grid[out_grid].data_status
+                                    == DataStatus::Partial,
                         }
                         .run(&mut scratch_space.palette_row_scratch)?;
                     }


### PR DESCRIPTION
This can introduce artefacts, and it is extremely unlikely that one intends to explicitly use cube/deltas for single-channel, no-predictor palettes. If that were actually the case, the image would look wrong anyway as off-by-ones would mess up the specific implicit palette entry.