### PR TITLE
Validate ICC preamble early in IncrementalIccReader

### DIFF
--- a/jxl/src/icc/mod.rs
+++ b/jxl/src/icc/mod.rs
@@ -25,22 +25,32 @@ use tag::{read_single_command, read_tag_list};
 
 const ICC_CONTEXTS: usize = 41;
 const ICC_HEADER_SIZE: u64 = 128;
+const PREAMBLE_SIZE: usize = 20;
+
+fn check_preamble(
+    output_size: u64,
+    commands_size: u64,
+    bytes_read: u64,
+    total_len: u64,
+) -> Result<()> {
+    if bytes_read.saturating_add(commands_size) > total_len {
+        return Err(Error::InvalidIccStream);
+    }
+    if output_size > (1 << 28) || output_size.saturating_add(65536) < total_len {
+        return Err(Error::IccTooLarge);
+    }
+    Ok(())
+}
 
 fn read_icc_inner(stream: &mut IccStream) -> Result<Vec<u8>, Error> {
     let output_size = stream.read_varint()?;
     let commands_size = stream.read_varint()?;
-    if stream.bytes_read().saturating_add(commands_size) > stream.len() {
-        return Err(Error::InvalidIccStream);
-    }
-
-    // Simple check to avoid allocating too large buffer.
-    if output_size > (1 << 28) {
-        return Err(Error::IccTooLarge);
-    }
-
-    if output_size + 65536 < stream.len() {
-        return Err(Error::IccTooLarge);
-    }
+    check_preamble(
+        output_size,
+        commands_size,
+        stream.bytes_read(),
+        stream.len(),
+    )?;
 
     // Extract command stream first.
     let commands = stream.read_to_vec_exact(commands_size as usize)?;
@@ -172,6 +182,16 @@ impl IncrementalIccReader {
         self.num_coded_bytes() - self.out_buf.len()
     }
 
+    fn check_preamble(&self) -> Result<()> {
+        let mut cursor = &self.out_buf[..];
+        let output_size =
+            read_varint_from_reader(&mut cursor).map_err(|_| Error::InvalidIccStream)?;
+        let commands_size =
+            read_varint_from_reader(&mut cursor).map_err(|_| Error::InvalidIccStream)?;
+        let bytes_read = (self.out_buf.len() - cursor.len()) as u64;
+        check_preamble(output_size, commands_size, bytes_read, self.len as u64)
+    }
+
     pub fn read_one(&mut self, br: &mut BitReader) -> Result<()> {
         let ctx = self.get_icc_ctx() as usize;
         let checkpoint = self.reader.checkpoint::<1>();
@@ -193,6 +213,9 @@ impl IncrementalIccReader {
         }
         self.out_buf.push(b);
         self.prev_bytes = [b, self.prev_bytes[0]];
+        if self.len > PREAMBLE_SIZE && self.out_buf.len() == PREAMBLE_SIZE {
+            self.check_preamble()?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
When an encoded ICC stream specifies a large size but an invalid preamble (such as output_size + 65536 < stream_len), previously IncrementalIccReader would decode the entire stream (up to 16 MB) before read_icc_inner caught the invalid preamble in finalize(). Under certain malformed bitstreams with single-symbol distributions, this allowed consuming zero bits in a fixed-point loop for millions of iterations.

Validate the preamble after the first 20 bytes (the maximum size of the two preamble varints) during incremental decoding, sharing the check_preamble helper with read_icc_inner.