### PR TITLE
Fix division by zero and empty channel handling during squeeze

### DIFF
--- a/jxl/src/error.rs
+++ b/jxl/src/error.rs
@@ -217,7 +217,7 @@ pub enum Error {
     MixingDifferentChannels,
     #[error("Invalid transform: squeezing meta-channels needs an in-place transform")]
     MetaSqueezeRequiresInPlace,
-    #[error("Invalid transform: too many squeezes (shift > 30)")]
+    #[error("Invalid transform: too many squeezes")]
     TooManySqueezes,
     #[error("Palette meta-channel too large: {0} samples > limit {1}")]
     PaletteTooLarge(usize, usize),

--- a/jxl/src/frame/modular/mod.rs
+++ b/jxl/src/frame/modular/mod.rs
@@ -190,6 +190,12 @@ impl ModularBufferInfo {
             (chan_size.0 - bx).min(grid_dim.0),
             (chan_size.1 - by).min(grid_dim.1),
         );
+        if size.0 == 0 || size.1 == 0 {
+            return Rect {
+                origin: (0, 0),
+                size: (0, 0),
+            };
+        }
         let origin = match (output_grid_kind, self.grid_kind) {
             (ModularGridKind::Lf, ModularGridKind::Lf)
             | (ModularGridKind::Hf, ModularGridKind::Hf) => (0, 0),
@@ -200,14 +206,7 @@ impl ModularBufferInfo {
             }
             _ => unreachable!("invalid combination of output grid kind and buffer grid kind"),
         };
-        if size.0 == 0 || size.1 == 0 {
-            Rect {
-                origin: (0, 0),
-                size: (0, 0),
-            }
-        } else {
-            Rect { origin, size }
-        }
+        Rect { origin, size }
     }
 }
 

--- a/jxl/src/frame/modular/transforms/squeeze.rs
+++ b/jxl/src/frame/modular/transforms/squeeze.rs
@@ -34,6 +34,11 @@ pub fn check_squeeze_params(
     if channels[params.begin_channel as usize].1.is_meta() && !params.in_place {
         return Err(Error::MetaSqueezeRequiresInPlace);
     }
+    for c in &channels[params.begin_channel as usize..end_channel] {
+        if c.1.size.0 == 0 || c.1.size.1 == 0 {
+            return Err(Error::TooManySqueezes);
+        }
+    }
     Ok(())
 }
 

--- a/jxl/src/frame/modular/transforms/step.rs
+++ b/jxl/src/frame/modular/transforms/step.rs
@@ -228,10 +228,12 @@ impl SqueezeInfo {
         let next_avg_grid = if let Some(pos) = pos_next {
             let grid = buf_avg.get_grid_idx(output_grid_kind, pos);
             if grid == in_grid {
-                if vertical {
-                    avg_rect.size.1 += 1;
-                } else {
-                    avg_rect.size.0 += 1;
+                if avg_rect.size.0 > 0 && avg_rect.size.1 > 0 {
+                    if vertical {
+                        avg_rect.size.1 += 1;
+                    } else {
+                        avg_rect.size.0 += 1;
+                    }
                 }
                 None
             } else {


### PR DESCRIPTION
- Evaluate empty size rects upfront in get_grid_rect to avoid division by zero in origin calculation
- Only increment avg_rect in SqueezeInfo::new if the rectangle is non-empty
- Forbid squeezing empty channels in check_squeeze_params