### PR TITLE
Fix undersized row buffer.

### DIFF
--- a/jxl/src/render/low_memory_pipeline/mod.rs
+++ b/jxl/src/render/low_memory_pipeline/mod.rs
@@ -69,7 +69,7 @@ impl LowMemoryRenderPipelinePerThread {
                     *next_y_border as usize,
                     stage.shift().1 as usize,
                     stage.shift().0 as usize,
-                    p.shared.chunk_size >> *dsx,
+                    (p.shared.chunk_size + 2 * p.border_size.0) >> *dsx,
                 )?);
             }
             self.row_buffers.push(stage_buffers);


### PR DESCRIPTION
A single call to process_row_chunk() might have an xsize of up to chunk_size + 2*border_size_x. This mostly comes up in progressive decoding (which might have unusual group orderings).